### PR TITLE
docs: update contributor username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Tool-level bounded tests for `get_policy_traffic_profile` and `get_policy_protocol_summary`
 
 ### Credits
-- Bounded slicing approach contributed by [@nzkller](https://github.com/nzkller) (PR [#11](https://github.com/rstierli/fortianalyzer-mcp/pull/11))
+- Bounded slicing approach contributed by [@inxbit](https://github.com/inxbit) (PR [#11](https://github.com/rstierli/fortianalyzer-mcp/pull/11))
 
 ## [1.1.2-beta] - 2026-04-23
 

--- a/README.md
+++ b/README.md
@@ -804,7 +804,7 @@ MIT License - See [LICENSE](LICENSE) file for details.
 
 - [Anthropic](https://anthropic.com) for the [Model Context Protocol](https://modelcontextprotocol.io)
 - [Fortinet](https://fortinet.com) for FortiAnalyzer
-- [@nzkller](https://github.com/nzkller) for policy usage analysis design concepts (exact-vs-sampled semantics, `is_exact` fail-closed model)
+- [@inxbit](https://github.com/inxbit) for policy usage analysis design concepts (exact-vs-sampled semantics, `is_exact` fail-closed model)
 
 ## Related Projects
 


### PR DESCRIPTION
Updates the contributor acknowledgment links from the previous GitHub username to the current account, @inxbit. 
No code changes.