### PR TITLE
fix: TZ-aware time-range parsing + consolidate 8 duplicates (#13)

### DIFF
--- a/src/fortianalyzer_mcp/api/client.py
+++ b/src/fortianalyzer_mcp/api/client.py
@@ -6,6 +6,7 @@ Based on FNDN FortiAnalyzer 7.6.5 API specifications.
 import json
 import logging
 from typing import Any
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from pyFMG.fortimgr import FortiManager
 
@@ -55,6 +56,7 @@ class FortiAnalyzerClient:
         self._fmg: FortiManager | None = None
         self._connected = False
         self._faz_version: tuple[int, int, int] | None = None  # (major, minor, patch)
+        self._faz_tz: ZoneInfo | None = None  # cached FAZ system timezone
 
         logger.info(f"Initialized FortiAnalyzer client for {self.host}")
 
@@ -182,6 +184,43 @@ class FortiAnalyzerClient:
             self._faz_version = (7, 0, 0)
 
         return self._faz_version
+
+    async def get_system_timezone(self) -> ZoneInfo | None:
+        """Detect and cache the FAZ system timezone as a ZoneInfo.
+
+        FAZ accepts naive ``YYYY-MM-DD HH:MM:SS`` timestamps and
+        interprets them in its own system TZ. When the MCP host is in
+        a different TZ than FAZ, relative time-range queries silently
+        miss real logs. Callers compute "now" in this TZ before
+        formatting so the bytes-on-wire always match FAZ's clock.
+
+        Falls back to ``None`` if FAZ doesn't report a parseable TZ
+        (older versions or unrecognized IANA names). In that case
+        callers degrade to naive ``datetime.now()`` (legacy behavior).
+
+        Returns:
+            ``ZoneInfo`` for the FAZ system TZ, or ``None`` if it
+            couldn't be determined.
+        """
+        if self._faz_tz is not None:
+            return self._faz_tz
+
+        try:
+            status = await self.get_system_status()
+            tz_name = status.get("TZ")
+            if isinstance(tz_name, str) and tz_name:
+                self._faz_tz = ZoneInfo(tz_name)
+                logger.info(f"Detected FAZ system timezone: {tz_name}")
+                return self._faz_tz
+            logger.warning(
+                f"FAZ system status missing TZ field; "
+                f"time-range queries may misalign. Got: {status.get('Time Zone')!r}"
+            )
+        except ZoneInfoNotFoundError as e:
+            logger.warning(f"FAZ reported unknown IANA timezone {e}; falling back to naive")
+        except Exception as e:
+            logger.warning(f"Failed to detect FAZ timezone: {e}; falling back to naive")
+        return None
 
     def _ensure_connected(self) -> FortiManager:
         """Ensure client is connected and return pyfmg instance."""

--- a/src/fortianalyzer_mcp/tools/event_tools.py
+++ b/src/fortianalyzer_mcp/tools/event_tools.py
@@ -5,10 +5,10 @@ Provides alert management, event handling, and SOC operations.
 """
 
 import logging
-from datetime import datetime, timedelta
 from typing import Any
 
 from fortianalyzer_mcp.server import get_faz_client, mcp
+from fortianalyzer_mcp.utils.time_range import parse_time_range
 from fortianalyzer_mcp.utils.validation import get_default_adom
 
 logger = logging.getLogger(__name__)
@@ -22,29 +22,19 @@ def _get_client():
     return client
 
 
-def _parse_time_range(time_range: str) -> dict[str, str]:
-    """Parse time range string to API format."""
-    now = datetime.now()
-    fmt = "%Y-%m-%d %H:%M:%S"
+async def _parse_time_range(time_range: str) -> dict[str, str]:
+    """Parse time range using FAZ system TZ for alignment.
 
+    Custom absolute ranges (``"start|end"``) skip the TZ lookup since
+    the caller is already supplying explicit timestamps. Relative
+    presets pull the cached FAZ timezone off the client so naive
+    timestamps land in FAZ's local TZ.
+    """
     if "|" in time_range:
-        parts = time_range.split("|")
-        return {"start": parts[0].strip(), "end": parts[1].strip()}
-
-    range_map = {
-        "1-hour": timedelta(hours=1),
-        "6-hour": timedelta(hours=6),
-        "12-hour": timedelta(hours=12),
-        "24-hour": timedelta(hours=24),
-        "1-day": timedelta(days=1),
-        "7-day": timedelta(days=7),
-        "30-day": timedelta(days=30),
-    }
-
-    delta = range_map.get(time_range, timedelta(hours=24))
-    start = now - delta
-
-    return {"start": start.strftime(fmt), "end": now.strftime(fmt)}
+        return parse_time_range(time_range)
+    client = _get_client()
+    faz_tz = await client.get_system_timezone()
+    return parse_time_range(time_range, faz_tz=faz_tz)
 
 
 @mcp.tool()
@@ -79,7 +69,7 @@ async def get_alerts(
     try:
         adom = adom or get_default_adom()
         client = _get_client()
-        tr = _parse_time_range(time_range)
+        tr = await _parse_time_range(time_range)
 
         logger.info(f"Getting alerts from ADOM {adom} for {time_range}")
 
@@ -126,7 +116,7 @@ async def get_alert_count(
     try:
         adom = adom or get_default_adom()
         client = _get_client()
-        tr = _parse_time_range(time_range)
+        tr = await _parse_time_range(time_range)
 
         logger.info(f"Getting alert count from ADOM {adom}")
 
@@ -382,7 +372,7 @@ async def get_alert_incident_stats(
     try:
         adom = adom or get_default_adom()
         client = _get_client()
-        tr = _parse_time_range(time_range)
+        tr = await _parse_time_range(time_range)
 
         logger.info(f"Getting {stat_type} stats from ADOM {adom}")
 

--- a/src/fortianalyzer_mcp/tools/fortiview_tools.py
+++ b/src/fortianalyzer_mcp/tools/fortiview_tools.py
@@ -6,10 +6,10 @@ Provides network visibility, threat analysis, and traffic analytics using TID-ba
 
 import asyncio
 import logging
-from datetime import datetime, timedelta
 from typing import Any
 
 from fortianalyzer_mcp.server import get_faz_client, mcp
+from fortianalyzer_mcp.utils.time_range import parse_time_range
 from fortianalyzer_mcp.utils.validation import (
     ValidationError,
     get_default_adom,
@@ -28,32 +28,19 @@ def _get_client():
     return client
 
 
-def _parse_time_range(time_range: str) -> dict[str, str]:
-    """Parse time range string to API format."""
-    now = datetime.now()
-    fmt = "%Y-%m-%d %H:%M:%S"
+async def _parse_time_range(time_range: str) -> dict[str, str]:
+    """Parse time range using FAZ system TZ for alignment.
 
+    Custom absolute ranges (``"start|end"``) skip the TZ lookup since
+    the caller is already supplying explicit timestamps. Relative
+    presets pull the cached FAZ timezone off the client so naive
+    timestamps land in FAZ's local TZ.
+    """
     if "|" in time_range:
-        parts = time_range.split("|")
-        return {"start": parts[0].strip(), "end": parts[1].strip()}
-
-    range_map = {
-        "now": timedelta(minutes=5),
-        "5-min": timedelta(minutes=5),
-        "15-min": timedelta(minutes=15),
-        "1-hour": timedelta(hours=1),
-        "6-hour": timedelta(hours=6),
-        "12-hour": timedelta(hours=12),
-        "24-hour": timedelta(hours=24),
-        "1-day": timedelta(days=1),
-        "7-day": timedelta(days=7),
-        "30-day": timedelta(days=30),
-    }
-
-    delta = range_map.get(time_range, timedelta(hours=1))
-    start = now - delta
-
-    return {"start": start.strftime(fmt), "end": now.strftime(fmt)}
+        return parse_time_range(time_range)
+    client = _get_client()
+    faz_tz = await client.get_system_timezone()
+    return parse_time_range(time_range, faz_tz=faz_tz)
 
 
 @mcp.tool()
@@ -118,7 +105,7 @@ async def run_fortiview(
         view_name = validate_fortiview_view(view_name)
 
         client = _get_client()
-        tr = _parse_time_range(time_range)
+        tr = await _parse_time_range(time_range)
 
         # Convert device string to API format
         device_filter = [{"devname": device}] if device else [{"devname": "All_Device"}]
@@ -260,7 +247,7 @@ async def get_fortiview_data(
         view_name = validate_fortiview_view(view_name)
 
         client = _get_client()
-        tr = _parse_time_range(time_range)
+        tr = await _parse_time_range(time_range)
 
         # Convert device string to API format
         device_filter = [{"devname": device}] if device else [{"devname": "All_Device"}]

--- a/src/fortianalyzer_mcp/tools/incident_tools.py
+++ b/src/fortianalyzer_mcp/tools/incident_tools.py
@@ -5,10 +5,10 @@ Provides incident creation, tracking, and SOC workflow operations.
 """
 
 import logging
-from datetime import datetime, timedelta
 from typing import Any
 
 from fortianalyzer_mcp.server import get_faz_client, mcp
+from fortianalyzer_mcp.utils.time_range import parse_time_range
 from fortianalyzer_mcp.utils.validation import get_default_adom
 
 logger = logging.getLogger(__name__)
@@ -22,30 +22,19 @@ def _get_client():
     return client
 
 
-def _parse_time_range(time_range: str) -> dict[str, str]:
-    """Parse time range string to API format."""
-    now = datetime.now()
-    fmt = "%Y-%m-%d %H:%M:%S"
+async def _parse_time_range(time_range: str) -> dict[str, str]:
+    """Parse time range using FAZ system TZ for alignment.
 
+    Custom absolute ranges (``"start|end"``) skip the TZ lookup since
+    the caller is already supplying explicit timestamps. Relative
+    presets pull the cached FAZ timezone off the client so naive
+    timestamps land in FAZ's local TZ.
+    """
     if "|" in time_range:
-        parts = time_range.split("|")
-        return {"start": parts[0].strip(), "end": parts[1].strip()}
-
-    range_map = {
-        "1-hour": timedelta(hours=1),
-        "6-hour": timedelta(hours=6),
-        "12-hour": timedelta(hours=12),
-        "24-hour": timedelta(hours=24),
-        "1-day": timedelta(days=1),
-        "7-day": timedelta(days=7),
-        "30-day": timedelta(days=30),
-        "90-day": timedelta(days=90),
-    }
-
-    delta = range_map.get(time_range, timedelta(days=7))
-    start = now - delta
-
-    return {"start": start.strftime(fmt), "end": now.strftime(fmt)}
+        return parse_time_range(time_range)
+    client = _get_client()
+    faz_tz = await client.get_system_timezone()
+    return parse_time_range(time_range, faz_tz=faz_tz)
 
 
 @mcp.tool()
@@ -81,7 +70,7 @@ async def get_incidents(
     try:
         adom = adom or get_default_adom()
         client = _get_client()
-        tr = _parse_time_range(time_range)
+        tr = await _parse_time_range(time_range)
 
         logger.info(f"Getting incidents from ADOM {adom}")
 
@@ -174,7 +163,7 @@ async def get_incident_count(
     try:
         adom = adom or get_default_adom()
         client = _get_client()
-        tr = _parse_time_range(time_range)
+        tr = await _parse_time_range(time_range)
 
         logger.info(f"Getting incident count from ADOM {adom}")
 
@@ -346,7 +335,7 @@ async def get_incident_stats(
     try:
         adom = adom or get_default_adom()
         client = _get_client()
-        tr = _parse_time_range(time_range)
+        tr = await _parse_time_range(time_range)
 
         logger.info(f"Getting incident stats from ADOM {adom}")
 

--- a/src/fortianalyzer_mcp/tools/ioc_tools.py
+++ b/src/fortianalyzer_mcp/tools/ioc_tools.py
@@ -6,10 +6,10 @@ Provides IOC detection, acknowledgment, and rescan operations.
 
 import asyncio
 import logging
-from datetime import datetime, timedelta
 from typing import Any
 
 from fortianalyzer_mcp.server import get_faz_client, mcp
+from fortianalyzer_mcp.utils.time_range import parse_time_range
 from fortianalyzer_mcp.utils.validation import get_default_adom
 
 logger = logging.getLogger(__name__)
@@ -23,29 +23,19 @@ def _get_client():
     return client
 
 
-def _parse_time_range(time_range: str) -> dict[str, str]:
-    """Parse time range string to API format."""
-    now = datetime.now()
-    fmt = "%Y-%m-%d %H:%M:%S"
+async def _parse_time_range(time_range: str) -> dict[str, str]:
+    """Parse time range using FAZ system TZ for alignment.
 
+    Custom absolute ranges (``"start|end"``) skip the TZ lookup since
+    the caller is already supplying explicit timestamps. Relative
+    presets pull the cached FAZ timezone off the client so naive
+    timestamps land in FAZ's local TZ.
+    """
     if "|" in time_range:
-        parts = time_range.split("|")
-        return {"start": parts[0].strip(), "end": parts[1].strip()}
-
-    range_map = {
-        "1-hour": timedelta(hours=1),
-        "6-hour": timedelta(hours=6),
-        "12-hour": timedelta(hours=12),
-        "24-hour": timedelta(hours=24),
-        "1-day": timedelta(days=1),
-        "7-day": timedelta(days=7),
-        "30-day": timedelta(days=30),
-    }
-
-    delta = range_map.get(time_range, timedelta(days=7))
-    start = now - delta
-
-    return {"start": start.strftime(fmt), "end": now.strftime(fmt)}
+        return parse_time_range(time_range)
+    client = _get_client()
+    faz_tz = await client.get_system_timezone()
+    return parse_time_range(time_range, faz_tz=faz_tz)
 
 
 @mcp.tool()
@@ -156,7 +146,7 @@ async def run_ioc_rescan(
     try:
         adom = adom or get_default_adom()
         client = _get_client()
-        tr = _parse_time_range(time_range)
+        tr = await _parse_time_range(time_range)
 
         logger.info(f"Starting IOC rescan in ADOM {adom}")
 
@@ -302,7 +292,7 @@ async def run_and_wait_ioc_rescan(
     try:
         adom = adom or get_default_adom()
         client = _get_client()
-        tr = _parse_time_range(time_range)
+        tr = await _parse_time_range(time_range)
 
         logger.info("Running IOC rescan and waiting for completion")
 

--- a/src/fortianalyzer_mcp/tools/log_tools.py
+++ b/src/fortianalyzer_mcp/tools/log_tools.py
@@ -6,10 +6,10 @@ Implements the two-step TID-based log search workflow.
 
 import asyncio
 import logging
-from datetime import datetime, timedelta
 from typing import Any
 
 from fortianalyzer_mcp.server import get_faz_client, mcp
+from fortianalyzer_mcp.utils.time_range import parse_time_range
 from fortianalyzer_mcp.utils.validation import (
     ValidationError,
     get_default_adom,
@@ -33,39 +33,19 @@ def _get_client():
     return client
 
 
-def _parse_time_range(time_range: str) -> dict[str, str]:
-    """Parse time range string to API format.
+async def _parse_time_range(time_range: str) -> dict[str, str]:
+    """Parse time range using FAZ system TZ for alignment.
 
-    Args:
-        time_range: Time range string like "1-hour", "24-hour", "7-day", "30-day"
-                   or a custom range in format "start|end" with ISO format.
-
-    Returns:
-        dict with "start" and "end" keys in FortiAnalyzer format.
+    Custom absolute ranges (``"start|end"``) skip the TZ lookup since
+    the caller is already supplying explicit timestamps. Relative
+    presets pull the cached FAZ timezone off the client so naive
+    timestamps land in FAZ's local TZ.
     """
-    now = datetime.now()
-    fmt = "%Y-%m-%d %H:%M:%S"
-
     if "|" in time_range:
-        # Custom range: "2024-01-01 00:00:00|2024-01-02 00:00:00"
-        parts = time_range.split("|")
-        return {"start": parts[0].strip(), "end": parts[1].strip()}
-
-    # Predefined ranges
-    range_map = {
-        "1-hour": timedelta(hours=1),
-        "6-hour": timedelta(hours=6),
-        "12-hour": timedelta(hours=12),
-        "24-hour": timedelta(hours=24),
-        "1-day": timedelta(days=1),
-        "7-day": timedelta(days=7),
-        "30-day": timedelta(days=30),
-    }
-
-    delta = range_map.get(time_range, timedelta(hours=1))
-    start = now - delta
-
-    return {"start": start.strftime(fmt), "end": now.strftime(fmt)}
+        return parse_time_range(time_range)
+    client = _get_client()
+    faz_tz = await client.get_system_timezone()
+    return parse_time_range(time_range, faz_tz=faz_tz)
 
 
 def _build_device_filter(device: str | None) -> list[dict[str, str]]:
@@ -179,7 +159,7 @@ async def query_logs(
         client = _get_client()
 
         # Parse time range
-        time_range_dict = _parse_time_range(time_range)
+        time_range_dict = await _parse_time_range(time_range)
 
         # Build device filter
         device_filter = _build_device_filter(device)
@@ -749,7 +729,7 @@ async def get_logfiles_state(
 
         time_range_dict = None
         if time_range:
-            time_range_dict = _parse_time_range(time_range)
+            time_range_dict = await _parse_time_range(time_range)
 
         result = await client.get_logfiles_state(
             adom=adom,

--- a/src/fortianalyzer_mcp/tools/pcap_tools.py
+++ b/src/fortianalyzer_mcp/tools/pcap_tools.py
@@ -12,10 +12,11 @@ import io
 import logging
 import os
 import zipfile
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Any
 
 from fortianalyzer_mcp.server import get_faz_client, mcp
+from fortianalyzer_mcp.utils.time_range import parse_time_range
 from fortianalyzer_mcp.utils.validation import (
     ValidationError,
     get_default_adom,
@@ -39,31 +40,19 @@ def _get_client():
     return client
 
 
-def _parse_time_range(time_range: str) -> dict[str, str]:
-    """Parse time range string to API format."""
-    now = datetime.now()
-    fmt = "%Y-%m-%d %H:%M:%S"
+async def _parse_time_range(time_range: str) -> dict[str, str]:
+    """Parse time range using FAZ system TZ for alignment.
 
+    Custom absolute ranges (``"start|end"``) skip the TZ lookup since
+    the caller is already supplying explicit timestamps. Relative
+    presets pull the cached FAZ timezone off the client so naive
+    timestamps land in FAZ's local TZ.
+    """
     if "|" in time_range:
-        parts = time_range.split("|")
-        return {"start": parts[0].strip(), "end": parts[1].strip()}
-
-    range_map = {
-        "5-min": timedelta(minutes=5),
-        "30-min": timedelta(minutes=30),
-        "1-hour": timedelta(hours=1),
-        "6-hour": timedelta(hours=6),
-        "12-hour": timedelta(hours=12),
-        "24-hour": timedelta(hours=24),
-        "1-day": timedelta(days=1),
-        "7-day": timedelta(days=7),
-        "30-day": timedelta(days=30),
-    }
-
-    delta = range_map.get(time_range, timedelta(hours=24))
-    start = now - delta
-
-    return {"start": start.strftime(fmt), "end": now.strftime(fmt)}
+        return parse_time_range(time_range)
+    client = _get_client()
+    faz_tz = await client.get_system_timezone()
+    return parse_time_range(time_range, faz_tz=faz_tz)
 
 
 def _build_ips_filter(
@@ -274,7 +263,7 @@ async def search_ips_logs(
         )
 
         # Parse time range
-        time_range_dict = _parse_time_range(time_range)
+        time_range_dict = await _parse_time_range(time_range)
 
         # Build device filter
         device_filter = [{"devid": device}] if device else [{"devid": "All_FortiGate"}]
@@ -409,7 +398,7 @@ async def get_pcap_by_session(
 
         # Build filter for specific session ID
         filter_str = f"sessionid=={session_id}"
-        time_range_dict = _parse_time_range(time_range)
+        time_range_dict = await _parse_time_range(time_range)
         device_filter = [{"devid": device}] if device else [{"devid": "All_FortiGate"}]
 
         logger.info(f"Searching for session {session_id} in ADOM {adom}")
@@ -789,7 +778,7 @@ async def search_and_download_pcaps(
             has_pcap=True,  # Only get entries with PCAP
         )
 
-        time_range_dict = _parse_time_range(time_range)
+        time_range_dict = await _parse_time_range(time_range)
         device_filter = [{"devid": device}] if device else [{"devid": "All_FortiGate"}]
 
         logger.info(f"Searching IPS logs for PCAP download: {filter_str}")

--- a/src/fortianalyzer_mcp/tools/report_tools.py
+++ b/src/fortianalyzer_mcp/tools/report_tools.py
@@ -10,10 +10,10 @@ import io
 import logging
 import os
 import zipfile
-from datetime import datetime, timedelta
 from typing import Any
 
 from fortianalyzer_mcp.server import get_faz_client, mcp
+from fortianalyzer_mcp.utils.time_range import parse_time_range
 from fortianalyzer_mcp.utils.validation import (
     ValidationError,
     get_default_adom,
@@ -32,33 +32,19 @@ def _get_client():
     return client
 
 
-def _parse_time_range(time_range: str) -> dict[str, str]:
-    """Parse time range string to start/end format for log searches.
+async def _parse_time_range(time_range: str) -> dict[str, str]:
+    """Parse time range using FAZ system TZ for alignment.
 
-    This is used for log-based APIs that require start/end timestamps.
+    Custom absolute ranges (``"start|end"``) skip the TZ lookup since
+    the caller is already supplying explicit timestamps. Relative
+    presets pull the cached FAZ timezone off the client so naive
+    timestamps land in FAZ's local TZ.
     """
-    now = datetime.now()
-    fmt = "%Y-%m-%d %H:%M:%S"
-
     if "|" in time_range:
-        parts = time_range.split("|")
-        return {"start": parts[0].strip(), "end": parts[1].strip()}
-
-    range_map = {
-        "1-hour": timedelta(hours=1),
-        "6-hour": timedelta(hours=6),
-        "12-hour": timedelta(hours=12),
-        "24-hour": timedelta(hours=24),
-        "1-day": timedelta(days=1),
-        "7-day": timedelta(days=7),
-        "30-day": timedelta(days=30),
-        "90-day": timedelta(days=90),
-    }
-
-    delta = range_map.get(time_range, timedelta(days=7))
-    start = now - delta
-
-    return {"start": start.strftime(fmt), "end": now.strftime(fmt)}
+        return parse_time_range(time_range)
+    client = _get_client()
+    faz_tz = await client.get_system_timezone()
+    return parse_time_range(time_range, faz_tz=faz_tz)
 
 
 def _convert_to_api_time_period(time_range: str) -> str:
@@ -517,7 +503,7 @@ async def get_report_history(
     try:
         adom = adom or get_default_adom()
         client = _get_client()
-        tr = _parse_time_range(time_range)
+        tr = await _parse_time_range(time_range)
 
         logger.info(f"Getting report history in ADOM {adom}")
 

--- a/src/fortianalyzer_mcp/tools/traffic_tools.py
+++ b/src/fortianalyzer_mcp/tools/traffic_tools.py
@@ -18,6 +18,10 @@ from datetime import datetime, timedelta
 from typing import Any, cast
 
 from fortianalyzer_mcp.server import get_faz_client, mcp
+from fortianalyzer_mcp.utils.time_range import (
+    parse_time_range,
+    parse_time_range_bounds,
+)
 from fortianalyzer_mcp.utils.validation import (
     ValidationError,
     get_default_adom,
@@ -152,38 +156,23 @@ def _build_policy_filter(policy_id: int, action: str | None = None) -> str:
     return " and ".join(parts)
 
 
-def _parse_time_range(time_range: str) -> dict[str, str]:
-    """Parse time range string to API format.
+async def _parse_time_range(time_range: str) -> dict[str, str]:
+    """Parse time range using FAZ system TZ for alignment.
 
-    Reuses the same format as log_tools._parse_time_range.
+    Custom absolute ranges (``"start|end"``) skip the TZ lookup since
+    the caller is already supplying explicit timestamps. Relative
+    presets pull the cached FAZ timezone off the client so naive
+    timestamps land in FAZ's local TZ.
     """
-    now = datetime.now()
-    fmt = "%Y-%m-%d %H:%M:%S"
-
     if "|" in time_range:
-        parts = time_range.split("|", maxsplit=1)
-        return {"start": parts[0].strip(), "end": parts[1].strip()}
-
-    range_map = {
-        "1-hour": timedelta(hours=1),
-        "6-hour": timedelta(hours=6),
-        "12-hour": timedelta(hours=12),
-        "24-hour": timedelta(hours=24),
-        "1-day": timedelta(days=1),
-        "7-day": timedelta(days=7),
-        "30-day": timedelta(days=30),
-    }
-
-    delta = range_map.get(time_range, timedelta(hours=1))
-    start = now - delta
-
-    return {"start": start.strftime(fmt), "end": now.strftime(fmt)}
+        return parse_time_range(time_range)
+    client = _get_client()
+    faz_tz = await client.get_system_timezone()
+    return parse_time_range(time_range, faz_tz=faz_tz)
 
 
-def _parse_time_range_bounds(time_range: dict[str, str]) -> tuple[datetime, datetime]:
-    """Parse a FortiAnalyzer time range dict into datetime bounds."""
-    fmt = "%Y-%m-%d %H:%M:%S"
-    return datetime.strptime(time_range["start"], fmt), datetime.strptime(time_range["end"], fmt)
+# parse_time_range_bounds is re-exported from utils.time_range above.
+_parse_time_range_bounds = parse_time_range_bounds
 
 
 def _format_time_range(start: datetime, end: datetime) -> dict[str, str]:
@@ -316,7 +305,7 @@ async def _query_policy_logs(
         List of log entries.
     """
     async with _QUERY_SEMAPHORE:
-        time_range_dict = _parse_time_range(time_range)
+        time_range_dict = await _parse_time_range(time_range)
         device_filter = _build_device_filter(device)
         return await _query_policy_log_slice(
             adom=adom,
@@ -341,7 +330,7 @@ async def _query_policy_logs_bounded(
 ) -> dict[str, Any]:
     """Query fixed bounded slices for one policy and report truncation metadata."""
     async with _QUERY_SEMAPHORE:
-        full_time_range = _parse_time_range(time_range)
+        full_time_range = await _parse_time_range(time_range)
         device_filter = _build_device_filter(device)
         slice_count = _plan_policy_slice_count(full_time_range, policy_count)
         time_slices = _build_bounded_time_slices(full_time_range, slice_count)
@@ -399,7 +388,7 @@ async def _estimate_policy_hits(
     """Fetch one bounded FortiView policy-hits page as optional metadata."""
     client = _get_client()
     device_filter = _build_device_filter(device)
-    time_range_dict = _parse_time_range(time_range)
+    time_range_dict = await _parse_time_range(time_range)
 
     run_result = await client.fortiview_run(
         adom=adom,

--- a/src/fortianalyzer_mcp/utils/time_range.py
+++ b/src/fortianalyzer_mcp/utils/time_range.py
@@ -1,0 +1,113 @@
+"""Time-range parsing shared by FAZ MCP tools.
+
+FortiAnalyzer's logview/fortiview/incident/report APIs accept a time-range
+dict ``{"start": "YYYY-MM-DD HH:MM:SS", "end": "YYYY-MM-DD HH:MM:SS"}``.
+The timestamps are naive (no TZ marker) and FAZ interprets them in its
+own system timezone. If the client's system timezone differs from the
+FAZ system timezone, relative ranges like "1-hour" silently miss real
+logs (see GitHub issue for the discovery story).
+
+This module is the single source of truth for translating either a
+preset key ("1-hour", "5-min", ...) or a custom range ("start|end") into
+that dict. When a ``faz_tz`` is supplied, "now" is computed in UTC and
+converted to the FAZ timezone before being stripped to naive — so the
+caller's wall clock no longer matters.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+_TIMESTAMP_FMT = "%Y-%m-%d %H:%M:%S"
+
+# Preset relative ranges. Keys are caller-facing strings; values are
+# the size of the window ending at "now". Order roughly small -> large.
+_RANGE_MAP: dict[str, timedelta] = {
+    "now": timedelta(minutes=5),  # alias for 5-min, used by FortiView "real-time"
+    "5-min": timedelta(minutes=5),
+    "15-min": timedelta(minutes=15),
+    "30-min": timedelta(minutes=30),
+    "1-hour": timedelta(hours=1),
+    "2-hour": timedelta(hours=2),
+    "6-hour": timedelta(hours=6),
+    "12-hour": timedelta(hours=12),
+    "24-hour": timedelta(hours=24),
+    "1-day": timedelta(days=1),
+    "2-day": timedelta(days=2),
+    "7-day": timedelta(days=7),
+    "30-day": timedelta(days=30),
+    "90-day": timedelta(days=90),
+}
+
+# Public for documentation / docstrings in callers.
+SUPPORTED_TIME_RANGES: tuple[str, ...] = tuple(_RANGE_MAP.keys())
+
+
+def parse_time_range(
+    time_range: str,
+    faz_tz: ZoneInfo | None = None,
+) -> dict[str, str]:
+    """Translate a caller-facing time-range string to FAZ's dict format.
+
+    Args:
+        time_range: Either a preset key from :data:`SUPPORTED_TIME_RANGES`
+            (e.g. ``"1-hour"``, ``"5-min"``, ``"7-day"``) or a custom
+            range ``"YYYY-MM-DD HH:MM:SS|YYYY-MM-DD HH:MM:SS"``.
+        faz_tz: FAZ system timezone (recommended). When provided, "now"
+            is taken in UTC and converted to ``faz_tz`` before being
+            stripped to naive form. When ``None``, falls back to
+            :func:`datetime.now` (caller-local) — preserves legacy
+            behavior, but only correct if the caller and FAZ happen
+            to share a timezone.
+
+    Returns:
+        ``{"start": "...", "end": "..."}`` ready to send as
+        ``time-range`` in a logview/fortiview/incident API call.
+
+    Raises:
+        ValueError: If ``time_range`` is neither a known preset key nor
+            a valid custom ``"start|end"`` range. The previous behavior
+            of silently falling back to ``1-hour`` for unknown keys hid
+            typos; callers now get a hard failure they can fix.
+    """
+    if "|" in time_range:
+        parts = time_range.split("|", maxsplit=1)
+        start = parts[0].strip()
+        end = parts[1].strip()
+        if not start or not end:
+            raise ValueError(
+                f"Custom time_range must be 'start|end' with non-empty parts, got {time_range!r}"
+            )
+        return {"start": start, "end": end}
+
+    delta = _RANGE_MAP.get(time_range)
+    if delta is None:
+        raise ValueError(
+            f"Unknown time_range {time_range!r}. Valid presets: "
+            f"{', '.join(SUPPORTED_TIME_RANGES)}. Or use a custom range "
+            f"'YYYY-MM-DD HH:MM:SS|YYYY-MM-DD HH:MM:SS'."
+        )
+
+    if faz_tz is not None:
+        now = datetime.now(UTC).astimezone(faz_tz).replace(tzinfo=None)
+    else:
+        now = datetime.now()
+
+    start_dt = now - delta
+    return {
+        "start": start_dt.strftime(_TIMESTAMP_FMT),
+        "end": now.strftime(_TIMESTAMP_FMT),
+    }
+
+
+def parse_time_range_bounds(time_range: dict[str, str]) -> tuple[datetime, datetime]:
+    """Parse a FAZ time-range dict back into ``datetime`` bounds.
+
+    Used by traffic-analysis tools that need to slice a window into
+    sub-ranges (see ``traffic_tools._build_bounded_time_slices``).
+    """
+    return (
+        datetime.strptime(time_range["start"], _TIMESTAMP_FMT),
+        datetime.strptime(time_range["end"], _TIMESTAMP_FMT),
+    )

--- a/tests/test_time_range.py
+++ b/tests/test_time_range.py
@@ -1,0 +1,149 @@
+"""Tests for the shared time-range parser."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from fortianalyzer_mcp.utils.time_range import (
+    SUPPORTED_TIME_RANGES,
+    parse_time_range,
+    parse_time_range_bounds,
+)
+
+
+class TestParseTimeRangePresets:
+    """Preset string handling: known keys, unknown keys, all supported values."""
+
+    def test_one_hour_returns_one_hour_window(self) -> None:
+        result = parse_time_range("1-hour")
+        start = datetime.strptime(result["start"], "%Y-%m-%d %H:%M:%S")
+        end = datetime.strptime(result["end"], "%Y-%m-%d %H:%M:%S")
+        assert end - start == timedelta(hours=1)
+
+    def test_supported_keys_match_advertised_list(self) -> None:
+        """SUPPORTED_TIME_RANGES is the contract — every key must parse."""
+        for key in SUPPORTED_TIME_RANGES:
+            result = parse_time_range(key)
+            assert "start" in result and "end" in result, f"key {key!r} returned {result!r}"
+
+    @pytest.mark.parametrize(
+        "key,delta",
+        [
+            ("5-min", timedelta(minutes=5)),
+            ("15-min", timedelta(minutes=15)),
+            ("30-min", timedelta(minutes=30)),
+            ("1-hour", timedelta(hours=1)),
+            ("2-hour", timedelta(hours=2)),
+            ("6-hour", timedelta(hours=6)),
+            ("12-hour", timedelta(hours=12)),
+            ("24-hour", timedelta(hours=24)),
+            ("1-day", timedelta(days=1)),
+            ("2-day", timedelta(days=2)),
+            ("7-day", timedelta(days=7)),
+            ("30-day", timedelta(days=30)),
+            ("90-day", timedelta(days=90)),
+        ],
+    )
+    def test_each_preset_produces_expected_window_size(self, key: str, delta: timedelta) -> None:
+        result = parse_time_range(key)
+        start = datetime.strptime(result["start"], "%Y-%m-%d %H:%M:%S")
+        end = datetime.strptime(result["end"], "%Y-%m-%d %H:%M:%S")
+        assert end - start == delta
+
+    def test_unknown_key_raises_value_error(self) -> None:
+        """Bug A regression: unknown keys must error, not silently fall back to 1h."""
+        with pytest.raises(ValueError, match="Unknown time_range"):
+            parse_time_range("3-hour")  # not in the supported set
+
+    def test_unknown_key_error_lists_supported_keys(self) -> None:
+        """The error message should help the caller fix their typo."""
+        with pytest.raises(ValueError) as exc_info:
+            parse_time_range("definitely-not-a-real-range")
+        msg = str(exc_info.value)
+        for key in ("1-hour", "24-hour", "7-day"):
+            assert key in msg
+
+
+class TestParseTimeRangeCustom:
+    """Custom 'start|end' range handling."""
+
+    def test_custom_range_returns_input_verbatim(self) -> None:
+        result = parse_time_range("2024-01-01 00:00:00|2024-01-02 00:00:00")
+        assert result == {"start": "2024-01-01 00:00:00", "end": "2024-01-02 00:00:00"}
+
+    def test_custom_range_strips_whitespace(self) -> None:
+        result = parse_time_range("  2024-01-01 00:00:00 | 2024-01-02 00:00:00  ")
+        assert result == {"start": "2024-01-01 00:00:00", "end": "2024-01-02 00:00:00"}
+
+    def test_custom_range_empty_start_raises(self) -> None:
+        with pytest.raises(ValueError, match="non-empty parts"):
+            parse_time_range("|2024-01-02 00:00:00")
+
+    def test_custom_range_empty_end_raises(self) -> None:
+        with pytest.raises(ValueError, match="non-empty parts"):
+            parse_time_range("2024-01-01 00:00:00|")
+
+
+class TestParseTimeRangeTimezone:
+    """Bug B regression: timestamps must align with FAZ TZ when provided."""
+
+    def test_faz_tz_applied_to_now(self) -> None:
+        """When faz_tz is provided, the formatted timestamps are in that TZ.
+
+        We verify by computing the expected UTC instant for the 'end' string
+        (interpreted as faz_tz-local) and comparing to "now" in UTC.
+        """
+        faz_tz = ZoneInfo("US/Pacific")
+        result = parse_time_range("1-hour", faz_tz=faz_tz)
+
+        end_naive = datetime.strptime(result["end"], "%Y-%m-%d %H:%M:%S")
+        end_in_faz_tz = end_naive.replace(tzinfo=faz_tz)
+        now_utc = datetime.now(UTC)
+        drift = abs((now_utc - end_in_faz_tz).total_seconds())
+        assert drift < 5, (
+            f"end timestamp drifts {drift:.1f}s from now-in-FAZ-TZ "
+            f"(end={result['end']!r}, faz_tz={faz_tz})"
+        )
+
+    def test_faz_tz_none_uses_local_time(self) -> None:
+        """When faz_tz is None, falls back to caller-local naive (legacy)."""
+        result = parse_time_range("1-hour", faz_tz=None)
+        end_naive = datetime.strptime(result["end"], "%Y-%m-%d %H:%M:%S")
+        # End should be within a few seconds of local now.
+        drift = abs((datetime.now() - end_naive).total_seconds())
+        assert drift < 5
+
+    def test_faz_tz_does_not_affect_custom_range(self) -> None:
+        """A caller-provided absolute range is sent verbatim regardless of TZ."""
+        custom = "2024-06-15 12:00:00|2024-06-15 13:00:00"
+        result_with_tz = parse_time_range(custom, faz_tz=ZoneInfo("US/Pacific"))
+        result_without_tz = parse_time_range(custom, faz_tz=None)
+        assert (
+            result_with_tz
+            == result_without_tz
+            == {
+                "start": "2024-06-15 12:00:00",
+                "end": "2024-06-15 13:00:00",
+            }
+        )
+
+    def test_window_size_unchanged_by_tz(self) -> None:
+        """end-start delta equals the preset, regardless of TZ choice."""
+        for tz in (None, ZoneInfo("UTC"), ZoneInfo("US/Pacific"), ZoneInfo("Europe/Zurich")):
+            result = parse_time_range("6-hour", faz_tz=tz)
+            start = datetime.strptime(result["start"], "%Y-%m-%d %H:%M:%S")
+            end = datetime.strptime(result["end"], "%Y-%m-%d %H:%M:%S")
+            assert end - start == timedelta(hours=6), f"failed for tz={tz}"
+
+
+class TestParseTimeRangeBounds:
+    """Inverse parser used by traffic_tools for slicing."""
+
+    def test_round_trip_preserves_strings(self) -> None:
+        original = {"start": "2024-01-01 00:00:00", "end": "2024-01-02 12:34:56"}
+        start, end = parse_time_range_bounds(original)
+        assert start == datetime(2024, 1, 1, 0, 0, 0)
+        assert end == datetime(2024, 1, 2, 12, 34, 56)

--- a/tests/test_traffic_tools.py
+++ b/tests/test_traffic_tools.py
@@ -441,7 +441,10 @@ class TestPolicyPortAnalysisToolBounded:
             adom="root",
             device="FGT70FTK22019321",
             policy_ids=[2],
-            time_range="24-hour",
+            # Custom range (same 24-hour window) avoids touching the FAZ
+            # client for TZ lookup, which isn't initialized in these
+            # unit tests.
+            time_range="2024-01-01 00:00:00|2024-01-02 00:00:00",
         )
 
         assert result["status"] == "success"
@@ -474,7 +477,8 @@ class TestPolicyPortAnalysisToolBounded:
             adom="root",
             device="FGT70FTK22019321",
             policy_ids=[1, 2],
-            time_range="24-hour",
+            # Custom range avoids the TZ client lookup in unit tests.
+            time_range="2024-01-01 00:00:00|2024-01-02 00:00:00",
         )
 
         assert result["status"] == "success"


### PR DESCRIPTION
Closes #13.

## Summary

Two latent bugs in the time-range parsing across every tool that queries log/event/incident/fortiview/report/pcap data. Discovered when a freshly-installed FAZ 8.0.0 GA defaulted to **US/Pacific** while the client lived in **CEST** — \`search_traffic_logs(time_range="1-hour")\` was searching a 1-hour window **9 hours in the future** and returning 0 logs.

### Bug A — silent fallback on unknown time-range keys

Each of the 8 tool files had its own \`_parse_time_range\` with a slightly different \`range_map\` and a hard-coded \`timedelta(hours=1)\` / \`(hours=24)\` fallback. Typos like \`"30-min"\` or \`"5-min"\` (advertised in some docstrings but not actually implemented in all parsers) silently became 1-hour or 24-hour queries.

### Bug B — TZ-naive \`datetime.now()\` sent to FAZ

The parsers formatted \`datetime.now()\` (caller-local) as a naive \`"YYYY-MM-DD HH:MM:SS"\` string. FAZ interprets naive strings in its own system TZ. When client and FAZ disagree by N hours, every relative window smaller than N silently returns 0 logs.

## What changed

- **\`utils/time_range.py\`** is the single source of truth. Supports \`now / 5-min / 15-min / 30-min / 1-hour / 2-hour / 6-hour / 12-hour / 24-hour / 1-day / 2-day / 7-day / 30-day / 90-day\` plus the absolute \`"start|end"\` form.
- **Unknown keys raise \`ValueError\`** with a message listing the supported set. Typos surface immediately instead of producing wrong-but-plausible windows.
- **\`FortiAnalyzerClient.get_system_timezone()\`** reads the IANA TZ from \`get_system_status\`, caches it as \`self._faz_tz\`, falls back to \`None\` if FAZ reports something \`zoneinfo\` can't parse.
- **Each tool's \`_parse_time_range\`** is now a thin async wrapper that pulls the FAZ TZ off the client and passes it to the parser. Custom absolute ranges short-circuit the TZ lookup.
- **TZ behavior:** when \`faz_tz\` is provided, "now" is computed in UTC and converted to the FAZ timezone before being stripped to naive form, so bytes-on-wire always match FAZ's clock. \`faz_tz=None\` preserves legacy caller-local behavior as a safety net.

## Behavioral changes worth flagging

| Scenario | Before | After |
|----------|--------|-------|
| Caller passes \`"5-min"\` to a tool that didn't have it | Silent 1-hour window | Correct 5-minute window |
| Caller passes \`"5-mn"\` (typo) | Silent 1-hour window | \`ValueError("Unknown time_range '5-mn'...")\` |
| Client and FAZ share TZ | works | works (identical) |
| Client in CEST, FAZ in PDT, \`"1-hour"\` | 0 logs ❌ | correct logs ✓ |
| Custom range \`"2024-01-01 ... | 2024-01-02 ..."\` | works | works (identical, no extra API call) |

## Verification

- \`pytest --ignore=tests/integration\` — **386 passed**, 0 failed
- \`mypy src/\` — not previously enforced; spot-checked new module clean
- \`ruff check .\` — clean
- \`ruff format --check .\` — clean
- 26 new tests in \`test_time_range.py\` covering presets, unknown keys, custom ranges, TZ correctness, round-trip bounds parser

## Diff scope

- **+** \`src/fortianalyzer_mcp/utils/time_range.py\` (113 lines, the single source of truth)
- **+** \`tests/test_time_range.py\` (26 tests)
- **−** ~30 lines × 8 files = 240 lines of duplicated parsers
- **+** \`FortiAnalyzerClient.get_system_timezone()\` (~40 lines)
- Net: **+425 / −220** across 12 files

## Test plan

- [x] Unit tests pass
- [x] Ruff + format clean
- [x] 1-hour preset returns logs when client and FAZ are aligned (verified live against fresh CEST FAZ)
- [x] Custom ranges still work for offline / test contexts
- [x] Unknown keys raise (regression guard for Bug A)