### PR TITLE
chore: Bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,15 @@ jobs:
         python-version: ["3.12", "3.13"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "latest"
 
@@ -49,7 +49,7 @@ jobs:
           uv run pytest tests/ --ignore=tests/integration --cov=src/fortianalyzer_mcp --cov-report=xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         if: matrix.python-version == '3.12'
         with:
           files: ./coverage.xml
@@ -58,15 +58,15 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v8.1.0
         with:
           version: "latest"
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -32,7 +32,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -41,7 +41,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true


### PR DESCRIPTION
## Summary

Silences the Node.js 20 deprecation warnings shown on every CI and Docker Publish run. Node 24 becomes the forced default on **June 2, 2026** — this PR gets us ahead of the cutover.

Mirrors the FMG MCP upgrade in [rstierli/fortimanager-mcp#9](https://github.com/rstierli/fortimanager-mcp/pull/9), which already validated this exact set of action versions end-to-end (test 3.12, test 3.13, lint, Docker Publish all passed on the same diff shape).

## Upgrades

| Workflow | Action | From | To |
|----------|--------|------|----|
| ci.yml | actions/checkout | v4 | v6 |
| ci.yml | actions/setup-python | v5 | v6 |
| ci.yml | astral-sh/setup-uv | v4 | v8.1.0 |
| ci.yml | codecov/codecov-action | v4 | v6 |
| docker-publish.yml | actions/checkout | v4 | v6 |
| docker-publish.yml | docker/setup-buildx-action | v3 | v4 |
| docker-publish.yml | docker/login-action | v3 | v4 |
| docker-publish.yml | docker/metadata-action | v5 | v6 |
| docker-publish.yml | docker/build-push-action | v6 | v7 |

## Notes

- `astral-sh/setup-uv` is pinned to `v8.1.0` (exact patch) because the upstream doesn't publish a rolling `v8` major tag — only `vX.Y.Z` and `vX.Y`. Verified via `gh api repos/astral-sh/setup-uv/tags`.
- The CI workflow itself is the validation: if any action breaks under the new major, this PR's own CI run fails.
- The Docker Publish workflow only fires on tag push, so it'll be exercised on the next release tag.

## Test plan

- [ ] CI passes on this PR (test 3.12, test 3.13, lint)
- [ ] Docker Publish will be exercised on the next `v*` tag push