### PR TITLE
Bound policy traffic analysis for large log windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Policy traffic analysis is now bounded for large windows** — traffic analysis tools scan a fixed number of log slices per request, return observed results instead of attempting unbounded raw-log reconstruction, and only set `is_exact=true` when every queried slice is below the log fetch limit.
+- **Port analysis metadata expanded** — policy results now include bounded-analysis metadata such as `analysis_mode`, `observed_hits`, `slices_scanned`, `truncated_slices`, `log_limit_per_slice`, and optional FortiView `estimated_total_hits`.
+
 ### Added
 - **Policy Traffic Analysis Tools** (3 tools) - Analyze traffic patterns per firewall policy for policy hardening
   - `get_policy_traffic_profile`: Sampled traffic summary with top ports, services, and applications
-  - `get_policy_port_analysis`: Exact port/protocol enumeration with `is_exact` semantics
+  - `get_policy_port_analysis`: Bounded port/protocol enumeration with conservative `is_exact` semantics
   - `get_policy_protocol_summary`: Lightweight protocol breakdown (TCP/UDP/ICMP/other)
 - Input validation for filter values (`sanitize_filter_value`) and action parameters (`validate_action`)
 - Concurrent policy query support with semaphore-bounded parallelism (`asyncio.Semaphore(5)`)

--- a/README.md
+++ b/README.md
@@ -469,8 +469,14 @@ networks:
 | Tool | Description |
 |------|-------------|
 | `get_policy_traffic_profile` | Get sampled traffic summary per policy (top ports, services, apps) |
-| `get_policy_port_analysis` | Get exact port/protocol enumeration per policy with `is_exact` semantics |
+| `get_policy_port_analysis` | Get bounded port/protocol enumeration per policy with conservative `is_exact` semantics |
 | `get_policy_protocol_summary` | Get lightweight protocol breakdown (TCP/UDP/ICMP/other) per policy |
+
+Traffic analysis tools keep large windows practical by scanning a fixed, bounded
+number of log slices per request. A result is marked `is_exact=true` only when
+every queried slice returns below the per-slice log limit. If any slice reaches
+the limit, the tool returns observed results with `analysis_mode=bounded_sample`,
+truncation metadata, and a recommendation to narrow the time window for exact proof.
 
 ### PCAP Tools (5 tools)
 

--- a/src/fortianalyzer_mcp/server.py
+++ b/src/fortianalyzer_mcp/server.py
@@ -193,7 +193,7 @@ def register_dynamic_tools(mcp_server: FastMCP) -> None:
             ],
             "traffic": [
                 ("get_policy_traffic_profile", "Get sampled traffic summary per policy"),
-                ("get_policy_port_analysis", "Get exact port/protocol enumeration per policy"),
+                ("get_policy_port_analysis", "Get bounded port/protocol enumeration per policy"),
                 ("get_policy_protocol_summary", "Get protocol breakdown per policy"),
             ],
         }

--- a/src/fortianalyzer_mcp/tools/traffic_tools.py
+++ b/src/fortianalyzer_mcp/tools/traffic_tools.py
@@ -14,7 +14,8 @@ import logging
 import re
 import time
 from collections import Counter
-from typing import Any
+from datetime import datetime, timedelta
+from typing import Any, cast
 
 from fortianalyzer_mcp.server import get_faz_client, mcp
 from fortianalyzer_mcp.utils.validation import (
@@ -31,7 +32,10 @@ _QUERY_SEMAPHORE = asyncio.Semaphore(5)
 # Default and max search parameters
 DEFAULT_SEARCH_TIMEOUT = 120
 POLL_INTERVAL = 1.0
-MAX_POLICY_IDS = 25
+LOG_FETCH_LIMIT = 1000
+ANALYSIS_QUERY_BUDGET = 24
+MAX_SLICES_PER_POLICY = 4
+MAX_POLICY_IDS = ANALYSIS_QUERY_BUDGET
 DEFAULT_TOP_N = 10
 
 # Valid action values for FortiGate traffic logs
@@ -124,7 +128,7 @@ def sanitize_filter_value(value: str) -> str:
 # =============================================================================
 
 
-def _get_client():
+def _get_client() -> Any:
     """Get the FortiAnalyzer client instance."""
     client = get_faz_client()
     if not client:
@@ -153,13 +157,11 @@ def _parse_time_range(time_range: str) -> dict[str, str]:
 
     Reuses the same format as log_tools._parse_time_range.
     """
-    from datetime import datetime, timedelta
-
     now = datetime.now()
     fmt = "%Y-%m-%d %H:%M:%S"
 
     if "|" in time_range:
-        parts = time_range.split("|")
+        parts = time_range.split("|", maxsplit=1)
         return {"start": parts[0].strip(), "end": parts[1].strip()}
 
     range_map = {
@@ -178,6 +180,50 @@ def _parse_time_range(time_range: str) -> dict[str, str]:
     return {"start": start.strftime(fmt), "end": now.strftime(fmt)}
 
 
+def _parse_time_range_bounds(time_range: dict[str, str]) -> tuple[datetime, datetime]:
+    """Parse a FortiAnalyzer time range dict into datetime bounds."""
+    fmt = "%Y-%m-%d %H:%M:%S"
+    return datetime.strptime(time_range["start"], fmt), datetime.strptime(time_range["end"], fmt)
+
+
+def _format_time_range(start: datetime, end: datetime) -> dict[str, str]:
+    """Format datetime bounds for FortiAnalyzer APIs."""
+    fmt = "%Y-%m-%d %H:%M:%S"
+    return {"start": start.strftime(fmt), "end": end.strftime(fmt)}
+
+
+def _plan_policy_slice_count(
+    time_range: dict[str, str],
+    policy_count: int,
+) -> int:
+    """Plan a fixed bounded slice count per policy for a tool call."""
+    start, end = _parse_time_range_bounds(time_range)
+    if end - start <= timedelta(hours=24):
+        return 1
+    return min(MAX_SLICES_PER_POLICY, max(1, ANALYSIS_QUERY_BUDGET // max(policy_count, 1)))
+
+
+def _build_bounded_time_slices(
+    time_range: dict[str, str],
+    slice_count: int,
+) -> list[dict[str, str]]:
+    """Split a time range into a fixed number of non-overlapping slices."""
+    start, end = _parse_time_range_bounds(time_range)
+    if slice_count <= 1 or end <= start:
+        return [time_range]
+
+    total_seconds = max(1, int((end - start).total_seconds()) + 1)
+    effective_count = min(max(slice_count, 1), total_seconds)
+    slices = []
+
+    for index in range(effective_count):
+        slice_start = start + timedelta(seconds=(total_seconds * index) // effective_count)
+        slice_end = start + timedelta(seconds=(total_seconds * (index + 1)) // effective_count - 1)
+        slices.append(_format_time_range(slice_start, min(slice_end, end)))
+
+    return slices
+
+
 def _build_device_filter(device: str | None) -> list[dict[str, str]]:
     """Build device filter for API. Mirrors log_tools._build_device_filter."""
     if not device:
@@ -189,13 +235,68 @@ def _build_device_filter(device: str | None) -> list[dict[str, str]]:
     return [{"devname": device}]
 
 
+async def _query_policy_log_slice(
+    adom: str,
+    device_filter: list[dict[str, str]],
+    policy_id: int,
+    time_range: dict[str, str],
+    action: str | None,
+    limit: int = LOG_FETCH_LIMIT,
+    timeout: int = DEFAULT_SEARCH_TIMEOUT,
+) -> list[dict[str, Any]]:
+    """Query traffic logs for a single policy/time slice."""
+    client = _get_client()
+    filter_str = _build_policy_filter(policy_id, action)
+
+    start_result = await client.logsearch_start(
+        adom=adom,
+        logtype="traffic",
+        device=device_filter,
+        time_range=time_range,
+        filter=filter_str,
+        limit=limit,
+    )
+
+    tid = start_result.get("tid")
+    if not tid:
+        logger.warning(f"No TID returned for policy {policy_id}: {start_result}")
+        return []
+
+    start_time = time.monotonic()
+    while True:
+        elapsed = time.monotonic() - start_time
+        if elapsed > timeout:
+            try:
+                await client.logsearch_cancel(adom, tid)
+            except (OSError, RuntimeError):
+                pass
+            logger.warning(f"Search timed out for policy {policy_id}")
+            return []
+
+        fetch_result = await client.logsearch_fetch(
+            adom=adom,
+            tid=tid,
+            limit=limit,
+            offset=0,
+        )
+
+        percentage = fetch_result.get("percentage", 0)
+        if percentage >= 100:
+            logs = fetch_result.get("data", [])
+            if not isinstance(logs, list):
+                logs = [logs] if logs else []
+            return [log for log in logs if isinstance(log, dict)]
+
+        await asyncio.sleep(POLL_INTERVAL)
+
+
 async def _query_policy_logs(
     adom: str,
     device: str | None,
     policy_id: int,
     time_range: str,
     action: str | None,
-    limit: int = 1000,
+    limit: int = LOG_FETCH_LIMIT,
     timeout: int = DEFAULT_SEARCH_TIMEOUT,
 ) -> list[dict[str, Any]]:
     """Query traffic logs for a single policy ID.
@@ -215,51 +316,176 @@ async def _query_policy_logs(
         List of log entries.
     """
     async with _QUERY_SEMAPHORE:
-        client = _get_client()
         time_range_dict = _parse_time_range(time_range)
         device_filter = _build_device_filter(device)
-        filter_str = _build_policy_filter(policy_id, action)
-
-        start_result = await client.logsearch_start(
+        return await _query_policy_log_slice(
             adom=adom,
-            logtype="traffic",
-            device=device_filter,
+            device_filter=device_filter,
+            policy_id=policy_id,
             time_range=time_range_dict,
-            filter=filter_str,
             limit=limit,
+            action=action,
+            timeout=timeout,
         )
 
-        tid = start_result.get("tid")
-        if not tid:
-            logger.warning(f"No TID returned for policy {policy_id}: {start_result}")
-            return []
 
-        start_time = time.monotonic()
-        while True:
-            elapsed = time.monotonic() - start_time
-            if elapsed > timeout:
-                try:
-                    await client.logsearch_cancel(adom, tid)
-                except (OSError, RuntimeError):
-                    pass
-                logger.warning(f"Search timed out for policy {policy_id}")
-                return []
+async def _query_policy_logs_bounded(
+    adom: str,
+    device: str | None,
+    policy_id: int,
+    time_range: str,
+    action: str | None,
+    policy_count: int,
+    limit: int = LOG_FETCH_LIMIT,
+    timeout: int = DEFAULT_SEARCH_TIMEOUT,
+) -> dict[str, Any]:
+    """Query fixed bounded slices for one policy and report truncation metadata."""
+    async with _QUERY_SEMAPHORE:
+        full_time_range = _parse_time_range(time_range)
+        device_filter = _build_device_filter(device)
+        slice_count = _plan_policy_slice_count(full_time_range, policy_count)
+        time_slices = _build_bounded_time_slices(full_time_range, slice_count)
+        logs: list[dict[str, Any]] = []
+        truncated_slices = 0
 
-            fetch_result = await client.logsearch_fetch(
+        for time_slice in time_slices:
+            slice_logs = await _query_policy_log_slice(
                 adom=adom,
-                tid=tid,
+                device_filter=device_filter,
+                policy_id=policy_id,
+                time_range=time_slice,
+                action=action,
                 limit=limit,
-                offset=0,
+                timeout=timeout,
             )
+            logs.extend(slice_logs)
+            if len(slice_logs) >= limit:
+                truncated_slices += 1
 
-            percentage = fetch_result.get("percentage", 0)
-            if percentage >= 100:
-                logs = fetch_result.get("data", [])
-                if not isinstance(logs, list):
-                    logs = [logs] if logs else []
-                return logs
+        return {
+            "logs": logs,
+            "slices_scanned": len(time_slices),
+            "truncated_slices": truncated_slices,
+        }
 
-            await asyncio.sleep(POLL_INTERVAL)
+
+def _extract_policy_hit_count(row: dict[str, Any], action: str | None) -> int | None:
+    """Extract a best-effort hit count from a FortiView policy-hits row."""
+    key = "counts"
+    if action == "accept":
+        key = "count_pass"
+    elif action in {"deny", "drop"}:
+        key = "count_block"
+
+    value = row.get(key)
+    if value is None and key != "counts":
+        value = row.get("counts")
+    if value is None:
+        return None
+    try:
+        return max(int(value), 0)
+    except (TypeError, ValueError):
+        return None
+
+
+async def _estimate_policy_hits(
+    adom: str,
+    device: str | None,
+    policy_ids: list[int],
+    time_range: str,
+    action: str | None,
+    timeout: int = 30,
+) -> dict[int, int]:
+    """Fetch one bounded FortiView policy-hits page as optional metadata."""
+    client = _get_client()
+    device_filter = _build_device_filter(device)
+    time_range_dict = _parse_time_range(time_range)
+
+    run_result = await client.fortiview_run(
+        adom=adom,
+        view_name="policy-hits",
+        device=device_filter,
+        time_range=time_range_dict,
+        limit=1000,
+        sort_by=[{"field": "counts", "order": "desc"}],
+    )
+    tid = run_result.get("tid")
+    if not tid:
+        return {}
+
+    start_time = time.monotonic()
+    while True:
+        if time.monotonic() - start_time > timeout:
+            return {}
+
+        result = await client.fortiview_fetch(
+            adom=adom,
+            view_name="policy-hits",
+            tid=tid,
+        )
+        rows = result.get("data", [])
+        if not isinstance(rows, list):
+            rows = [rows] if rows else []
+
+        if result.get("percentage", 100) >= 100 or rows:
+            wanted = set(policy_ids)
+            estimates: dict[int, int] = {}
+            for row in rows:
+                if not isinstance(row, dict):
+                    continue
+                raw_policy_id = row.get("agg_policyid", row.get("policyid"))
+                if raw_policy_id is None or not str(raw_policy_id).isdigit():
+                    continue
+                policy_id = int(raw_policy_id)
+                if policy_id not in wanted:
+                    continue
+                hits = _extract_policy_hit_count(row, action)
+                if hits is not None:
+                    estimates[policy_id] = hits
+            return estimates
+
+        await asyncio.sleep(POLL_INTERVAL)
+
+
+async def _estimate_policy_hits_best_effort(
+    adom: str,
+    device: str | None,
+    policy_ids: list[int],
+    time_range: str,
+    action: str | None,
+) -> dict[int, int]:
+    """Return FortiView estimates when available without failing the caller."""
+    try:
+        return await _estimate_policy_hits(adom, device, policy_ids, time_range, action)
+    except Exception as exc:
+        logger.info(f"FortiView policy-hit estimate unavailable: {exc}")
+        return {}
+
+
+def _bounded_metadata(
+    observed_hits: int,
+    slices_scanned: int,
+    truncated_slices: int,
+    estimated_total_hits: int | None = None,
+) -> dict[str, Any]:
+    """Build common bounded-analysis response metadata."""
+    is_exact = truncated_slices == 0
+    metadata: dict[str, Any] = {
+        "is_exact": is_exact,
+        "analysis_mode": "complete" if is_exact else "bounded_sample",
+        "observed_hits": observed_hits,
+        "slices_scanned": slices_scanned,
+        "truncated_slices": truncated_slices,
+        "log_limit_per_slice": LOG_FETCH_LIMIT,
+        "estimate_available": estimated_total_hits is not None,
+    }
+    if estimated_total_hits is not None:
+        metadata["estimated_total_hits"] = estimated_total_hits
+    if not is_exact:
+        metadata["recommendation"] = (
+            "Narrow the request to 24-hour, 6-hour, or a custom shorter window for exact proof."
+        )
+    return metadata
 
 
 # =============================================================================
@@ -310,8 +536,8 @@ def _aggregate_traffic_profile(logs: list[dict[str, Any]], top_n: int) -> dict[s
     }
 
 
-def _aggregate_port_analysis(logs: list[dict[str, Any]], limit: int = 1000) -> dict[str, Any]:
-    """Aggregate logs into exact port/protocol enumeration.
+def _aggregate_port_analysis(logs: list[dict[str, Any]], limit: int = LOG_FETCH_LIMIT) -> dict[str, Any]:
+    """Aggregate logs into port/protocol enumeration.
 
     Returns complete port list, protocol breakdown, ICMP summary,
     and is_exact indicator.
@@ -426,7 +652,7 @@ async def get_policy_traffic_profile(
         adom: ADOM name (default: from config DEFAULT_ADOM)
         device: Device filter (serial number like "FG100FTK19001333" or name).
             Default: All FortiGate devices.
-        policy_ids: List of firewall policy IDs to analyze (1-25 IDs, each > 0).
+        policy_ids: List of firewall policy IDs to analyze (1-24 IDs, each > 0).
         time_range: Time range for log query. Options:
             - "1-hour", "6-hour", "12-hour", "24-hour" (default)
             - "7-day", "30-day"
@@ -460,9 +686,20 @@ async def get_policy_traffic_profile(
             top_n = DEFAULT_TOP_N
 
         start = time.monotonic()
+        estimates = await _estimate_policy_hits_best_effort(adom, device, policy_ids, time_range, action)
 
         # Query all policies concurrently
-        tasks = [_query_policy_logs(adom, device, pid, time_range, action) for pid in policy_ids]
+        tasks = [
+            _query_policy_logs_bounded(
+                adom,
+                device,
+                pid,
+                time_range,
+                action,
+                policy_count=len(policy_ids),
+            )
+            for pid in policy_ids
+        ]
         results_list = await asyncio.gather(*tasks, return_exceptions=True)
 
         per_policy = []
@@ -475,7 +712,17 @@ async def get_policy_traffic_profile(
                     }
                 )
             else:
-                profile = _aggregate_traffic_profile(result, top_n)
+                policy_result = cast(dict[str, Any], result)
+                logs = policy_result["logs"]
+                profile = _aggregate_traffic_profile(logs, top_n)
+                profile.update(
+                    _bounded_metadata(
+                        observed_hits=len(logs),
+                        slices_scanned=policy_result["slices_scanned"],
+                        truncated_slices=policy_result["truncated_slices"],
+                        estimated_total_hits=estimates.get(pid),
+                    )
+                )
                 profile["policy_id"] = pid
                 per_policy.append(profile)
 
@@ -504,18 +751,18 @@ async def get_policy_port_analysis(
     time_range: str = "24-hour",
     action: str | None = None,
 ) -> dict[str, Any]:
-    """Get exact port/protocol enumeration per firewall policy.
+    """Get bounded port/protocol enumeration per firewall policy.
 
-    Enumerates all destination ports and protocols observed in traffic logs
-    for each policy. Returns complete lists (not sampled) with an is_exact
-    indicator. Useful for identifying exactly which ports are in use for
-    policy tightening.
+    Enumerates destination ports and protocols observed in fixed bounded traffic
+    log slices for each policy. The result is exact only when no queried slice
+    reaches the log fetch limit; otherwise it returns observed values with
+    limitation metadata and a recommendation to narrow the time window.
 
     Args:
         adom: ADOM name (default: from config DEFAULT_ADOM)
         device: Device filter (serial number like "FG100FTK19001333" or name).
             Default: All FortiGate devices.
-        policy_ids: List of firewall policy IDs to analyze (1-25 IDs, each > 0).
+        policy_ids: List of firewall policy IDs to analyze (1-24 IDs, each > 0).
         time_range: Time range for log query. Options:
             - "1-hour", "6-hour", "12-hour", "24-hour" (default)
             - "7-day", "30-day"
@@ -527,7 +774,9 @@ async def get_policy_port_analysis(
         dict with keys:
             - status: "success" or "error"
             - results: Per-policy port analysis with:
-                - is_exact: Whether the port list is complete
+                - is_exact: Whether the port list is complete for queried window
+                - analysis_mode: "complete" or "bounded_sample"
+                - observed_hits: Number of log rows aggregated
                 - ports: List of port/protocol pairs with hit counts
                 - protocols: Protocol breakdown
                 - portless_protocols: Protocols without ports (ICMP, GRE, etc.)
@@ -550,8 +799,19 @@ async def get_policy_port_analysis(
         action = validate_action(action)
 
         start = time.monotonic()
+        estimates = await _estimate_policy_hits_best_effort(adom, device, policy_ids, time_range, action)
 
-        tasks = [_query_policy_logs(adom, device, pid, time_range, action) for pid in policy_ids]
+        tasks = [
+            _query_policy_logs_bounded(
+                adom,
+                device,
+                pid,
+                time_range,
+                action,
+                policy_count=len(policy_ids),
+            )
+            for pid in policy_ids
+        ]
         results_list = await asyncio.gather(*tasks, return_exceptions=True)
 
         per_policy = []
@@ -564,7 +824,17 @@ async def get_policy_port_analysis(
                     }
                 )
             else:
-                analysis = _aggregate_port_analysis(result, limit=1000)
+                policy_result = cast(dict[str, Any], result)
+                logs = policy_result["logs"]
+                analysis = _aggregate_port_analysis(logs, limit=LOG_FETCH_LIMIT)
+                analysis.update(
+                    _bounded_metadata(
+                        observed_hits=len(logs),
+                        slices_scanned=policy_result["slices_scanned"],
+                        truncated_slices=policy_result["truncated_slices"],
+                        estimated_total_hits=estimates.get(pid),
+                    )
+                )
                 analysis["policy_id"] = pid
                 per_policy.append(analysis)
 
@@ -603,7 +873,7 @@ async def get_policy_protocol_summary(
         adom: ADOM name (default: from config DEFAULT_ADOM)
         device: Device filter (serial number like "FG100FTK19001333" or name).
             Default: All FortiGate devices.
-        policy_ids: List of firewall policy IDs to analyze (1-25 IDs, each > 0).
+        policy_ids: List of firewall policy IDs to analyze (1-24 IDs, each > 0).
         time_range: Time range for log query. Options:
             - "1-hour", "6-hour", "12-hour", "24-hour" (default)
             - "7-day", "30-day"
@@ -632,8 +902,19 @@ async def get_policy_protocol_summary(
         action = validate_action(action)
 
         start = time.monotonic()
+        estimates = await _estimate_policy_hits_best_effort(adom, device, policy_ids, time_range, action)
 
-        tasks = [_query_policy_logs(adom, device, pid, time_range, action) for pid in policy_ids]
+        tasks = [
+            _query_policy_logs_bounded(
+                adom,
+                device,
+                pid,
+                time_range,
+                action,
+                policy_count=len(policy_ids),
+            )
+            for pid in policy_ids
+        ]
         results_list = await asyncio.gather(*tasks, return_exceptions=True)
 
         per_policy = []
@@ -646,7 +927,17 @@ async def get_policy_protocol_summary(
                     }
                 )
             else:
-                summary = _aggregate_protocol_summary(result)
+                policy_result = cast(dict[str, Any], result)
+                logs = policy_result["logs"]
+                summary = _aggregate_protocol_summary(logs)
+                summary.update(
+                    _bounded_metadata(
+                        observed_hits=len(logs),
+                        slices_scanned=policy_result["slices_scanned"],
+                        truncated_slices=policy_result["truncated_slices"],
+                        estimated_total_hits=estimates.get(pid),
+                    )
+                )
                 summary["policy_id"] = pid
                 per_policy.append(summary)
 

--- a/tests/test_traffic_tools.py
+++ b/tests/test_traffic_tools.py
@@ -6,12 +6,17 @@ without triggering server initialization.
 
 import pytest
 
+import fortianalyzer_mcp.tools.traffic_tools as traffic_tools
 from fortianalyzer_mcp.tools.traffic_tools import (
+    ANALYSIS_QUERY_BUDGET,
+    LOG_FETCH_LIMIT,
     VALID_ACTIONS,
     _aggregate_port_analysis,
     _aggregate_protocol_summary,
     _aggregate_traffic_profile,
+    _build_bounded_time_slices,
     _build_policy_filter,
+    _plan_policy_slice_count,
     sanitize_filter_value,
     validate_action,
     validate_policy_ids,
@@ -97,15 +102,62 @@ class TestValidatePolicyIds:
             validate_policy_ids([-1])
 
     def test_too_many_ids(self) -> None:
-        """More than 25 IDs should be rejected."""
-        ids = list(range(1, 27))  # 26 IDs
+        """More than the query budget should be rejected."""
+        ids = list(range(1, ANALYSIS_QUERY_BUDGET + 2))
         with pytest.raises(ValidationError, match="Too many policy IDs"):
             validate_policy_ids(ids)
 
     def test_max_ids_allowed(self) -> None:
-        """Exactly 25 IDs should be accepted."""
-        ids = list(range(1, 26))  # 25 IDs
+        """Exactly the query budget should be accepted."""
+        ids = list(range(1, ANALYSIS_QUERY_BUDGET + 1))
         assert validate_policy_ids(ids) == ids
+
+
+# =============================================================================
+# Bounded analysis planning
+# =============================================================================
+
+
+class TestBoundedAnalysisPlanning:
+    """Tests for fixed bounded query planning."""
+
+    def test_24_hour_window_uses_one_slice(self) -> None:
+        """Windows up to 24 hours should use one slice per policy."""
+        time_range = {
+            "start": "2024-01-01 00:00:00",
+            "end": "2024-01-02 00:00:00",
+        }
+        assert _plan_policy_slice_count(time_range, policy_count=1) == 1
+
+    def test_30_day_single_policy_uses_four_slices(self) -> None:
+        """Large single-policy windows should use the maximum four slices."""
+        time_range = {
+            "start": "2024-01-01 00:00:00",
+            "end": "2024-01-31 00:00:00",
+        }
+        assert _plan_policy_slice_count(time_range, policy_count=1) == 4
+
+    def test_30_day_many_policies_stays_within_query_budget(self) -> None:
+        """Many-policy large windows should stay within the logsearch query budget."""
+        time_range = {
+            "start": "2024-01-01 00:00:00",
+            "end": "2024-01-31 00:00:00",
+        }
+        policy_count = 12
+        slices = _plan_policy_slice_count(time_range, policy_count=policy_count)
+        assert slices == 2
+        assert slices * policy_count <= ANALYSIS_QUERY_BUDGET
+
+    def test_bounded_slices_cover_window(self) -> None:
+        """Fixed slices should preserve the requested first and last timestamps."""
+        time_range = {
+            "start": "2024-01-01 00:00:00",
+            "end": "2024-01-31 00:00:00",
+        }
+        slices = _build_bounded_time_slices(time_range, 4)
+        assert len(slices) == 4
+        assert slices[0]["start"] == time_range["start"]
+        assert slices[-1]["end"] == time_range["end"]
 
 
 # =============================================================================
@@ -327,6 +379,116 @@ class TestAggregatePortAnalysis:
         ]
         result = _aggregate_port_analysis(logs)
         assert result["uncovered_port_hits"] == 1
+
+
+# =============================================================================
+# Tool behavior: bounded policy analysis
+# =============================================================================
+
+
+class TestPolicyPortAnalysisToolBounded:
+    """Tests for bounded tool behavior without live FortiAnalyzer access."""
+
+    async def test_large_request_returns_bounded_result(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Large windows should return bounded observations instead of failing."""
+        call_count = 0
+
+        async def fake_estimate(*_args: object, **_kwargs: object) -> dict[int, int]:
+            return {2: 448566}
+
+        async def fake_slice(*_args: object, **_kwargs: object) -> list[dict[str, object]]:
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return [{"dstport": 443, "proto": "6"} for _ in range(LOG_FETCH_LIMIT)]
+            return [{"dstport": 80, "proto": "6"}]
+
+        monkeypatch.setattr(traffic_tools, "_estimate_policy_hits_best_effort", fake_estimate)
+        monkeypatch.setattr(traffic_tools, "_query_policy_log_slice", fake_slice)
+
+        result = await traffic_tools.get_policy_port_analysis(
+            adom="root",
+            device="FGT70FTK22019321",
+            policy_ids=[2],
+            time_range="2024-01-01 00:00:00|2024-01-31 00:00:00",
+        )
+
+        assert result["status"] == "success"
+        analysis = result["results"][0]
+        assert call_count == 4
+        assert analysis["policy_id"] == 2
+        assert analysis["is_exact"] is False
+        assert analysis["analysis_mode"] == "bounded_sample"
+        assert analysis["observed_hits"] == LOG_FETCH_LIMIT + 3
+        assert analysis["slices_scanned"] == 4
+        assert analysis["truncated_slices"] == 1
+        assert analysis["log_limit_per_slice"] == LOG_FETCH_LIMIT
+        assert analysis["estimated_total_hits"] == 448566
+        assert "recommendation" in analysis
+
+    async def test_fortiview_estimate_failure_does_not_fail_tool(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """FortiView estimate failures should be metadata-only."""
+
+        async def fake_estimate(*_args: object, **_kwargs: object) -> dict[int, int]:
+            raise RuntimeError("FortiView unavailable")
+
+        async def fake_slice(*_args: object, **_kwargs: object) -> list[dict[str, object]]:
+            return [{"dstport": 443, "proto": "6"}]
+
+        monkeypatch.setattr(traffic_tools, "_estimate_policy_hits", fake_estimate)
+        monkeypatch.setattr(traffic_tools, "_query_policy_log_slice", fake_slice)
+
+        result = await traffic_tools.get_policy_port_analysis(
+            adom="root",
+            device="FGT70FTK22019321",
+            policy_ids=[2],
+            time_range="24-hour",
+        )
+
+        assert result["status"] == "success"
+        analysis = result["results"][0]
+        assert analysis["is_exact"] is True
+        assert analysis["estimate_available"] is False
+
+    async def test_per_policy_exceptions_are_isolated(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """One policy failure should not hide successful peer-policy results."""
+
+        async def fake_estimate(*_args: object, **_kwargs: object) -> dict[int, int]:
+            return {}
+
+        async def fake_slice(
+            *_args: object,
+            policy_id: int,
+            **_kwargs: object,
+        ) -> list[dict[str, object]]:
+            if policy_id == 1:
+                raise RuntimeError("policy failed")
+            return [{"dstport": 53, "proto": "17"}]
+
+        monkeypatch.setattr(traffic_tools, "_estimate_policy_hits_best_effort", fake_estimate)
+        monkeypatch.setattr(traffic_tools, "_query_policy_log_slice", fake_slice)
+
+        result = await traffic_tools.get_policy_port_analysis(
+            adom="root",
+            device="FGT70FTK22019321",
+            policy_ids=[1, 2],
+            time_range="24-hour",
+        )
+
+        assert result["status"] == "success"
+        assert result["results"][0]["policy_id"] == 1
+        assert result["results"][0]["error"] == "policy failed"
+        assert result["results"][1]["policy_id"] == 2
+        assert result["results"][1]["observed_hits"] == 1
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Closes #10.

This PR redesigns the policy traffic analysis tools so they stay useful on dense FortiAnalyzer log datasets without promising impossible exactness for large windows.

The key behavioral change is that policy traffic analysis is now **bounded and explicit**:

- short or sparse windows can still be exact
- dense windows return observed ports/protocols instead of failing
- `is_exact=true` is only returned when every queried slice comes back below the FortiAnalyzer row cap
- if any slice reaches the row cap, the result is marked as `analysis_mode="bounded_sample"` and includes limitation metadata

This is intended as a smaller, upstream-aligned replacement for the earlier exact-recursive direction discussed in #4.

## Why This Change

The previous direction tried to reconstruct exact raw-log usage over arbitrary windows. In practice, that is not a reliable contract for busy FortiAnalyzer datasets.

During live testing, FortiAnalyzer rejected a fetch limit above 1000 rows:

```text
Invalid params: limit: 2000 is bigger than max value 1000
```

That makes `1000` a hard API constraint for this logsearch path, not just a conservative implementation choice. For busy policies, a 30-day query can easily exceed that cap in every slice. Recursively splitting until success creates poor user experience and pushes the MCP toward queue/worker/cache infrastructure that does not match this repo's current architecture.

This PR instead makes the tool contract truthful:

- return bounded observations for large windows
- clearly say when the result is not exact
- recommend narrowing the window when exact proof is required
- keep exactness possible for smaller/sparser windows

## What Changed

### Bounded slice planning

Policy traffic tools now use fixed bounded slicing instead of recursive split-until-success behavior:

- `LOG_FETCH_LIMIT = 1000`
- `ANALYSIS_QUERY_BUDGET = 24`
- `MAX_SLICES_PER_POLICY = 4`
- windows up to 24 hours use one slice per policy
- larger windows use `min(4, max(1, 24 // len(policy_ids)))` slices per policy
- the tool never retries indefinitely by recursively splitting dense slices

This keeps each MCP call predictable and bounded.

### Conservative exactness

Exactness is now intentionally strict:

- `is_exact=true` only when every queried slice returns fewer than `LOG_FETCH_LIMIT` rows
- if any queried slice returns exactly `LOG_FETCH_LIMIT`, the result is considered truncated
- truncated results still return `status=success` with observed ports/protocols and clear metadata

For backward compatibility, `total_hits` remains present. When `is_exact=false`, `total_hits` should be read as the number of observed log rows aggregated, not the full historical total.

### Per-policy metadata

Each policy result now includes additional backward-compatible fields:

- `analysis_mode`: `"complete"` or `"bounded_sample"`
- `observed_hits`
- `slices_scanned`
- `truncated_slices`
- `log_limit_per_slice`
- `estimate_available`
- optional `estimated_total_hits`
- `recommendation` when exactness could not be proven

The existing `ports`, `protocols`, `icmp`, `portless_protocols`, `uncovered_port_hits`, `total_hits`, and `query_time_seconds` fields remain available.

### Best-effort FortiView estimate

The implementation adds a bounded, non-fatal FortiView `policy-hits` estimate path. If FortiView can provide a policy hit estimate, it is included as `estimated_total_hits`. If that call fails or cannot map a policy, analysis still succeeds and `estimate_available=false` is returned.

This estimate is metadata only. It does not change exactness and is not used to infer a complete port list.

## What This Preserves

This PR deliberately keeps the upstream architecture intact:

- same single FastMCP process
- same in-process tool model
- no background worker daemon
- no SQLite or job queue
- no persistent slice cache
- no new dependencies
- no server lifecycle changes
- no new MCP tools

The existing three policy traffic tools remain the public interface:

- `get_policy_traffic_profile`
- `get_policy_port_analysis`
- `get_policy_protocol_summary`

## User Impact

Before this change, dense large-window analysis could either take too long, imply exactness that was not defensible, or require a more complex worker-style architecture.

After this change, users get a practical answer immediately:

- which ports/protocols were observed for the policy
- how many raw log rows were actually aggregated
- how many slices were scanned
- whether any slice hit the FortiAnalyzer row cap
- whether the result is exact enough to use as proof
- what to do next when exact proof is needed

For policy hardening, this is safer: the MCP can provide useful 30-day guidance without claiming full raw-log reconstruction when the appliance API does not support that cheaply or reliably.

## Live Validation Notes

The branch was exercised against a live FortiAnalyzer instance after deployment.

Examples observed during testing:

- policy `2`, `1-hour`: returned `status=success`, `observed_hits=1000`, `truncated_slices=1`, `is_exact=false`
- policy `2`, `30-day`: returned `status=success`, `observed_hits=4000`, `slices_scanned=4`, `truncated_slices=4`, `is_exact=false`
- policies `2,7,8,9`, `30-day`: returned `status=success`; dense policies returned bounded observations while policy `9` returned `is_exact=true` with zero observed hits

The attempted `LOG_FETCH_LIMIT=2000` live test failed with FortiAnalyzer's hard API validation error, confirming that the per-slice limit should remain `1000`.

## Tests

Local validation completed:

```text
pytest -m 'not integration'
350 passed, 56 deselected, 1 warning

pytest tests/test_traffic_tools.py
50 passed

ruff check src/fortianalyzer_mcp/tools/traffic_tools.py tests/test_traffic_tools.py
All checks passed

mypy src/fortianalyzer_mcp/tools/traffic_tools.py
Success: no issues found in 1 source file
```

## Files Changed

- `src/fortianalyzer_mcp/tools/traffic_tools.py`
  - bounded slice planning
  - conservative exactness metadata
  - best-effort FortiView estimates
  - isolated per-policy error handling

- `tests/test_traffic_tools.py`
  - slice planning coverage
  - exactness/truncation coverage
  - aggregation coverage for TCP/UDP/ICMP/portless protocols
  - large-window success behavior
  - FortiView estimate failure behavior

- `README.md`, `CHANGELOG.md`, `server.py`
  - documentation and tool description updates for bounded semantics

## Review Notes

The most important review point is the semantics: this PR intentionally does **not** attempt exact 30-day raw-log reconstruction for dense policies. It chooses bounded, truthful, upstream-maintainable behavior instead. Exact proof is still supported by narrowing the time range until no slice hits the FortiAnalyzer fetch cap.
