### PR TITLE
fix: poll-before-fetch log search to stop slot exhaustion on FortiAnalyzer 7.6.7

### DIFF
--- a/src/fortianalyzer_mcp/api/client.py
+++ b/src/fortianalyzer_mcp/api/client.py
@@ -66,8 +66,18 @@ class FortiAnalyzerClient:
 
         self._fmg: FortiManager | None = None
         self._connected = False
+        # True once a login has succeeded at least once. Distinguishes a session
+        # that dropped after being connected (revive it) from a client that was
+        # never connected (a direct API call should still raise "Not connected").
+        self._ever_connected = False
         self._faz_version: tuple[int, int, int] | None = None  # (major, minor, patch)
         self._faz_tz: ZoneInfo | None = None  # cached FAZ system timezone
+        # Serialize forced reconnects so concurrent requests that all hit a
+        # dropped session perform a single re-login instead of racing to clear
+        # and rebuild ``_fmg`` underneath one another. The generation counter
+        # lets a waiter detect that a peer already reconnected while it blocked.
+        self._reconnect_lock = asyncio.Lock()
+        self._reconnect_generation = 0
 
         logger.info(f"Initialized FortiAnalyzer client for {self.host}")
 
@@ -125,6 +135,7 @@ class FortiAnalyzerClient:
                 raise AuthenticationError(f"FortiAnalyzer login failed: {error_msg}")
 
             self._connected = True
+            self._ever_connected = True
             logger.info("Successfully connected to FortiAnalyzer")
 
         except AuthenticationError:
@@ -276,17 +287,46 @@ class FortiAnalyzerClient:
 
         A stale/expired session (e.g. the appliance closed an idle session)
         surfaces as an auth error while the local client still believes it is
-        connected. These are recoverable by re-logging in once.
+        connected. A raw ``ConnectionError("Not connected. ...")`` from
+        :meth:`_ensure_connected` means the local client lost its session
+        mid-request (e.g. another path disconnected it). Both are recoverable by
+        re-logging in once. Invalid-tid errors are deliberately excluded (the
+        not-connected message carries no ``tid``) — those are owned by the log
+        tools, which re-issue the search.
         """
         if isinstance(exc, AuthenticationError):
+            return True
+        # A local not-connected error means the session dropped mid-request --
+        # but only revive it if we were genuinely connected before. A client that
+        # never connected must still surface "Not connected" rather than silently
+        # attempting a first login on an arbitrary API call.
+        if (
+            self._ever_connected
+            and isinstance(exc, ConnectionError)
+            and "not connected" in str(exc).lower()
+        ):
             return True
         return getattr(exc, "code", None) in self._RECONNECTABLE_ERROR_CODES
 
     async def _force_reconnect(self) -> None:
-        """Drop stale connection state and reconnect (re-login)."""
-        self._connected = False
-        self._fmg = None
-        await self.connect()
+        """Drop stale connection state and reconnect (re-login), serialized.
+
+        The lock ensures that when several concurrent requests all hit a dropped
+        session, only the first re-logs in; the others observe the bumped
+        generation and return without tearing the revived connection back down.
+        (A stale session still reports ``is_connected`` locally, so the
+        generation counter -- not ``is_connected`` -- is what detects a peer's
+        reconnect.)
+        """
+        observed = self._reconnect_generation
+        async with self._reconnect_lock:
+            if self._reconnect_generation != observed:
+                # A concurrent caller already reconnected while we waited.
+                return
+            self._connected = False
+            self._fmg = None
+            await self.connect()
+            self._reconnect_generation += 1
 
     async def _execute_resilient(
         self,

--- a/src/fortianalyzer_mcp/server.py
+++ b/src/fortianalyzer_mcp/server.py
@@ -3,7 +3,6 @@
 import hmac
 import logging
 from collections.abc import AsyncIterator
-from contextlib import asynccontextmanager
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
@@ -31,36 +30,6 @@ def get_faz_client() -> FortiAnalyzerClient | None:
     return faz_client
 
 
-@asynccontextmanager
-async def server_lifespan(server: FastMCP) -> AsyncIterator[dict]:
-    """Manage server startup and shutdown.
-
-    Args:
-        server: FastMCP server instance
-
-    Yields:
-        Dictionary with FortiAnalyzer client
-    """
-    global faz_client
-
-    logger.info("Starting FortiAnalyzer MCP server")
-
-    # Initialize and connect FortiAnalyzer client
-    faz_client = FortiAnalyzerClient.from_settings(settings)
-    await faz_client.connect()
-
-    logger.info("FortiAnalyzer MCP server started successfully")
-
-    try:
-        yield {"faz_client": faz_client}
-    finally:
-        # Cleanup on shutdown
-        logger.info("Shutting down FortiAnalyzer MCP server")
-        if faz_client:
-            await faz_client.disconnect()
-        logger.info("FortiAnalyzer MCP server shut down")
-
-
 # Configure transport security for reverse proxy deployments
 _transport_security = None
 if settings.MCP_ALLOWED_HOSTS:
@@ -68,11 +37,17 @@ if settings.MCP_ALLOWED_HOSTS:
         allowed_hosts=settings.MCP_ALLOWED_HOSTS,
     )
 
-# Create FastMCP server
+# Create FastMCP server.
+#
+# Lifecycle ownership of the process-global ``faz_client`` is deliberately held
+# by exactly one path: ``run_http``'s ``app_lifespan`` in HTTP mode and
+# ``run_stdio`` in stdio mode. We do NOT pass a FastMCP ``lifespan`` here: with
+# ``stateless_http=True`` that lifespan runs per request/session, so it would
+# connect and then *disconnect* the shared client around every call, dropping the
+# session out from under concurrent requests.
 mcp = FastMCP(
     "FortiAnalyzer API Server",
     stateless_http=True,  # Stateless for Docker deployment
-    lifespan=server_lifespan,
     transport_security=_transport_security,
 )
 

--- a/src/fortianalyzer_mcp/tools/log_tools.py
+++ b/src/fortianalyzer_mcp/tools/log_tools.py
@@ -6,13 +6,16 @@ Implements the two-step TID-based log search workflow.
 
 import asyncio
 import logging
+import math
 from typing import Any
 
 from fortianalyzer_mcp.server import get_faz_client, mcp
+from fortianalyzer_mcp.utils.log_clock import resolve_time_window
 from fortianalyzer_mcp.utils.responses import build_warnings, error_response, redact
 from fortianalyzer_mcp.utils.time_range import parse_time_range
 from fortianalyzer_mcp.utils.validation import (
     ValidationError,
+    build_device_filter,
     get_default_adom,
     sanitize_filter_value,
     validate_adom,
@@ -30,10 +33,34 @@ logger = logging.getLogger(__name__)
 
 # Default search timeout in seconds
 DEFAULT_SEARCH_TIMEOUT = 60
-# Poll interval for search progress
+# Hard upper bound on a single search's wall-clock budget. Because a search now
+# *holds* a concurrency slot for its whole budget (poll-before-fetch), a caller
+# passing a huge timeout must not be able to monopolize the slot pool.
+MAX_SEARCH_TIMEOUT = 300
+# Poll cadence: the first logsearch_count check is immediate, then the delay
+# backs off from _INITIAL_POLL_DELAY doubling up to POLL_INTERVAL. logsearch_count
+# is a cheap GET that does not reap the tid or consume a search slot, so an
+# immediate first check returns sub-second searches without a fixed 1s floor.
 POLL_INTERVAL = 1.0
+_INITIAL_POLL_DELAY = 0.25
 # Appliance maximum for the logsearch fetch limit (rejects > 1000).
 LOG_FETCH_LIMIT_MAX = 1000
+# Shared recovery budget for ALL re-issue causes within one page (invalid-tid
+# during count, invalid-tid race during fetch, and the 7.6.7 "premature 100%"
+# empty page). Contract: at most 1 initial start + MAX_SEARCH_REISSUES recovery
+# starts per page, and no new start/fetch past the deadline -- so a reaping
+# appliance can never spin logsearch_start and re-create slot exhaustion.
+MAX_SEARCH_REISSUES = 3
+# Bound concurrent in-flight appliance searches across every call site in this
+# process (query_logs, fetch_more_logs, policy fan-out, PCAP). Poll-before-fetch
+# holds a search slot until readiness, so the appliance-slot guard lives here at
+# the shared page runner rather than only in the policy fan-out.
+LOGSEARCH_CONCURRENCY_LIMIT = 4
+_LOGSEARCH_SEMAPHORE = asyncio.Semaphore(LOGSEARCH_CONCURRENCY_LIMIT)
+# Bounded best-effort cleanup-cancel budget (seconds). Kept short so a
+# non-delivered exit cannot meaningfully extend the concurrency-slot hold past
+# the search's own timeout budget.
+_CLEANUP_CANCEL_TIMEOUT = 2.0
 
 
 # In-process registry of log-search context, keyed by a pagination handle.
@@ -145,7 +172,101 @@ def _coerce_total(value: Any) -> int | None:
     return None
 
 
-async def _run_search_page(
+def _normalize_logs(data: Any) -> list[Any]:
+    """Normalize a logsearch ``data`` field to a list."""
+    if isinstance(data, list):
+        return data
+    return [data] if data else []
+
+
+def _clamp_timeout(timeout: int) -> int:
+    """Clamp a caller-supplied search timeout to ``[1, MAX_SEARCH_TIMEOUT]``.
+
+    Non-int/non-positive values fall back to the default. The upper bound keeps a
+    single search from holding a concurrency slot indefinitely.
+    """
+    if not isinstance(timeout, int) or isinstance(timeout, bool):
+        return DEFAULT_SEARCH_TIMEOUT
+    return max(1, min(timeout, MAX_SEARCH_TIMEOUT))
+
+
+def _coerce_num(value: Any) -> float | None:
+    """Coerce a FAZ count/progress field to a finite number for readiness checks.
+
+    Accepts ``int``/``float`` and numeric strings (``"100"``, ``"100.0"``);
+    rejects ``bool``, non-numeric, and non-finite (``inf``/``nan``) values.
+    Returns ``None`` when the field is absent or unusable. Used only for
+    readiness, never for the reported total.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        num = float(value)
+    elif isinstance(value, str):
+        try:
+            num = float(value.strip())
+        except ValueError:
+            return None
+    else:
+        return None
+    return num if math.isfinite(num) else None
+
+
+def _search_complete(count: dict[str, Any]) -> bool:
+    """Decide whether a logsearch scan has finished (safe to fetch).
+
+    Readiness only -- never the match total; unknown fields are ignored. Complete
+    iff ``progress-percent >= 100`` OR (``total-logs > 0`` and
+    ``scanned-logs >= total-logs``). ``matched-logs`` is deliberately NOT a
+    readiness signal (it proves matches exist, not that scanning is done), and
+    ``estimated-remain-sec`` is not used (live 7.6.7 does not return it). A
+    just-started ``0 >= 0`` scan is not complete; a real zero-result search
+    completes via ``progress-percent >= 100``.
+    """
+    progress = _coerce_num(count.get("progress-percent"))
+    if progress is not None and progress >= 100:
+        return True
+    total_logs = _coerce_num(count.get("total-logs"))
+    scanned = _coerce_num(count.get("scanned-logs"))
+    return (
+        total_logs is not None and total_logs > 0 and scanned is not None and scanned >= total_logs
+    )
+
+
+def _is_unsupported_count_endpoint(exc: Exception) -> bool:
+    """Detect an older build whose ``logsearch/count`` endpoint is absent.
+
+    Only matches a clear missing/unsupported-URL error -- never an invalid-tid,
+    timeout, or generic error (those must NOT trigger the direct-fetch fallback).
+    """
+    msg = str(exc).lower()
+    if "tid" in msg:  # invalid-tid is a different, non-fallback condition
+        return False
+    return any(
+        marker in msg
+        for marker in ("unknown url", "unsupported url", "invalid url", "endpoint not found")
+    )
+
+
+def _page_is_final(logs: list[Any], total: int | None, offset: int) -> bool:
+    """Decide whether a ``percentage>=100`` fetch is genuinely complete.
+
+    FortiAnalyzer 7.6.7 can report ``percentage:100`` with an *empty* ``data``
+    page even though ``total-count`` says matching rows exist at/after the
+    requested offset. That is not a real completion -- treating it as one returns
+    a misleading zero-result success. Such a page is reported as non-final so the
+    caller re-issues a fresh search (bounded). A page is final when it carries
+    rows, or when the total is unknown, or when the total does not claim rows
+    beyond this offset (a genuine empty result).
+    """
+    if logs:
+        return True
+    if total is not None and total > offset:
+        return False
+    return True
+
+
+async def _run_logsearch_page(
     client: Any,
     *,
     adom: str,
@@ -157,24 +278,74 @@ async def _run_search_page(
     limit: int,
     timeout: int,
 ) -> dict[str, Any]:
-    """Run one self-contained search page: start, fetch, return the page.
+    """Run one self-contained search page under the global concurrency guard.
 
-    Each page is its own search because a FAZ logsearch tid is single-use: the
-    first fetch delivers the slice plus ``total-count`` and the task is reaped.
-    The fetch blocks server-side until the search completes, so it usually
-    returns ``percentage>=100`` on the first try. If it returns incomplete, or
-    the task was reaped before our fetch, the search is re-issued from scratch.
-    Re-issues are bounded by the wall-clock ``timeout`` (not a fixed attempt
-    count), so the caller's timeout budget is honored; on expiry the page is
-    returned as ``timed_out`` rather than raising a raw appliance error.
-
-    Returns ``{"timed_out": bool, "tid": int, "logs": list, "total": int|None}``.
+    Acquires ``_LOGSEARCH_SEMAPHORE`` around the whole start -> poll -> fetch
+    lifecycle so total in-flight appliance searches across every call site stay
+    bounded, then delegates to :func:`_run_logsearch_page_unlocked`.
     """
+    async with _LOGSEARCH_SEMAPHORE:
+        return await _run_logsearch_page_unlocked(
+            client,
+            adom=adom,
+            logtype=logtype,
+            device_filter=device_filter,
+            time_range=time_range,
+            filter=filter,
+            offset=offset,
+            limit=limit,
+            timeout=timeout,
+        )
+
+
+# Backward-compatible alias for the previous fetch-first page-runner name.
+_run_search_page = _run_logsearch_page
+
+
+async def _run_logsearch_page_unlocked(
+    client: Any,
+    *,
+    adom: str,
+    logtype: str,
+    device_filter: list[dict[str, str]],
+    time_range: dict[str, str],
+    filter: str | None,
+    offset: int,
+    limit: int,
+    timeout: int,
+) -> dict[str, Any]:
+    """Run one search page: start -> poll ``logsearch_count`` -> fetch once.
+
+    A FAZ logsearch tid is single-use (the first ``fetch`` reaps it), and the
+    async search needs a moment to finish, so we must NOT fetch before it is
+    ready: doing so returns an incomplete page AND reaps the tid, forcing a
+    re-issue. Instead we poll ``logsearch_count`` (a cheap GET that does not reap)
+    until :func:`_search_complete`, then fetch exactly once. The reported
+    ``total`` comes from the fetch's ``total-count`` (authoritative for this
+    page); count fields are readiness only.
+
+    Recovery (invalid-tid during count, invalid-tid race during fetch, premature
+    100%) shares one budget of ``MAX_SEARCH_REISSUES`` and is also bounded by the
+    wall-clock ``deadline``; no new start or fetch is issued past the deadline,
+    and every ``count``/``fetch`` await is bounded by the remaining budget. On a
+    non-delivered exit the started tid is best-effort (shielded, bounded)
+    cancelled so a search is never leaked.
+
+    Returns ``{"timed_out": bool, "tid": int|None, "logs": list, "total": int|None}``.
+    """
+    await client.ensure_connected()
     loop = asyncio.get_event_loop()
+    timeout = _clamp_timeout(timeout)
+    limit = _clamp_limit(limit)
     deadline = loop.time() + timeout
-    tid: int | None = None
+    reissues_left = MAX_SEARCH_REISSUES
+    count_unsupported = bool(getattr(client, "_logsearch_count_unsupported", False))
 
     while True:
+        # No new start once the budget is spent.
+        if loop.time() >= deadline:
+            return {"timed_out": True, "tid": None, "logs": [], "total": None}
+
         start_result = await client.logsearch_start(
             adom=adom,
             logtype=logtype,
@@ -188,38 +359,100 @@ async def _run_search_page(
         if not tid:
             raise RuntimeError(f"Failed to start search: no TID returned. Response: {start_result}")
 
-        fetch_result: dict[str, Any] | None
+        delivered = False  # True once a fetch result is in hand (tid self-reaped)
         try:
-            fetch_result = await client.logsearch_fetch(
-                adom=adom, tid=tid, limit=limit, offset=offset
-            )
-        except Exception as exc:
-            # Task reaped before our fetch -> re-issue (bounded by deadline).
-            if not _is_invalid_tid_error(exc):
-                raise
-            fetch_result = None
+            reissue = False
+            # ---- Poll readiness via logsearch_count (does NOT reap the tid) ----
+            if not count_unsupported:
+                poll_delay = _INITIAL_POLL_DELAY
+                while True:
+                    remaining = deadline - loop.time()
+                    if remaining <= 0:
+                        return {"timed_out": True, "tid": tid, "logs": [], "total": None}
+                    try:
+                        count_result = await asyncio.wait_for(
+                            client.logsearch_count(adom, tid), timeout=remaining
+                        )
+                    except TimeoutError:
+                        return {"timed_out": True, "tid": tid, "logs": [], "total": None}
+                    except Exception as exc:
+                        if _is_invalid_tid_error(exc):
+                            reissue = True  # appliance reaped the tid -> recover
+                            break
+                        if _is_unsupported_count_endpoint(exc):
+                            # Older build with no count endpoint: cache and fall
+                            # through to a single direct fetch on this same tid.
+                            client._logsearch_count_unsupported = True
+                            count_unsupported = True
+                            break
+                        raise
+                    if _search_complete(count_result):
+                        break
+                    remaining = deadline - loop.time()
+                    if remaining <= 0:
+                        return {"timed_out": True, "tid": tid, "logs": [], "total": None}
+                    await asyncio.sleep(min(poll_delay, remaining))
+                    poll_delay = min(poll_delay * 2, POLL_INTERVAL)
 
-        if fetch_result is not None and fetch_result.get("percentage", 0) >= 100:
-            logs = fetch_result.get("data", [])
-            if not isinstance(logs, list):
-                logs = [logs] if logs else []
-            return {
-                "timed_out": False,
-                "tid": tid,
-                "logs": logs,
-                "total": _coerce_total(fetch_result.get("total-count")),
-            }
+            if reissue:
+                if reissues_left <= 0:
+                    return {"timed_out": True, "tid": tid, "logs": [], "total": None}
+                reissues_left -= 1
+                continue
 
-        # Incomplete (the single-use task is now reaped) or reaped before fetch:
-        # re-issue a fresh search until the timeout budget is exhausted.
-        remaining = deadline - loop.time()
-        if remaining <= 0:
+            # ---- Re-check the deadline: count may complete after it expired ----
+            if loop.time() >= deadline:
+                return {"timed_out": True, "tid": tid, "logs": [], "total": None}
+
+            # ---- Fetch once (reaps tid; returns the page + total-count) ----
+            remaining = deadline - loop.time()
             try:
-                await client.logsearch_cancel(adom, tid)
-            except Exception:
-                pass
-            return {"timed_out": True, "tid": tid, "logs": [], "total": None}
-        await asyncio.sleep(min(POLL_INTERVAL, remaining))
+                fetch_result = await asyncio.wait_for(
+                    client.logsearch_fetch(adom=adom, tid=tid, limit=limit, offset=offset),
+                    timeout=remaining,
+                )
+            except TimeoutError:
+                return {"timed_out": True, "tid": tid, "logs": [], "total": None}
+            except Exception as exc:
+                if _is_invalid_tid_error(exc):
+                    # Race: tid reaped between count-complete and our fetch.
+                    if reissues_left <= 0:
+                        return {"timed_out": True, "tid": tid, "logs": [], "total": None}
+                    reissues_left -= 1
+                    continue
+                raise
+            delivered = True
+
+            logs = _normalize_logs(fetch_result.get("data"))
+            total = _coerce_total(fetch_result.get("total-count"))
+            if _page_is_final(logs, total, offset):
+                return {"timed_out": False, "tid": tid, "logs": logs, "total": total}
+            # Premature 100%: empty page while total claims rows here -> recover.
+            if reissues_left <= 0:
+                return {"timed_out": False, "tid": tid, "logs": logs, "total": total}
+            reissues_left -= 1
+            continue
+        finally:
+            # Any exit without a delivered fetch (generic count/fetch error,
+            # cancellation, or deadline) may leave the started search running:
+            # best-effort cancel it. The cancel is shielded so it is dispatched
+            # even while this task is being cancelled, and bounded by a short
+            # budget so it cannot meaningfully extend the slot hold past the
+            # search budget. Non-cancel exceptions are swallowed; on a real
+            # CancelledError the shielded cancel is dispatched and the
+            # CancelledError then propagates (it is a BaseException, not caught
+            # by ``except Exception``) -- if even the dispatch cannot run, the
+            # appliance reaps the single-use task on its own.
+            if not delivered and tid:
+                try:
+                    await asyncio.shield(
+                        asyncio.wait_for(
+                            client.logsearch_cancel(adom, tid),
+                            timeout=_CLEANUP_CANCEL_TIMEOUT,
+                        )
+                    )
+                except Exception:  # noqa: BLE001 - cleanup must not mask the real exit
+                    pass
 
 
 def _get_client():
@@ -245,37 +478,10 @@ async def _parse_time_range(time_range: str) -> dict[str, str]:
     return parse_time_range(time_range, faz_tz=faz_tz)
 
 
-def _build_device_filter(device: str | None) -> list[dict[str, str]]:
-    """Build device filter for API.
-
-    Args:
-        device: Device serial number, name, or None for all FortiGate devices.
-                - Serial number format: FGxxxxxxxxxxxxxx (e.g., FG100FTK19001333)
-                - Device name format: device-name or device-name[vdom]
-                - None: Uses All_FortiGate to search all FortiGate devices
-
-    Returns:
-        Device filter list for API.
-
-    Note:
-        The FAZ API requires a device filter. Without one, searches return 0 results.
-        Use the device serial number for best results. Device names may not work
-        if they don't match exactly in the FAZ database.
-    """
-    if not device:
-        # Default to all FortiGate devices - empty list returns 0 results
-        return [{"devid": "All_FortiGate"}]
-
-    # Check if it looks like a serial number (starts with FG, FM, etc.)
-    if device.startswith(("FG", "FM", "FW", "FA", "FS", "FD", "FP", "FC")):
-        return [{"devid": device}]
-
-    # Check for special "All_*" device types
-    if device.startswith("All_"):
-        return [{"devid": device}]
-
-    # Otherwise, try as device name (devname)
-    return [{"devname": device}]
+# Device filter construction is shared across the log, traffic, and pcap tools;
+# the single implementation lives in utils.validation. Kept as a module alias so
+# existing call sites (and any callers importing this name) keep working.
+_build_device_filter = build_device_filter
 
 
 @mcp.tool()
@@ -372,13 +578,14 @@ async def query_logs(
         client = _get_client()
         await client.ensure_connected()
 
-        # Resolve the FAZ system timezone once: used both to align relative
-        # time ranges and to label the returned timestamps (FAZ interprets the
-        # naive bounds in its own local TZ).
-        faz_tz = await client.get_system_timezone()
-        tz_name = str(faz_tz) if faz_tz else "unknown"
+        # Resolve the query window. Relative presets are anchored on the detected
+        # LogView ingest clock (so a post-upgrade clock skew does not miss recent
+        # logs); custom ranges pass through verbatim. tz_name labels the returned
+        # timestamps (FAZ interprets the naive bounds in its own local TZ).
         try:
-            time_range_dict = parse_time_range(time_range, faz_tz=faz_tz)
+            window = await resolve_time_window(
+                client, adom, time_range, device, faz_tz_for_custom=True
+            )
         except ValueError as e:
             return error_response(
                 error="invalid_time_range",
@@ -387,6 +594,10 @@ async def query_logs(
                 adom=adom,
                 logtype=logtype,
             )
+        time_range_dict = window.time_range
+        tz_name = window.timezone
+        time_basis_source = window.time_basis_source
+        clock_skew_seconds = window.clock_skew_seconds
 
         # Build device filter
         device_filter = _build_device_filter(device)
@@ -394,13 +605,14 @@ async def query_logs(
         requested_limit = limit
         limit = _clamp_limit(limit)
         offset = max(0, offset)
+        timeout = _clamp_timeout(timeout)
 
         # Run this page as a self-contained search (FAZ tids are single-use).
         logger.info(
             f"Starting log search: adom={adom}, logtype={logtype}, "
             f"filter={redact(str(filter))[:200]}"
         )
-        page = await _run_search_page(
+        page = await _run_logsearch_page(
             client,
             adom=adom,
             logtype=logtype,
@@ -457,6 +669,8 @@ async def query_logs(
                 "device": device,
                 "time_range": time_range_dict,
                 "timezone": tz_name,
+                "time_basis_source": time_basis_source,
+                "clock_skew_seconds": clock_skew_seconds,
             },
         )
 
@@ -479,6 +693,8 @@ async def query_logs(
             "time_basis": (
                 f"time_range and log timestamps are interpreted in FAZ local time ({tz_name})"
             ),
+            "time_basis_source": time_basis_source,
+            "clock_skew_seconds": clock_skew_seconds,
             "offset": offset,
             "limit": limit,
             "warnings": warnings,
@@ -557,6 +773,7 @@ async def fetch_more_logs(
     tid: int = 0,
     limit: int = 100,
     offset: int = 0,
+    timeout: int = DEFAULT_SEARCH_TIMEOUT,
 ) -> dict[str, Any]:
     """Fetch another page of a previous query_logs search using its handle.
 
@@ -572,6 +789,8 @@ async def fetch_more_logs(
         tid: Reusable pagination handle from a previous query_logs call
         limit: Maximum logs to return (default: 100)
         offset: Offset for pagination (default: 0)
+        timeout: Search timeout in seconds (default: 60) -- raise it to page over
+            large windows (e.g. 30-day) that take longer than the default to scan
 
     Returns:
         dict: Additional log results with keys:
@@ -619,11 +838,12 @@ async def fetch_more_logs(
         requested_limit = limit
         limit = _clamp_limit(limit)
         offset = max(0, offset)
+        timeout = _clamp_timeout(timeout)
 
         client = _get_client()
         await client.ensure_connected()
 
-        page = await _run_search_page(
+        page = await _run_logsearch_page(
             client,
             adom=adom,
             logtype=context["logtype"],
@@ -632,13 +852,13 @@ async def fetch_more_logs(
             filter=context.get("filter"),
             offset=offset,
             limit=limit,
-            timeout=DEFAULT_SEARCH_TIMEOUT,
+            timeout=timeout,
         )
 
         if page["timed_out"]:
             return error_response(
                 error="search_timeout",
-                message=f"Search timed out after {DEFAULT_SEARCH_TIMEOUT} seconds",
+                message=f"Search timed out after {timeout} seconds",
                 operation="fetch_more_logs",
                 adom=adom,
                 logtype=context.get("logtype"),
@@ -652,6 +872,8 @@ async def fetch_more_logs(
         has_more = _compute_has_more(offset, count, limit, total)
         next_offset = offset + count if has_more else None
         timezone = context.get("timezone", "unknown")
+        time_basis_source = context.get("time_basis_source", "unknown")
+        clock_skew_seconds = context.get("clock_skew_seconds")
 
         warnings = build_warnings(
             requested_limit=requested_limit,
@@ -685,6 +907,8 @@ async def fetch_more_logs(
             "limit": limit,
             "timezone": timezone,
             "time_basis": f"log timestamps are interpreted in FAZ local time ({timezone})",
+            "time_basis_source": time_basis_source,
+            "clock_skew_seconds": clock_skew_seconds,
             "warnings": warnings,
         }
     except ValidationError as e:

--- a/src/fortianalyzer_mcp/tools/pcap_tools.py
+++ b/src/fortianalyzer_mcp/tools/pcap_tools.py
@@ -16,10 +16,12 @@ from datetime import datetime
 from typing import Any
 
 from fortianalyzer_mcp.server import get_faz_client, mcp
+from fortianalyzer_mcp.tools.log_tools import _clamp_timeout, _run_logsearch_page
 from fortianalyzer_mcp.utils.time_range import parse_time_range
 from fortianalyzer_mcp.utils.validation import (
     ValidationError,
     assert_within_directory,
+    build_device_filter,
     get_default_adom,
     sanitize_filter_value,
     validate_adom,
@@ -37,7 +39,6 @@ logger = logging.getLogger(__name__)
 
 # Constants
 DEFAULT_SEARCH_TIMEOUT = 60
-POLL_INTERVAL = 1.0
 MAX_PCAP_SIZE = 50 * 1024 * 1024  # 50MB per PCAP file
 
 
@@ -244,7 +245,7 @@ async def search_ips_logs(
                 - pcapurl: PCAP URL (if available, use for download)
                 - date, time: Event timestamp
             - filter_applied: Filter string used
-            - tid: Task ID for pagination
+            - tid: Reaped appliance task id (vestigial echo, not a pagination handle)
             - message: Error message if failed
 
     Example:
@@ -292,76 +293,49 @@ async def search_ips_logs(
         time_range_dict = await _parse_time_range(time_range)
 
         # Build device filter
-        device_filter = [{"devid": device}] if device else [{"devid": "All_FortiGate"}]
+        device_filter = build_device_filter(device)
 
         logger.info(f"Searching IPS logs: adom={adom}, filter={filter_str}")
 
-        # Start search - use logtype "attack" for IPS logs
-        start_result = await client.logsearch_start(
+        # Clamp here so the timed_out message reflects the effective budget.
+        timeout = _clamp_timeout(timeout)
+        # Run one search page (start -> poll logsearch_count -> fetch once).
+        # logtype "attack" for IPS logs.
+        page = await _run_logsearch_page(
+            client,
             adom=adom,
             logtype="attack",
-            device=device_filter,
+            device_filter=device_filter,
             time_range=time_range_dict,
             filter=filter_str,
-            limit=limit,
             offset=0,
+            limit=limit,
+            timeout=timeout,
         )
 
-        tid = start_result.get("tid")
-        if not tid:
+        if page["timed_out"]:
             return {
                 "status": "error",
-                "message": f"Failed to start search: no TID returned. Response: {start_result}",
+                "message": f"Search timed out after {timeout} seconds",
+                "tid": page["tid"],
             }
 
-        logger.info(f"IPS search started with TID: {tid}")
+        logs = page["logs"]
+        total = page["total"]
 
-        # Poll for results
-        start_time = asyncio.get_event_loop().time()
-        while True:
-            elapsed = asyncio.get_event_loop().time() - start_time
-            if elapsed > timeout:
-                try:
-                    await client.logsearch_cancel(adom, tid)
-                except Exception:
-                    pass
-                return {
-                    "status": "error",
-                    "message": f"Search timed out after {timeout} seconds",
-                    "tid": tid,
-                }
+        # Count how many have PCAP available
+        pcap_available = sum(1 for log in logs if log.get("pcapurl"))
 
-            # Fetch results
-            fetch_result = await client.logsearch_fetch(
-                adom=adom,
-                tid=tid,
-                limit=limit,
-                offset=0,
-            )
-
-            percentage = fetch_result.get("percentage", 0)
-            logger.debug(f"Search progress: {percentage}%")
-
-            if percentage >= 100:
-                logs = fetch_result.get("data", [])
-                if not isinstance(logs, list):
-                    logs = [logs] if logs else []
-
-                # Count how many have PCAP available
-                pcap_available = sum(1 for log in logs if log.get("pcapurl"))
-
-                return {
-                    "status": "success",
-                    "count": len(logs),
-                    "pcap_available_count": pcap_available,
-                    "total": fetch_result.get("total-lines", len(logs)),
-                    "logs": logs,
-                    "filter_applied": filter_str or "none",
-                    "tid": tid,
-                    "time_range": time_range_dict,
-                }
-
-            await asyncio.sleep(POLL_INTERVAL)
+        return {
+            "status": "success",
+            "count": len(logs),
+            "pcap_available_count": pcap_available,
+            "total": total if total is not None else len(logs),
+            "logs": logs,
+            "filter_applied": filter_str or "none",
+            "tid": page["tid"],
+            "time_range": time_range_dict,
+        }
 
     except ValidationError as e:
         return {"status": "error", "message": f"Validation error: {e}"}
@@ -423,53 +397,34 @@ async def get_pcap_by_session(
         # Build filter for specific session ID
         filter_str = f"sessionid=={session_id}"
         time_range_dict = await _parse_time_range(time_range)
-        device_filter = [{"devid": device}] if device else [{"devid": "All_FortiGate"}]
+        device_filter = build_device_filter(device)
 
         logger.info(f"Searching for session {session_id} in ADOM {adom}")
 
-        # Start search
-        start_result = await client.logsearch_start(
+        # Clamp here so the timed_out message reflects the effective budget.
+        timeout = _clamp_timeout(timeout)
+        # Run one search page (start -> poll logsearch_count -> fetch once).
+        page = await _run_logsearch_page(
+            client,
             adom=adom,
             logtype="attack",
-            device=device_filter,
+            device_filter=device_filter,
             time_range=time_range_dict,
             filter=filter_str,
-            limit=10,
             offset=0,
+            limit=10,
+            timeout=timeout,
         )
 
-        tid = start_result.get("tid")
-        if not tid:
+        if page["timed_out"]:
             return {
                 "status": "error",
                 "session_id": session_id,
-                "message": "Failed to start search: no TID returned",
+                "message": f"Search timed out after {timeout} seconds",
             }
 
-        # Poll for results
-        start_time = asyncio.get_event_loop().time()
-        while True:
-            elapsed = asyncio.get_event_loop().time() - start_time
-            if elapsed > timeout:
-                try:
-                    await client.logsearch_cancel(adom, tid)
-                except Exception:
-                    pass
-                return {
-                    "status": "error",
-                    "session_id": session_id,
-                    "message": f"Search timed out after {timeout} seconds",
-                }
-
-            fetch_result = await client.logsearch_fetch(adom=adom, tid=tid, limit=10, offset=0)
-
-            if fetch_result.get("percentage", 0) >= 100:
-                break
-
-            await asyncio.sleep(POLL_INTERVAL)
-
         # Check results
-        logs = fetch_result.get("data", [])
+        logs = page["logs"]
         if not logs:
             return {
                 "status": "error",
@@ -808,51 +763,30 @@ async def search_and_download_pcaps(
         )
 
         time_range_dict = await _parse_time_range(time_range)
-        device_filter = [{"devid": device}] if device else [{"devid": "All_FortiGate"}]
+        device_filter = build_device_filter(device)
 
         logger.info(f"Searching IPS logs for PCAP download: {filter_str}")
 
-        # Start search
-        start_result = await client.logsearch_start(
+        # Clamp here so the timed_out message reflects the effective budget.
+        timeout = _clamp_timeout(timeout)
+        # Run one search page (start -> poll logsearch_count -> fetch once).
+        # Get extra in case some fail.
+        page = await _run_logsearch_page(
+            client,
             adom=adom,
             logtype="attack",
-            device=device_filter,
+            device_filter=device_filter,
             time_range=time_range_dict,
             filter=filter_str,
-            limit=max_downloads * 2,  # Get extra in case some fail
             offset=0,
+            limit=max_downloads * 2,
+            timeout=timeout,
         )
 
-        tid = start_result.get("tid")
-        if not tid:
-            return {
-                "status": "error",
-                "message": "Failed to start search: no TID returned",
-            }
+        if page["timed_out"]:
+            return {"status": "error", "message": f"Search timed out after {timeout}s"}
 
-        # Poll for results
-        start_time = asyncio.get_event_loop().time()
-        while True:
-            elapsed = asyncio.get_event_loop().time() - start_time
-            if elapsed > timeout:
-                try:
-                    await client.logsearch_cancel(adom, tid)
-                except Exception:
-                    pass
-                return {"status": "error", "message": f"Search timed out after {timeout}s"}
-
-            fetch_result = await client.logsearch_fetch(
-                adom=adom, tid=tid, limit=max_downloads * 2, offset=0
-            )
-
-            if fetch_result.get("percentage", 0) >= 100:
-                break
-
-            await asyncio.sleep(POLL_INTERVAL)
-
-        logs = fetch_result.get("data", [])
-        if not isinstance(logs, list):
-            logs = [logs] if logs else []
+        logs = page["logs"]
 
         # Filter to only those with pcapurl
         logs_with_pcap = [log for log in logs if log.get("pcapurl")]

--- a/src/fortianalyzer_mcp/tools/report_tools.py
+++ b/src/fortianalyzer_mcp/tools/report_tools.py
@@ -826,6 +826,10 @@ async def save_report(
                 output_file = output_path / f"{stem}_{counter}{suffix}"
                 counter += 1
 
+            # Defense-in-depth: keep the resolved path inside the validated
+            # output directory (mirrors the ZIP-extract path above).
+            output_file = assert_within_directory(output_file, output_path)
+
             with open(output_file, "wb") as f:
                 f.write(zip_data)
 

--- a/src/fortianalyzer_mcp/tools/traffic_tools.py
+++ b/src/fortianalyzer_mcp/tools/traffic_tools.py
@@ -19,7 +19,10 @@ from datetime import datetime, timedelta
 from typing import Any, cast
 
 from fortianalyzer_mcp.server import get_faz_client, mcp
-from fortianalyzer_mcp.tools.log_tools import _is_invalid_tid_error
+from fortianalyzer_mcp.tools.log_tools import (
+    _run_logsearch_page,
+)
+from fortianalyzer_mcp.utils.log_clock import resolve_time_window
 from fortianalyzer_mcp.utils.responses import error_response
 from fortianalyzer_mcp.utils.time_range import (
     parse_time_range,
@@ -27,6 +30,7 @@ from fortianalyzer_mcp.utils.time_range import (
 )
 from fortianalyzer_mcp.utils.validation import (
     ValidationError,
+    build_device_filter,
     get_default_adom,
     validate_adom,
 )
@@ -38,7 +42,6 @@ _QUERY_SEMAPHORE = asyncio.Semaphore(5)
 
 # Default and max search parameters
 DEFAULT_SEARCH_TIMEOUT = 120
-POLL_INTERVAL = 1.0
 LOG_FETCH_LIMIT = 1000
 ANALYSIS_QUERY_BUDGET = 24
 MAX_SLICES_PER_POLICY = 4
@@ -174,24 +177,6 @@ async def _parse_time_range(time_range: str) -> dict[str, str]:
     return parse_time_range(time_range, faz_tz=faz_tz)
 
 
-async def _resolve_window(time_range: str) -> tuple[dict[str, str], str]:
-    """Resolve the query window once and report the FAZ timezone name.
-
-    Custom absolute ranges (``"start|end"``) skip the TZ client lookup -- the
-    caller already supplied explicit timestamps -- and report timezone
-    ``"unknown"``. Relative presets pull the FAZ system timezone so the naive
-    bounds land in FAZ-local time. Resolving here once keeps the reported
-    ``time_range`` and the bounded slices on a single window (no seconds-level
-    drift from re-parsing relative ranges).
-    """
-    if "|" in time_range:
-        return parse_time_range(time_range), "unknown"
-    client = _get_client()
-    faz_tz = await client.get_system_timezone()
-    tz_name = str(faz_tz) if faz_tz else "unknown"
-    return parse_time_range(time_range, faz_tz=faz_tz), tz_name
-
-
 # parse_time_range_bounds is re-exported from utils.time_range above.
 _parse_time_range_bounds = parse_time_range_bounds
 
@@ -234,26 +219,8 @@ def _build_bounded_time_slices(
     return slices
 
 
-def _build_device_filter(device: str | None) -> list[dict[str, str]]:
-    """Build device filter for API. Mirrors log_tools._build_device_filter."""
-    if not device:
-        return [{"devid": "All_FortiGate"}]
-    if device.startswith(("FG", "FM", "FW", "FA", "FS", "FD", "FP", "FC")):
-        return [{"devid": device}]
-    if device.startswith("All_"):
-        return [{"devid": device}]
-    return [{"devname": device}]
-
-
-def _coerce_log_total(value: Any) -> int | None:
-    """Coerce a FAZ logsearch total-count value to int."""
-    if isinstance(value, bool):
-        return None
-    if isinstance(value, int):
-        return value
-    if isinstance(value, str) and value.isdigit():
-        return int(value)
-    return None
+# Shared device-filter construction (see utils.validation.build_device_filter).
+_build_device_filter = build_device_filter
 
 
 async def _query_policy_log_slice(
@@ -267,64 +234,49 @@ async def _query_policy_log_slice(
 ) -> dict[str, Any]:
     """Query traffic logs and total-count for a single policy/time slice.
 
-    Each attempt is its own search because a FortiAnalyzer logsearch ``tid`` is
-    single-use: the first fetch delivers the slice plus ``total-count`` and the
-    task is reaped. The fetch usually returns ``percentage>=100`` on the first
-    try; if it comes back incomplete, or the task was already reaped before our
-    fetch (an invalid-tid error), the search is re-issued from scratch rather
-    than re-fetching the reaped tid. Re-issues are bounded by the wall-clock
-    ``timeout``; on expiry an empty result with an unknown total is returned.
+    Delegates to the shared :func:`_run_logsearch_page` runner, which polls
+    ``logsearch_count`` (a cheap GET that does not reap the single-use ``tid``)
+    until the scan is complete and then fetches exactly once -- so we never fetch
+    a still-running search. The runner owns connection revival, limit/timeout
+    clamping, the global concurrency guard, and all bounded re-issue/cancel
+    recovery (invalid-tid races and 7.6.7 premature-100% empty pages). On a
+    timed-out page an empty result with an unknown total is returned.
     """
     client = _get_client()
     filter_str = _build_policy_filter(policy_id, action)
-    loop = asyncio.get_event_loop()
-    deadline = loop.time() + timeout
 
-    while True:
-        start_result = await client.logsearch_start(
+    try:
+        page = await _run_logsearch_page(
+            client,
             adom=adom,
             logtype="traffic",
-            device=device_filter,
+            device_filter=device_filter,
             time_range=time_range,
             filter=filter_str,
+            offset=0,
             limit=limit,
+            timeout=timeout,
         )
-        tid = start_result.get("tid")
-        if not tid:
-            logger.warning(f"No TID returned for policy {policy_id}: {start_result}")
-            return {"logs": [], "total_hits": None, "total_hits_is_known": False}
+    except RuntimeError as exc:
+        # An abnormal start with no TID would abort the whole policy fan-out;
+        # for one slice, degrade to an empty/unknown result (as the prior
+        # fetch-first slice did) so other slices/policies still report.
+        if "no TID returned" not in str(exc):
+            raise
+        logger.warning(f"No TID returned for policy {policy_id}: {exc}")
+        return {"logs": [], "total_hits": None, "total_hits_is_known": False}
 
-        fetch_result: dict[str, Any] | None
-        try:
-            fetch_result = await client.logsearch_fetch(adom=adom, tid=tid, limit=limit, offset=0)
-        except Exception as exc:
-            # Task reaped before our fetch -> re-issue (bounded by deadline).
-            if not _is_invalid_tid_error(exc):
-                raise
-            fetch_result = None
+    if page["timed_out"]:
+        logger.warning(f"Search timed out for policy {policy_id}")
+        return {"logs": [], "total_hits": None, "total_hits_is_known": False}
 
-        if fetch_result is not None and fetch_result.get("percentage", 0) >= 100:
-            logs = fetch_result.get("data", [])
-            if not isinstance(logs, list):
-                logs = [logs] if logs else []
-            total_hits = _coerce_log_total(fetch_result.get("total-count"))
-            return {
-                "logs": [log for log in logs if isinstance(log, dict)],
-                "total_hits": total_hits,
-                "total_hits_is_known": total_hits is not None,
-            }
-
-        # Incomplete (the single-use task is now reaped) or reaped before fetch:
-        # re-issue a fresh search until the timeout budget is exhausted.
-        remaining = deadline - loop.time()
-        if remaining <= 0:
-            try:
-                await client.logsearch_cancel(adom, tid)
-            except (OSError, RuntimeError):
-                pass
-            logger.warning(f"Search timed out for policy {policy_id}")
-            return {"logs": [], "total_hits": None, "total_hits_is_known": False}
-        await asyncio.sleep(min(POLL_INTERVAL, remaining))
+    logs = [log for log in page["logs"] if isinstance(log, dict)]
+    total_hits = page["total"]
+    return {
+        "logs": logs,
+        "total_hits": total_hits,
+        "total_hits_is_known": total_hits is not None,
+    }
 
 
 async def _query_policy_total_count(
@@ -669,7 +621,9 @@ async def _run_bounded_policy_analysis(
         await _get_client().ensure_connected()
 
         try:
-            window, tz_name = await _resolve_window(time_range)
+            resolved = await resolve_time_window(
+                _get_client(), adom_value, time_range, device, faz_tz_for_custom=False
+            )
         except ValueError as e:
             return error_response(
                 error="invalid_time_range",
@@ -677,6 +631,8 @@ async def _run_bounded_policy_analysis(
                 operation=operation,
                 adom=adom_value,
             )
+        window = resolved.time_range
+        tz_name = resolved.timezone
 
         start = time.monotonic()
         query_tasks = [
@@ -722,6 +678,8 @@ async def _run_bounded_policy_analysis(
             "adom": adom_value,
             "time_range": window,
             "timezone": tz_name,
+            "time_basis_source": resolved.time_basis_source,
+            "clock_skew_seconds": resolved.clock_skew_seconds,
             "results": per_policy,
             "query_time_seconds": round(elapsed, 2),
         }

--- a/src/fortianalyzer_mcp/utils/log_clock.py
+++ b/src/fortianalyzer_mcp/utils/log_clock.py
@@ -1,0 +1,238 @@
+"""LogView clock detection for relative time-range alignment.
+
+FortiAnalyzer interprets the naive ``time-range`` timestamps a logview search
+sends against its own LogView ingest clock. That clock can drift from the FAZ
+*system* timezone "now" — notably after a version upgrade — so a relative window
+like ``"1-hour"`` anchored on system-now can land *ahead* of the newest ingested
+log and silently return zero rows even though traffic exists.
+
+This module anchors relative windows on the appliance's latest log time instead,
+with documented, safe fallbacks:
+
+1. ``logfiles_state`` — newest log end time reported for the log files.
+2. ``logstats``       — newest per-device ``last_log_time``.
+3. ``faz_tz``         — FAZ system timezone "now" (the previous behavior).
+4. ``naive``          — local ``datetime.now()`` when even the FAZ TZ is unknown.
+
+Detection is strictly best-effort: any error or unparseable response degrades to
+the next fallback, so a clock probe can never break a query. Custom absolute
+ranges skip detection entirely (the caller already supplied explicit bounds).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from fortianalyzer_mcp.utils.time_range import parse_time_range
+from fortianalyzer_mcp.utils.validation import build_device_filter
+
+logger = logging.getLogger(__name__)
+
+_TIMESTAMP_FMT = "%Y-%m-%d %H:%M:%S"
+
+# Keys whose values may carry a log end/last time in a logview response. Matched
+# case-insensitively after stripping ``-``/``_`` so e.g. ``last-log-time``,
+# ``last_log_time`` and ``lastLogTime`` all match. Kept focused to avoid latching
+# onto unrelated timestamps (e.g. a search start time).
+_ANCHOR_TIME_KEYS = frozenset(
+    {"lastlogtime", "etime", "endtime", "end", "ftime", "maxtime", "latesttime"}
+)
+
+# Plausibility guard for a detected anchor relative to FAZ "now": reject values
+# that are absurdly stale or in the future (a wrong field or a ms-vs-s unit
+# mismatch), falling back rather than trusting a bogus clock.
+_MAX_ANCHOR_FUTURE = timedelta(days=2)
+_MAX_ANCHOR_PAST = timedelta(days=400)
+
+
+@dataclass(frozen=True)
+class AnchorResult:
+    """Outcome of LogView clock detection.
+
+    ``anchor`` is always set (it falls back to FAZ-now / local-now) so callers
+    can pass it straight to :func:`parse_time_range`.
+    """
+
+    anchor: datetime  # naive, FAZ-local "now" to end relative windows on
+    source: str  # logfiles_state | logstats | faz_tz | naive
+    timezone: str  # FAZ system tz name, or "unknown"
+    clock_skew_seconds: int | None  # anchor - faz_now, when measurable
+
+
+@dataclass(frozen=True)
+class TimeWindow:
+    """A resolved query window plus the time-basis audit metadata."""
+
+    time_range: dict[str, str]
+    timezone: str
+    time_basis_source: str
+    clock_skew_seconds: int | None
+
+
+def _device_to_devid(device: str | None) -> str | None:
+    """Return a serial-style devid for logfiles_state, or None for broad scope."""
+    if not device:
+        return None
+    if device.startswith("All_"):
+        return None
+    filt = build_device_filter(device)
+    return filt[0].get("devid")
+
+
+def _coerce_anchor_dt(value: Any, faz_tz: ZoneInfo | None) -> datetime | None:
+    """Coerce one field value to a naive FAZ-local datetime, or None.
+
+    Accepts epoch seconds (int or digit string, converted through ``faz_tz``) and
+    naive ``"YYYY-MM-DD HH:MM:SS"`` strings (already FAZ-local). Anything else,
+    or a non-positive epoch, yields ``None``.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int) or (isinstance(value, str) and value.strip().isdigit()):
+        epoch = int(value)
+        if epoch <= 0:
+            return None
+        try:
+            aware = datetime.fromtimestamp(epoch, UTC)
+        except (OverflowError, OSError, ValueError):
+            return None
+        if faz_tz is not None:
+            aware = aware.astimezone(faz_tz)
+        return aware.replace(tzinfo=None)
+    if isinstance(value, str):
+        try:
+            return datetime.strptime(value.strip(), _TIMESTAMP_FMT)
+        except ValueError:
+            return None
+    return None
+
+
+def _extract_latest_anchor(obj: Any, faz_tz: ZoneInfo | None) -> datetime | None:
+    """Walk a logview response and return the newest anchorable timestamp."""
+    best: datetime | None = None
+    stack: list[Any] = [obj]
+    seen = 0
+    while stack and seen < 10000:
+        seen += 1
+        cur = stack.pop()
+        if isinstance(cur, dict):
+            for key, val in cur.items():
+                if isinstance(val, dict | list):
+                    stack.append(val)
+                    continue
+                normalized = str(key).replace("-", "").replace("_", "").lower()
+                if normalized in _ANCHOR_TIME_KEYS:
+                    candidate = _coerce_anchor_dt(val, faz_tz)
+                    if candidate is not None and (best is None or candidate > best):
+                        best = candidate
+        elif isinstance(cur, list):
+            stack.extend(cur)
+    return best
+
+
+def _is_plausible(anchor: datetime, faz_now: datetime) -> bool:
+    """Reject anchors that are implausibly stale or in the future."""
+    return (faz_now - _MAX_ANCHOR_PAST) <= anchor <= (faz_now + _MAX_ANCHOR_FUTURE)
+
+
+async def detect_logview_anchor(
+    client: Any,
+    adom: str,
+    device: str | None = None,
+) -> AnchorResult:
+    """Detect the LogView ingest clock to anchor relative windows on.
+
+    Best-effort: each probe is wrapped so a missing method, network error, or
+    unparseable shape degrades to the next fallback. Always returns a usable
+    anchor (FAZ-now, or local-now if even the FAZ timezone is unknown).
+    """
+    faz_tz: ZoneInfo | None = None
+    try:
+        faz_tz = await client.get_system_timezone()
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug(f"FAZ timezone lookup failed during clock detection: {exc}")
+    tz_name = str(faz_tz) if faz_tz else "unknown"
+
+    if faz_tz is not None:
+        faz_now = datetime.now(UTC).astimezone(faz_tz).replace(tzinfo=None)
+    else:
+        faz_now = datetime.now()
+
+    probes: tuple[tuple[str, Any], ...] = (
+        (
+            "logfiles_state",
+            lambda: client.get_logfiles_state(adom=adom, devid=_device_to_devid(device)),
+        ),
+        (
+            "logstats",
+            lambda: client.get_logstats(adom=adom, device=build_device_filter(device)),
+        ),
+    )
+    for source, call in probes:
+        try:
+            resp = await call()
+        except Exception as exc:
+            logger.debug(f"Clock probe {source} unavailable: {exc}")
+            continue
+        anchor = _extract_latest_anchor(resp, faz_tz)
+        if anchor is None:
+            continue
+        if not _is_plausible(anchor, faz_now):
+            logger.debug(f"Clock probe {source} anchor {anchor} implausible; skipping")
+            continue
+        skew = int((anchor - faz_now).total_seconds())
+        logger.info(f"LogView clock anchored via {source}: {anchor} (skew {skew}s)")
+        return AnchorResult(anchor=anchor, source=source, timezone=tz_name, clock_skew_seconds=skew)
+
+    if faz_tz is not None:
+        return AnchorResult(anchor=faz_now, source="faz_tz", timezone=tz_name, clock_skew_seconds=0)
+    return AnchorResult(anchor=faz_now, source="naive", timezone=tz_name, clock_skew_seconds=None)
+
+
+async def resolve_time_window(
+    client: Any,
+    adom: str,
+    time_range: str,
+    device: str | None = None,
+    *,
+    faz_tz_for_custom: bool = True,
+) -> TimeWindow:
+    """Resolve a caller time-range string into a window plus time-basis metadata.
+
+    Relative presets are anchored on the detected LogView clock. Custom absolute
+    ranges (``"start|end"``) are passed through verbatim; their reported timezone
+    is the FAZ system tz when ``faz_tz_for_custom`` (query_logs convention) or
+    ``"unknown"`` otherwise (policy-analysis convention).
+
+    Raises:
+        ValueError: If ``time_range`` is neither a known preset nor a valid
+            custom range (propagated from :func:`parse_time_range`).
+    """
+    if "|" in time_range:
+        window = parse_time_range(time_range)
+        tz_name = "unknown"
+        if faz_tz_for_custom:
+            try:
+                faz_tz = await client.get_system_timezone()
+            except Exception:  # pragma: no cover - defensive
+                faz_tz = None
+            tz_name = str(faz_tz) if faz_tz else "unknown"
+        return TimeWindow(
+            time_range=window,
+            timezone=tz_name,
+            time_basis_source="custom",
+            clock_skew_seconds=None,
+        )
+
+    anchor = await detect_logview_anchor(client, adom, device)
+    window = parse_time_range(time_range, anchor=anchor.anchor)
+    return TimeWindow(
+        time_range=window,
+        timezone=anchor.timezone,
+        time_basis_source=anchor.source,
+        clock_skew_seconds=anchor.clock_skew_seconds,
+    )

--- a/src/fortianalyzer_mcp/utils/time_range.py
+++ b/src/fortianalyzer_mcp/utils/time_range.py
@@ -47,6 +47,7 @@ SUPPORTED_TIME_RANGES: tuple[str, ...] = tuple(_RANGE_MAP.keys())
 def parse_time_range(
     time_range: str,
     faz_tz: ZoneInfo | None = None,
+    anchor: datetime | None = None,
 ) -> dict[str, str]:
     """Translate a caller-facing time-range string to FAZ's dict format.
 
@@ -60,6 +61,12 @@ def parse_time_range(
             :func:`datetime.now` (caller-local) — preserves legacy
             behavior, but only correct if the caller and FAZ happen
             to share a timezone.
+        anchor: Explicit naive FAZ-local "now" to end relative windows on.
+            When provided it takes precedence over ``faz_tz``/``datetime.now``
+            — used to align relative ranges to the appliance's LogView ingest
+            clock (see :mod:`fortianalyzer_mcp.utils.log_clock`) so a post-
+            upgrade clock skew does not silently miss recent logs. Ignored for
+            custom ``"start|end"`` ranges (those carry explicit timestamps).
 
     Returns:
         ``{"start": "...", "end": "..."}`` ready to send as
@@ -98,7 +105,11 @@ def parse_time_range(
             f"'YYYY-MM-DD HH:MM:SS|YYYY-MM-DD HH:MM:SS'."
         )
 
-    if faz_tz is not None:
+    if anchor is not None:
+        # Explicit FAZ-local anchor (e.g. latest LogView ingest time). Strip any
+        # tzinfo so the bytes-on-wire stay naive FAZ-local like every other path.
+        now = anchor.replace(tzinfo=None)
+    elif faz_tz is not None:
         now = datetime.now(UTC).astimezone(faz_tz).replace(tzinfo=None)
     else:
         now = datetime.now()

--- a/src/fortianalyzer_mcp/utils/validation.py
+++ b/src/fortianalyzer_mcp/utils/validation.py
@@ -306,6 +306,42 @@ def validate_device_serial(serial: str) -> str:
     return serial
 
 
+# Serial-number prefixes used to decide whether a device string is a serial
+# (devid) or a device name (devname). Kept here as the single source of truth so
+# every tool builds the FAZ device filter identically.
+_DEVICE_SERIAL_PREFIXES = ("FG", "FM", "FW", "FA", "FS", "FD", "FP", "FC")
+
+
+def build_device_filter(device: str | None) -> list[dict[str, str]]:
+    """Build the FortiAnalyzer ``device`` filter array for a logview search.
+
+    This is the single source of truth shared by the log, traffic, and pcap
+    tools (each previously carried its own copy). The FAZ logview API requires a
+    device filter; without one, searches return zero results.
+
+    Args:
+        device: Device serial number (e.g. ``"FG100FTK19001333"``), device name
+            (optionally ``"name[vdom]"``), an ``"All_*"`` device group, or
+            ``None`` to default to all FortiGate devices.
+
+    Returns:
+        A device-filter list, one of ``[{"devid": ...}]`` or
+        ``[{"devname": ...}]``, ready to pass as the ``device`` parameter.
+
+    Note:
+        Serial-looking values (``FG``/``FM``/... prefixes) and ``All_*`` groups
+        are sent as ``devid``; anything else is treated as a ``devname``.
+    """
+    if not device:
+        # FAZ rejects an empty device filter with 0 results; default to all FGTs.
+        return [{"devid": "All_FortiGate"}]
+    if device.startswith(_DEVICE_SERIAL_PREFIXES):
+        return [{"devid": device}]
+    if device.startswith("All_"):
+        return [{"devid": device}]
+    return [{"devname": device}]
+
+
 def validate_log_type(logtype: str) -> str:
     """Validate log type.
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -439,6 +439,95 @@ class TestSessionReconnect:
         assert len(calls) == 2
 
 
+class TestNotConnectedReconnect:
+    """A dropped session surfaces a local 'Not connected' error mid-request.
+
+    It should be revived once -- but only if the client was ever connected; a
+    never-connected client must still surface the raw error rather than silently
+    attempt a first login on an arbitrary API call.
+    """
+
+    async def test_local_not_connected_reconnects_once_then_succeeds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        client = _bare_client()
+        client._connected = True
+        client._fmg = MagicMock()
+        client._ever_connected = True  # was connected before; session then dropped
+        reconnects: list[int] = []
+
+        async def fake_connect() -> None:
+            reconnects.append(1)
+            client._connected = True
+
+        monkeypatch.setattr(client, "connect", fake_connect)
+
+        calls: list[int] = []
+
+        async def factory() -> str:
+            calls.append(1)
+            if len(calls) == 1:
+                raise ConnectionError("Not connected. Call connect() first.")
+            return "ok"
+
+        result = await client._execute_resilient(factory, sleep=_no_sleep)
+
+        assert result == "ok"
+        assert len(calls) == 2
+        assert len(reconnects) == 1
+
+    async def test_never_connected_does_not_reconnect(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        client = _bare_client()  # _ever_connected is False
+        reconnects: list[int] = []
+
+        async def fake_connect() -> None:
+            reconnects.append(1)
+
+        monkeypatch.setattr(client, "connect", fake_connect)
+
+        calls: list[int] = []
+
+        async def factory() -> str:
+            calls.append(1)
+            raise ConnectionError("Not connected. Call connect() first.")
+
+        with pytest.raises(ConnectionError, match="Not connected"):
+            await client._execute_resilient(factory, sleep=_no_sleep)
+
+        assert len(calls) == 1
+        assert reconnects == []
+
+
+class TestConcurrentReconnect:
+    """The reconnect lock + generation counter serialize concurrent reconnects."""
+
+    async def test_concurrent_force_reconnect_logs_in_once(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import asyncio
+
+        client = _bare_client()
+        client._connected = True
+        client._fmg = MagicMock()
+        connects: list[int] = []
+
+        async def fake_connect() -> None:
+            # Yield so the second waiter blocks on the lock before we finish.
+            await asyncio.sleep(0)
+            connects.append(1)
+            client._connected = True
+
+        monkeypatch.setattr(client, "connect", fake_connect)
+
+        await asyncio.gather(client._force_reconnect(), client._force_reconnect())
+
+        # Only the first caller re-logs in; the second sees the bumped generation.
+        assert len(connects) == 1
+        assert client._reconnect_generation == 1
+
+
 class TestSystemTimezoneDetection:
     """Tests for FAZ system timezone field detection."""
 

--- a/tests/test_device_filter.py
+++ b/tests/test_device_filter.py
@@ -1,0 +1,40 @@
+"""Tests for the shared device-filter builder (utils.validation)."""
+
+from __future__ import annotations
+
+import fortianalyzer_mcp.tools.log_tools as log_tools
+import fortianalyzer_mcp.tools.traffic_tools as traffic_tools
+from fortianalyzer_mcp.utils.validation import build_device_filter
+
+
+class TestBuildDeviceFilter:
+    def test_none_defaults_to_all_fortigate(self) -> None:
+        assert build_device_filter(None) == [{"devid": "All_FortiGate"}]
+
+    def test_empty_string_defaults_to_all_fortigate(self) -> None:
+        assert build_device_filter("") == [{"devid": "All_FortiGate"}]
+
+    def test_serial_prefix_uses_devid(self) -> None:
+        assert build_device_filter("FG100FTK19001333") == [{"devid": "FG100FTK19001333"}]
+
+    def test_fortimanager_prefix_uses_devid(self) -> None:
+        assert build_device_filter("FMG-VM0000000001") == [{"devid": "FMG-VM0000000001"}]
+
+    def test_all_group_uses_devid(self) -> None:
+        assert build_device_filter("All_FortiMail") == [{"devid": "All_FortiMail"}]
+
+    def test_plain_name_uses_devname(self) -> None:
+        assert build_device_filter("myfw01") == [{"devname": "myfw01"}]
+
+    def test_name_with_vdom_uses_devname(self) -> None:
+        assert build_device_filter("myfw01[root]") == [{"devname": "myfw01[root]"}]
+
+
+class TestModuleAliasesShareImplementation:
+    """The per-tool aliases must resolve to the single shared implementation."""
+
+    def test_log_tools_alias_is_shared(self) -> None:
+        assert log_tools._build_device_filter is build_device_filter
+
+    def test_traffic_tools_alias_is_shared(self) -> None:
+        assert traffic_tools._build_device_filter is build_device_filter

--- a/tests/test_log_clock.py
+++ b/tests/test_log_clock.py
@@ -1,0 +1,144 @@
+"""Tests for LogView clock detection and time-window resolution."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from fortianalyzer_mcp.utils.log_clock import (
+    detect_logview_anchor,
+    resolve_time_window,
+)
+
+_UTC = ZoneInfo("UTC")
+
+
+def _recent_epoch(seconds_ago: int = 300) -> int:
+    return int(datetime.now(UTC).timestamp()) - seconds_ago
+
+
+class FakeClock:
+    """Configurable fake exposing only the clock-probe surface."""
+
+    def __init__(
+        self,
+        *,
+        tz: ZoneInfo | None = _UTC,
+        logfiles_state: object = None,
+        logstats: object = None,
+        logfiles_state_error: Exception | None = None,
+        logstats_error: Exception | None = None,
+    ) -> None:
+        self.tz = tz
+        self._logfiles_state = logfiles_state
+        self._logstats = logstats
+        self._logfiles_state_error = logfiles_state_error
+        self._logstats_error = logstats_error
+
+    async def get_system_timezone(self) -> ZoneInfo | None:
+        return self.tz
+
+    async def get_logfiles_state(self, **_kw: object) -> object:
+        if self._logfiles_state_error is not None:
+            raise self._logfiles_state_error
+        return self._logfiles_state
+
+    async def get_logstats(self, **_kw: object) -> object:
+        if self._logstats_error is not None:
+            raise self._logstats_error
+        return self._logstats
+
+
+class TestDetectLogviewAnchor:
+    async def test_prefers_logfiles_state(self) -> None:
+        epoch = _recent_epoch(300)
+        fake = FakeClock(
+            logfiles_state={"data": [{"etime": epoch}]},
+            logstats={"data": [{"last_log_time": _recent_epoch(60)}]},
+        )
+        result = await detect_logview_anchor(fake, "root")
+        assert result.source == "logfiles_state"
+        expected = datetime.fromtimestamp(epoch, UTC).replace(tzinfo=None)
+        assert result.anchor == expected
+        assert result.timezone == "UTC"
+        assert result.clock_skew_seconds is not None
+
+    async def test_falls_back_to_logstats(self) -> None:
+        epoch = _recent_epoch(120)
+        fake = FakeClock(
+            logfiles_state={"data": []},  # nothing parseable
+            logstats={"data": [{"last_log_time": epoch}]},
+        )
+        result = await detect_logview_anchor(fake, "root")
+        assert result.source == "logstats"
+        assert result.anchor == datetime.fromtimestamp(epoch, UTC).replace(tzinfo=None)
+
+    async def test_falls_back_to_faz_tz_when_probes_fail(self) -> None:
+        fake = FakeClock(
+            logfiles_state_error=RuntimeError("boom"),
+            logstats_error=AttributeError("missing"),
+        )
+        result = await detect_logview_anchor(fake, "root")
+        assert result.source == "faz_tz"
+        assert result.clock_skew_seconds == 0
+
+    async def test_falls_back_to_naive_when_no_tz(self) -> None:
+        fake = FakeClock(tz=None, logfiles_state={"data": []}, logstats={"data": []})
+        result = await detect_logview_anchor(fake, "root")
+        assert result.source == "naive"
+        assert result.timezone == "unknown"
+        assert result.clock_skew_seconds is None
+
+    async def test_implausible_future_anchor_is_skipped(self) -> None:
+        future = int((datetime.now(UTC) + timedelta(days=30)).timestamp())
+        recent = _recent_epoch(120)
+        fake = FakeClock(
+            logfiles_state={"data": [{"etime": future}]},  # absurd, must be skipped
+            logstats={"data": [{"last_log_time": recent}]},
+        )
+        result = await detect_logview_anchor(fake, "root")
+        assert result.source == "logstats"
+
+    async def test_picks_latest_among_devices(self) -> None:
+        older = _recent_epoch(600)
+        newer = _recent_epoch(60)
+        fake = FakeClock(
+            logfiles_state={"data": [{"etime": older}, {"etime": newer}]},
+        )
+        result = await detect_logview_anchor(fake, "root")
+        assert result.anchor == datetime.fromtimestamp(newer, UTC).replace(tzinfo=None)
+
+
+class TestResolveTimeWindow:
+    async def test_custom_range_reports_faz_tz_when_requested(self) -> None:
+        fake = FakeClock(tz=ZoneInfo("Europe/Zurich"))
+        win = await resolve_time_window(
+            fake, "root", "2024-01-01 00:00:00|2024-01-02 00:00:00", faz_tz_for_custom=True
+        )
+        assert win.time_range == {"start": "2024-01-01 00:00:00", "end": "2024-01-02 00:00:00"}
+        assert win.timezone == "Europe/Zurich"
+        assert win.time_basis_source == "custom"
+        assert win.clock_skew_seconds is None
+
+    async def test_custom_range_unknown_tz_when_not_requested(self) -> None:
+        fake = FakeClock(tz=ZoneInfo("Europe/Zurich"))
+        win = await resolve_time_window(
+            fake, "root", "2024-01-01 00:00:00|2024-01-02 00:00:00", faz_tz_for_custom=False
+        )
+        assert win.timezone == "unknown"
+        assert win.time_basis_source == "custom"
+
+    async def test_relative_range_anchored_on_logview_clock(self) -> None:
+        epoch = _recent_epoch(300)
+        fake = FakeClock(logfiles_state={"data": [{"etime": epoch}]})
+        win = await resolve_time_window(fake, "root", "1-hour")
+        anchor = datetime.fromtimestamp(epoch, UTC).replace(tzinfo=None)
+        assert win.time_range["end"] == anchor.strftime("%Y-%m-%d %H:%M:%S")
+        assert win.time_basis_source == "logfiles_state"
+
+    async def test_invalid_preset_raises(self) -> None:
+        fake = FakeClock()
+        with pytest.raises(ValueError, match="Unknown time_range"):
+            await resolve_time_window(fake, "root", "3-hour")

--- a/tests/test_log_pagination.py
+++ b/tests/test_log_pagination.py
@@ -2,12 +2,16 @@
 
 These exercise query_logs / fetch_more_logs / cancel_log_search through a
 stateful in-memory FortiAnalyzer fake that models the *real* appliance
-contract discovered on the lab FAZ (7.6.x):
+contract discovered on the lab FAZ (7.6.x), under the poll-before-fetch rule:
 
 - ``logsearch_start(offset, limit)`` issues a task id (tid).
-- The first ``logsearch_fetch`` returns ``data[offset:offset+limit]`` plus a
-  ``total-count``; the task is then reaped, so a *second* fetch on the same tid
-  raises "Invalid tid".
+- ``logsearch_count(adom, tid)`` is a cheap GET that does NOT reap the tid; its
+  ``progress-percent`` climbs 0 -> 100 over a few polls.
+- ``logsearch_fetch`` may only be called once the scan is complete: a fetch
+  while the search is still running RAISES "Invalid tid" (the runner must poll
+  ``logsearch_count`` first). The first valid fetch returns
+  ``data[offset:offset+limit]`` plus ``total-count`` and reaps the task, so a
+  *second* fetch on the same tid raises "Invalid tid".
 - Therefore pagination is done by running a *fresh* search per page (the tid is
   not reusable). For a fixed time window the row order is stable across
   searches, so offset/limit paging is consistent.
@@ -25,6 +29,10 @@ from fortianalyzer_mcp.utils.errors import ResourceNotFoundError
 
 CUSTOM_RANGE = "2024-01-01 00:00:00|2024-01-02 00:00:00"
 
+# Number of logsearch_count polls a search reports as in-progress before it
+# reads 100% (so a normal search makes >=1 count call before the single fetch).
+_POLLS_TO_COMPLETE = 2
+
 
 def _rows(n: int) -> list[dict[str, object]]:
     """Build n distinct, stably ordered traffic log rows."""
@@ -34,13 +42,25 @@ def _rows(n: int) -> list[dict[str, object]]:
     ]
 
 
-class FakeFaz:
-    """Faithful fake of the FortiAnalyzer log-search surface.
+@pytest.fixture(autouse=True)
+def _fast_polls(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Drop the poll cadence to zero so the start->poll->fetch loop is fast."""
+    monkeypatch.setattr(log_tools, "_INITIAL_POLL_DELAY", 0)
+    monkeypatch.setattr(log_tools, "POLL_INTERVAL", 0)
 
-    Models single-use tids: the first fetch delivers an offset slice plus
-    ``total-count`` and reaps the task; any later fetch on that tid raises
-    "Invalid tid". ``complete_on_attempt`` simulates a task that reaps
-    mid-poll before completing, forcing the tool to re-issue the search.
+
+class FakeFaz:
+    """Faithful fake of the FortiAnalyzer log-search surface (poll-before-fetch).
+
+    Each ``logsearch_start`` issues a fresh single-use tid. ``logsearch_count``
+    climbs ``progress-percent`` 0 -> 100 over ``_POLLS_TO_COMPLETE`` polls and
+    never reaps. ``logsearch_fetch`` raises "Invalid tid" if called before the
+    scan is complete *or* a second time on a reaped tid; a valid fetch delivers
+    the offset slice plus ``total-count`` and reaps the task.
+
+    ``complete_on_attempt`` models an appliance that reaps a search mid-poll: a
+    search whose start-attempt number is below it has its ``logsearch_count``
+    raise an invalid-tid error, forcing the runner to re-issue from scratch.
     """
 
     def __init__(
@@ -51,17 +71,21 @@ class FakeFaz:
         connected: bool = True,
         complete_on_attempt: int = 1,
         omit_total: bool = False,
+        stall: bool = False,
     ) -> None:
         self.dataset = dataset
         self.tz = tz
         self.connected = connected
         self.complete_on_attempt = complete_on_attempt
         self.omit_total = omit_total
+        self.stall = stall
         self.reconnects = 0
         self._tasks: dict[int, dict[str, object]] = {}
         self._next_tid = 1000
         self._start_count = 0
         self.start_calls: list[dict[str, object]] = []
+        self.count_calls: list[int] = []
+        self.fetch_calls: list[int] = []
         self.cancelled: list[int] = []
 
     @property
@@ -93,8 +117,29 @@ class FakeFaz:
         )
         tid = self._next_tid
         self._next_tid += 1
-        self._tasks[tid] = {"adom": adom, "alive": True, "attempt": self._start_count}
+        self._tasks[tid] = {"adom": adom, "alive": True, "attempt": self._start_count, "polls": 0}
         return {"tid": tid}
+
+    async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
+        """Report scan progress without reaping the tid (a cheap GET)."""
+        self.count_calls.append(tid)
+        task = self._tasks.get(tid)
+        if task is None or task["adom"] != adom:
+            raise ResourceNotFoundError(f"Invalid tid {tid} for count.", code=-1)
+        # A search reaped before completing (older attempt) surfaces as an
+        # invalid-tid during count, forcing a fresh re-issue.
+        if int(task["attempt"]) < self.complete_on_attempt:
+            task["alive"] = False
+            raise ResourceNotFoundError(f"Invalid tid {tid} reaped mid-poll.", code=-1)
+        task["polls"] = int(task["polls"]) + 1
+        done = (not self.stall) and int(task["polls"]) >= _POLLS_TO_COMPLETE
+        total = len(self.dataset)
+        return {
+            "progress-percent": 100 if done else 50,
+            "matched-logs": min(total, int(task["polls"])),
+            "scanned-logs": total if done else 0,
+            "total-logs": total,
+        }
 
     async def logsearch_fetch(
         self,
@@ -103,14 +148,17 @@ class FakeFaz:
         limit: int = 50,
         offset: int = 0,
     ) -> dict[str, object]:
+        self.fetch_calls.append(tid)
         task = self._tasks.get(tid)
+        # Poll-before-fetch: fetching a still-running or reaped tid is invalid.
         if task is None or not task["alive"] or task["adom"] != adom:
             raise ResourceNotFoundError(f"Invalid tid {tid} for fetching result.", code=-1)
+        if int(task["polls"]) < _POLLS_TO_COMPLETE:
+            raise ResourceNotFoundError(f"Invalid tid {tid}: search not complete.", code=-1)
         task["alive"] = False  # single-use: task is reaped after one fetch
         page = self.dataset[offset : offset + limit]
-        complete = int(task["attempt"]) >= self.complete_on_attempt
         result: dict[str, object] = {
-            "percentage": 100 if complete else 50,
+            "percentage": 100,
             "return-lines": len(page),
             "data": page,
             "tid": tid,
@@ -221,6 +269,30 @@ class TestFetchMoreLogs:
         assert len(fake.start_calls) == 2
         assert fake.start_calls[1]["offset"] == 5
 
+    async def test_timeout_is_forwarded_to_page_runner(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """fetch_more_logs(timeout=180) forwards 180 into _run_logsearch_page."""
+        fake = FakeFaz(_rows(25))
+        _install(monkeypatch, fake)
+
+        first = await log_tools.query_logs(adom="root", time_range=CUSTOM_RANGE, limit=10)
+        tid = first["tid"]
+
+        seen: dict[str, object] = {}
+        real_runner = log_tools._run_logsearch_page
+
+        async def recording_runner(client: object, **kwargs: object) -> dict[str, object]:
+            seen.update(kwargs)
+            return await real_runner(client, **kwargs)
+
+        monkeypatch.setattr(log_tools, "_run_logsearch_page", recording_runner)
+
+        more = await log_tools.fetch_more_logs(tid=tid, offset=10, limit=10, timeout=180)
+
+        assert more["status"] == "success"
+        assert seen["timeout"] == 180
+
     async def test_reuses_query_context_from_handle(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """fetch_more_logs reuses the ADOM and filter recorded for the handle."""
         fake = FakeFaz(_rows(25))
@@ -269,8 +341,8 @@ class TestReissueOnReap:
     async def test_query_logs_reissues_when_task_reaped_midpoll(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """If a task reaps mid-poll, the search is re-issued and still completes."""
-        monkeypatch.setattr(log_tools, "POLL_INTERVAL", 0)
+        """If a task reaps mid-poll (invalid-tid during count), the search is
+        re-issued exactly once and still completes."""
         fake = FakeFaz(_rows(8), complete_on_attempt=2)
         _install(monkeypatch, fake)
 
@@ -283,22 +355,25 @@ class TestReissueOnReap:
     async def test_never_completing_search_times_out_cleanly(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """A search that never reaches 100% within timeout returns a clean
-        search_timeout error (honoring the timeout budget), not a raw 'Invalid
+        """A search whose scan never reaches 100% within the timeout returns a
+        clean search_timeout error (honoring the deadline), not a raw 'Invalid
         tid' string."""
-        monkeypatch.setattr(log_tools, "POLL_INTERVAL", 0.01)
-        fake = FakeFaz(_rows(8), complete_on_attempt=10_000)
+        monkeypatch.setattr(log_tools, "POLL_INTERVAL", 0.005)
+        monkeypatch.setattr(log_tools, "_INITIAL_POLL_DELAY", 0.005)
+        fake = FakeFaz(_rows(8), stall=True)  # count never reads 100%
         _install(monkeypatch, fake)
 
         result = await log_tools.query_logs(
-            adom="root", time_range=CUSTOM_RANGE, limit=10, timeout=0.05
+            adom="root", time_range=CUSTOM_RANGE, limit=10, timeout=1
         )
 
         assert result["status"] == "error"
         assert result["error"] == "search_timeout"
         assert "invalid tid" not in result.get("message", "").lower()
-        # The timeout (not a small fixed attempt cap) bounds the work.
-        assert len(fake.start_calls) >= 2
+        # A stalled scan is bounded by the deadline, not a fetch loop: the single
+        # search is polled but never fetched.
+        assert len(fake.start_calls) == 1
+        assert fake.fetch_calls == []
 
 
 class TestUnknownTotal:
@@ -333,6 +408,109 @@ class TestCancelLogSearch:
 
         assert result["status"] == "success"
         assert tid not in log_tools._SEARCH_REGISTRY
+
+
+class PrematureFaz:
+    """Models the 7.6.7 premature-100 case under poll-before-fetch.
+
+    ``logsearch_count`` always reports the scan complete (``progress-percent``
+    100), but the fetch returns an *empty* ``data`` page while ``total-count``
+    reports rows exist, until ``data_on_attempt`` searches have started -- at
+    which point the page carries real data. Each search is a fresh single-use
+    tid; the runner must therefore re-issue on a premature-empty-100 page.
+    """
+
+    def __init__(self, dataset: list[dict[str, object]], *, data_on_attempt: int) -> None:
+        self.dataset = dataset
+        self.data_on_attempt = data_on_attempt
+        self.connected = True
+        self.reconnects = 0
+        self._next_tid = 2000
+        self._attempt = 0
+        self._tasks: dict[int, int] = {}
+        self.count_calls: list[int] = []
+        self.cancelled: list[int] = []
+
+    @property
+    def is_connected(self) -> bool:
+        return self.connected
+
+    async def ensure_connected(self) -> None:
+        if not self.connected:
+            self.reconnects += 1
+            self.connected = True
+
+    async def get_system_timezone(self):  # noqa: ANN201 - test fake
+        return None
+
+    async def logsearch_start(self, **_kw: object) -> dict[str, object]:
+        self._attempt += 1
+        tid = self._next_tid
+        self._next_tid += 1
+        self._tasks[tid] = self._attempt
+        return {"tid": tid}
+
+    async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
+        """Always report the scan complete (the premature-100 case)."""
+        self.count_calls.append(tid)
+        total = len(self.dataset)
+        return {
+            "progress-percent": 100,
+            "matched-logs": total,
+            "scanned-logs": total,
+            "total-logs": total,
+        }
+
+    async def logsearch_fetch(
+        self, adom: str, tid: int, limit: int = 50, offset: int = 0
+    ) -> dict[str, object]:
+        attempt = self._tasks[tid]
+        data = self.dataset[offset : offset + limit] if attempt >= self.data_on_attempt else []
+        return {
+            "percentage": 100,
+            "data": data,
+            "total-count": len(self.dataset),
+            "tid": tid,
+            "status": {"code": 0, "message": "succeeded"},
+        }
+
+    async def logsearch_cancel(self, adom: str, tid: int) -> dict[str, object]:
+        self.cancelled.append(tid)
+        return {"status": {"code": 0, "message": "ok"}}
+
+
+class TestPremature100:
+    async def test_empty_100pct_with_total_reissues_then_returns_rows(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """percentage:100 + empty data + total-count>0 must re-issue, not report 0."""
+        fake = PrematureFaz(_rows(5), data_on_attempt=2)
+        _install(monkeypatch, fake)
+
+        result = await log_tools.query_logs(adom="root", time_range=CUSTOM_RANGE, limit=10)
+
+        assert result["status"] == "success"
+        assert result["count"] == 5
+        assert result["total"] == 5
+        assert fake._attempt == 2  # first empty completion re-issued once
+
+    async def test_persistent_empty_100pct_is_bounded_and_warns(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A deterministically empty 100% page stops after a bounded re-issue
+        count (it must not loop to the timeout) and surfaces the inconsistency."""
+        fake = PrematureFaz(_rows(5), data_on_attempt=10_000)  # never yields data
+        _install(monkeypatch, fake)
+
+        result = await log_tools.query_logs(adom="root", time_range=CUSTOM_RANGE, limit=10)
+
+        assert result["status"] == "success"
+        assert result["count"] == 0
+        assert result["has_more"] is False
+        assert any("beyond this offset" in w for w in result["warnings"])
+        # Bounded by the shared recovery budget: one initial search +
+        # MAX_SEARCH_REISSUES re-issues.
+        assert fake._attempt == 1 + log_tools.MAX_SEARCH_REISSUES
 
 
 class TestReconnectOnce:

--- a/tests/test_logsearch_runner.py
+++ b/tests/test_logsearch_runner.py
@@ -1,0 +1,646 @@
+"""Regression tests for the shared poll-before-fetch page runner.
+
+These pin the hard contract of ``log_tools._run_logsearch_page`` /
+``_run_logsearch_page_unlocked`` discovered against the lab FAZ (7.6.7): the
+runner starts a search, polls ``logsearch_count`` (a cheap GET that does NOT
+reap the single-use ``tid``) until :func:`log_tools._search_complete`, and then
+fetches exactly once. It never loops ``logsearch_start`` on a normally
+completing search (the root cause of search-slot exhaustion), bounds all
+recovery by a shared ``MAX_SEARCH_REISSUES`` budget and the wall-clock deadline,
+caps concurrent in-flight searches, best-effort cancels a leaked tid, and falls
+back to a direct fetch only on a proven unsupported ``logsearch_count`` endpoint.
+"""
+
+import asyncio
+
+import pytest
+
+import fortianalyzer_mcp.tools.log_tools as log_tools
+from fortianalyzer_mcp.tools.log_tools import _run_logsearch_page, _search_complete
+from fortianalyzer_mcp.utils.errors import APIError, ResourceNotFoundError
+
+_DEVICE = [{"devid": "All_FortiGate"}]
+_WINDOW = {"start": "2024-01-01 00:00:00", "end": "2024-01-01 01:00:00"}
+
+
+@pytest.fixture(autouse=True)
+def _fast_polls(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Drop the poll cadence to zero so start->poll->fetch is fast."""
+    monkeypatch.setattr(log_tools, "_INITIAL_POLL_DELAY", 0)
+    monkeypatch.setattr(log_tools, "POLL_INTERVAL", 0)
+
+
+def _rows(n: int) -> list[dict[str, object]]:
+    return [{"id": i, "srcip": f"10.0.0.{i}"} for i in range(n)]
+
+
+async def _run(client: object, *, limit: int = 100, offset: int = 0, timeout: int = 60) -> dict:
+    return await _run_logsearch_page(
+        client,
+        adom="root",
+        logtype="traffic",
+        device_filter=_DEVICE,
+        time_range=_WINDOW,
+        filter=None,
+        offset=offset,
+        limit=limit,
+        timeout=timeout,
+    )
+
+
+class _BaseFake:
+    """Records every call; subclasses override count/fetch behavior."""
+
+    def __init__(self) -> None:
+        self.ensure_connected_calls = 0
+        self.starts: list[int] = []
+        self.counts: list[int] = []
+        self.fetches: list[int] = []
+        self.cancels: list[int] = []
+        self._next_tid = 700
+
+    async def ensure_connected(self) -> None:
+        self.ensure_connected_calls += 1
+
+    async def logsearch_start(self, **_kw: object) -> dict[str, int]:
+        self._next_tid += 1
+        self.starts.append(self._next_tid)
+        return {"tid": self._next_tid}
+
+    async def logsearch_cancel(self, adom: str, tid: int) -> dict[str, object]:
+        self.cancels.append(tid)
+        return {}
+
+
+# =============================================================================
+# Readiness predicate
+# =============================================================================
+
+
+class TestSearchCompletePredicate:
+    def test_matched_logs_alone_is_not_complete(self) -> None:
+        """matched-logs>0 with progress<100 and scanned<total is NOT complete:
+        matches existing proves rows match, not that scanning finished."""
+        count = {
+            "matched-logs": 42,
+            "progress-percent": 60,
+            "scanned-logs": 300,
+            "total-logs": 1000,
+        }
+        assert _search_complete(count) is False
+
+    def test_progress_100_is_complete(self) -> None:
+        assert _search_complete({"progress-percent": 100}) is True
+
+    def test_scanned_meets_total_is_complete(self) -> None:
+        assert _search_complete({"total-logs": 50, "scanned-logs": 50}) is True
+
+    def test_zero_scan_is_not_complete(self) -> None:
+        """A just-started 0>=0 scan must not read as complete."""
+        assert _search_complete({"total-logs": 0, "scanned-logs": 0}) is False
+
+
+# =============================================================================
+# No-slot-exhaustion: exactly one start / >=1 count / exactly one fetch
+# =============================================================================
+
+
+class _NormalFake(_BaseFake):
+    """A normally-completing async search: count climbs, then one valid fetch."""
+
+    def __init__(self, dataset: list[dict[str, object]], *, polls_to_complete: int = 2) -> None:
+        super().__init__()
+        self.dataset = dataset
+        self.polls_to_complete = polls_to_complete
+        self._polls: dict[int, int] = {}
+
+    async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
+        self.counts.append(tid)
+        self._polls[tid] = self._polls.get(tid, 0) + 1
+        done = self._polls[tid] >= self.polls_to_complete
+        total = len(self.dataset)
+        return {
+            "progress-percent": 100 if done else 30,
+            "scanned-logs": total if done else 0,
+            "total-logs": total,
+        }
+
+    async def logsearch_fetch(self, *, adom: str, tid: int, limit: int, offset: int) -> dict:
+        self.fetches.append(tid)
+        if self._polls.get(tid, 0) < self.polls_to_complete:
+            raise ResourceNotFoundError(f"Invalid tid {tid}: not complete.", code=-1)
+        return {
+            "percentage": 100,
+            "data": self.dataset[offset : offset + limit],
+            "total-count": len(self.dataset),
+        }
+
+
+class TestNoSlotExhaustion:
+    async def test_one_start_one_fetch_many_counts(self) -> None:
+        fake = _NormalFake(_rows(5), polls_to_complete=3)
+        page = await _run(fake, limit=10)
+
+        assert page["timed_out"] is False
+        assert page["logs"] == _rows(5)
+        assert page["total"] == 5
+        # The contract: exactly one start, >=1 count, exactly one fetch.
+        assert len(fake.starts) == 1
+        assert len(fake.counts) >= 1
+        assert len(fake.fetches) == 1
+        assert fake.cancels == []  # delivered fetch -> no leak cleanup
+
+    async def test_zero_result_clean_success(self) -> None:
+        """progress 100 / scanned 0 / total 0 + fetch total-count 0 -> clean
+        empty success with one start, one count, one fetch, no reissue."""
+
+        class _ZeroFake(_BaseFake):
+            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
+                self.counts.append(tid)
+                return {"progress-percent": 100, "scanned-logs": 0, "total-logs": 0}
+
+            async def logsearch_fetch(
+                self, *, adom: str, tid: int, limit: int, offset: int
+            ) -> dict:
+                self.fetches.append(tid)
+                return {"percentage": 100, "data": [], "total-count": 0}
+
+        fake = _ZeroFake()
+        page = await _run(fake, limit=10)
+
+        assert page["timed_out"] is False
+        assert page["logs"] == []
+        assert page["total"] == 0
+        assert len(fake.starts) == 1
+        assert len(fake.counts) == 1
+        assert len(fake.fetches) == 1
+
+
+# =============================================================================
+# Shared recovery-budget cap
+# =============================================================================
+
+
+class TestSharedBudgetCap:
+    async def test_always_invalid_count_caps_starts_then_times_out(self) -> None:
+        """A fake that always invalidates count exhausts the shared budget:
+        1 + MAX_SEARCH_REISSUES starts, then timed_out."""
+
+        class _AlwaysInvalidCount(_BaseFake):
+            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
+                self.counts.append(tid)
+                raise ResourceNotFoundError(f"Invalid tid {tid} reaped.", code=-1)
+
+            async def logsearch_fetch(
+                self, *, adom: str, tid: int, limit: int, offset: int
+            ) -> dict:
+                raise AssertionError("must not fetch when count never completes")
+
+        fake = _AlwaysInvalidCount()
+        page = await _run(fake, limit=10)
+
+        assert page["timed_out"] is True
+        assert len(fake.starts) == 1 + log_tools.MAX_SEARCH_REISSUES
+
+    async def test_always_premature_100_caps_starts(self) -> None:
+        """A fake that always returns premature-empty-100 hits the same cap."""
+
+        class _AlwaysPremature(_BaseFake):
+            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
+                self.counts.append(tid)
+                return {"progress-percent": 100, "scanned-logs": 9, "total-logs": 9}
+
+            async def logsearch_fetch(
+                self, *, adom: str, tid: int, limit: int, offset: int
+            ) -> dict:
+                self.fetches.append(tid)
+                # 100% complete but empty while total claims rows here.
+                return {"percentage": 100, "data": [], "total-count": 9}
+
+        fake = _AlwaysPremature()
+        page = await _run(fake, limit=10)
+
+        # The last premature page is accepted (not a timeout) once the budget is
+        # spent, but the start count is bounded by 1 + MAX_SEARCH_REISSUES.
+        assert page["logs"] == []
+        assert len(fake.starts) == 1 + log_tools.MAX_SEARCH_REISSUES
+
+
+# =============================================================================
+# Deadline behavior
+# =============================================================================
+
+
+class TestDeadline:
+    async def test_count_completes_after_deadline_does_not_fetch(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The post-count deadline re-check guard: ``logsearch_count`` reports
+        COMPLETE promptly (progress 100), but by the time the runner re-checks
+        the deadline it has already passed -- so the runner returns timed_out
+        WITHOUT fetching and cancels the live tid. We drive the loop clock past
+        the deadline once the count returns complete (rather than burning real
+        time in the count, which would exit via the count wait_for TimeoutError
+        branch instead and leave the post-count guard uncovered)."""
+
+        loop = asyncio.get_event_loop()
+        real_time = loop.time
+        ticks = {"count_done": False}
+        # Start measuring from a fixed base so the bump is deterministic.
+        base = real_time()
+
+        def _fake_time() -> float:
+            # Once the count has reported complete, jump the clock far past the
+            # deadline so the post-count re-check (loop.time() >= deadline) fires.
+            if ticks["count_done"]:
+                return base + 10_000.0
+            return real_time()
+
+        monkeypatch.setattr(loop, "time", _fake_time)
+
+        fetch_calls = {"n": 0}
+
+        class _CompleteThenDeadlinePassed(_BaseFake):
+            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
+                self.counts.append(tid)
+                # Return COMPLETE promptly; only after we hand back a complete
+                # count do we advance the clock past the deadline.
+                result = {"progress-percent": 100, "scanned-logs": 5, "total-logs": 5}
+                ticks["count_done"] = True
+                return result
+
+            async def logsearch_fetch(
+                self, *, adom: str, tid: int, limit: int, offset: int
+            ) -> dict:
+                fetch_calls["n"] += 1
+                raise AssertionError("must not fetch after the deadline")
+
+        fake = _CompleteThenDeadlinePassed()
+        page = await _run(fake, limit=10, timeout=1)
+
+        assert page["timed_out"] is True
+        assert fetch_calls["n"] == 0  # post-count guard skipped the fetch
+        assert fake.fetches == []
+        assert fake.cancels == [fake.starts[0]]  # live tid best-effort cancelled
+
+    async def test_no_new_start_once_deadline_passed_on_reissue(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The loop-top 'no new start past deadline' guard: an invalid-tid count
+        forces a reissue, but the deadline has elapsed before the second loop
+        iteration begins, so the runner hits ``loop.time() >= deadline`` at the
+        top of the loop and returns timed_out WITHOUT issuing a second
+        logsearch_start. This proves a reaping appliance cannot spin
+        logsearch_start past the budget (the runaway that caused slot
+        exhaustion). We advance the loop clock past the deadline as soon as the
+        first count signals the reissue."""
+
+        loop = asyncio.get_event_loop()
+        real_time = loop.time
+        ticks = {"reissue_signalled": False}
+        base = real_time()
+
+        def _fake_time() -> float:
+            if ticks["reissue_signalled"]:
+                return base + 10_000.0
+            return real_time()
+
+        monkeypatch.setattr(loop, "time", _fake_time)
+
+        class _InvalidThenDeadlinePassed(_BaseFake):
+            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
+                self.counts.append(tid)
+                # Trip the reissue path, then jump the clock past the deadline so
+                # the loop-top guard short-circuits the second start.
+                ticks["reissue_signalled"] = True
+                raise ResourceNotFoundError(f"Invalid tid {tid} reaped.", code=-1)
+
+            async def logsearch_fetch(
+                self, *, adom: str, tid: int, limit: int, offset: int
+            ) -> dict:
+                raise AssertionError("must not fetch when count never completes")
+
+        fake = _InvalidThenDeadlinePassed()
+        page = await _run(fake, limit=10, timeout=1)
+
+        assert page["timed_out"] is True
+        # Bounded: exactly one start; the loop-top guard prevented a second.
+        assert len(fake.starts) == 1
+        assert fake.fetches == []
+        # The first (still-live) tid is best-effort cancelled on the way out.
+        assert fake.cancels == [fake.starts[0]]
+
+    async def test_incomplete_count_then_deadline_in_poll_sleep_times_out(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The mid-poll-sleep deadline re-check: ``logsearch_count`` reports
+        INCOMPLETE, and the deadline elapses before the next poll -- the runner
+        re-checks the remaining budget after the (incomplete) count and returns
+        timed_out instead of sleeping/polling again. We advance the loop clock
+        past the deadline as soon as the count returns incomplete."""
+
+        loop = asyncio.get_event_loop()
+        real_time = loop.time
+        ticks = {"incomplete": False}
+        base = real_time()
+
+        def _fake_time() -> float:
+            if ticks["incomplete"]:
+                return base + 10_000.0
+            return real_time()
+
+        monkeypatch.setattr(loop, "time", _fake_time)
+
+        class _ForeverIncomplete(_BaseFake):
+            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
+                self.counts.append(tid)
+                # Not complete: progress < 100 and scanned < total. After we
+                # return, the clock jumps past the deadline so the re-check that
+                # guards the poll-sleep fires.
+                result = {"progress-percent": 20, "scanned-logs": 0, "total-logs": 9}
+                ticks["incomplete"] = True
+                return result
+
+            async def logsearch_fetch(
+                self, *, adom: str, tid: int, limit: int, offset: int
+            ) -> dict:
+                raise AssertionError("must not fetch a stalled, timed-out search")
+
+        fake = _ForeverIncomplete()
+        page = await _run(fake, limit=10, timeout=1)
+
+        assert page["timed_out"] is True
+        assert len(fake.counts) == 1  # re-checked after one incomplete count
+        assert fake.fetches == []
+        assert fake.cancels == [fake.starts[0]]
+
+    async def test_count_overruns_remaining_budget_times_out(self) -> None:
+        """The count wait_for TimeoutError branch: ``logsearch_count`` awaits
+        longer than the remaining wall-clock budget, so ``asyncio.wait_for``
+        cancels the count and the runner returns page timed_out without fetching,
+        best-effort cancelling the live tid."""
+
+        class _SlowCount(_BaseFake):
+            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
+                self.counts.append(tid)
+                # Sleep past the remaining budget; wait_for must cancel us.
+                await asyncio.sleep(10)
+                return {"progress-percent": 100, "scanned-logs": 5, "total-logs": 5}
+
+            async def logsearch_fetch(
+                self, *, adom: str, tid: int, limit: int, offset: int
+            ) -> dict:
+                raise AssertionError("must not fetch after a count timeout")
+
+        fake = _SlowCount()
+        page = await _run(fake, limit=10, timeout=1)
+
+        assert page["timed_out"] is True
+        assert fake.fetches == []
+        assert fake.cancels == [fake.starts[0]]
+
+    async def test_fetch_overruns_remaining_budget_times_out(self) -> None:
+        """The fetch wait_for TimeoutError branch: ``logsearch_count`` completes
+        immediately, but ``logsearch_fetch`` awaits longer than the remaining
+        wall-clock budget, so ``asyncio.wait_for`` cancels the fetch and the
+        runner returns page timed_out -- best-effort cancelling the live tid."""
+
+        class _SlowFetch(_BaseFake):
+            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
+                self.counts.append(tid)
+                return {"progress-percent": 100, "scanned-logs": 5, "total-logs": 5}
+
+            async def logsearch_fetch(
+                self, *, adom: str, tid: int, limit: int, offset: int
+            ) -> dict:
+                self.fetches.append(tid)
+                # Sleep well past the remaining budget; wait_for must cancel us.
+                await asyncio.sleep(10)
+                return {"percentage": 100, "data": _rows(1), "total-count": 1}
+
+        fake = _SlowFetch()
+        page = await _run(fake, limit=10, timeout=1)
+
+        assert page["timed_out"] is True
+        assert fake.fetches == [fake.starts[0]]  # fetch was attempted, then cancelled
+        assert page["logs"] == []
+        # Live tid best-effort cancelled on the non-delivered exit.
+        assert fake.cancels == [fake.starts[0]]
+
+
+# =============================================================================
+# Leak cleanup: cancel the live tid on non-delivered exits
+# =============================================================================
+
+
+class TestLeakCleanup:
+    async def test_generic_count_error_reraises_and_cancels(self) -> None:
+        class _GenericCountError(_BaseFake):
+            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
+                self.counts.append(tid)
+                raise RuntimeError("connection reset by peer")
+
+            async def logsearch_fetch(
+                self, *, adom: str, tid: int, limit: int, offset: int
+            ) -> dict:
+                raise AssertionError("must not fetch after a generic count error")
+
+        fake = _GenericCountError()
+        with pytest.raises(RuntimeError, match="connection reset"):
+            await _run(fake, limit=10)
+        assert fake.cancels == [fake.starts[0]]  # leaked tid best-effort cancelled
+
+    async def test_generic_fetch_error_reraises_and_cancels(self) -> None:
+        class _GenericFetchError(_BaseFake):
+            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
+                self.counts.append(tid)
+                return {"progress-percent": 100, "scanned-logs": 5, "total-logs": 5}
+
+            async def logsearch_fetch(
+                self, *, adom: str, tid: int, limit: int, offset: int
+            ) -> dict:
+                self.fetches.append(tid)
+                raise RuntimeError("disk full")
+
+        fake = _GenericFetchError()
+        with pytest.raises(RuntimeError, match="disk full"):
+            await _run(fake, limit=10)
+        assert fake.cancels == [fake.starts[0]]
+
+    async def test_cancelled_task_best_effort_cancels_tid(self) -> None:
+        """A task cancelled mid-count still issues a (shielded, bounded)
+        best-effort logsearch_cancel for the live tid."""
+        cancelled_evt = asyncio.Event()
+
+        class _BlockingCount(_BaseFake):
+            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
+                self.counts.append(tid)
+                cancelled_evt.set()
+                await asyncio.sleep(10)  # block until the caller cancels us
+                return {"progress-percent": 100}
+
+            async def logsearch_fetch(
+                self, *, adom: str, tid: int, limit: int, offset: int
+            ) -> dict:
+                raise AssertionError("must not fetch a cancelled search")
+
+        fake = _BlockingCount()
+        task = asyncio.ensure_future(_run(fake, limit=10, timeout=60))
+        await cancelled_evt.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert fake.cancels == [fake.starts[0]]
+
+
+# =============================================================================
+# Compat: unsupported logsearch_count endpoint -> direct fetch fallback
+# =============================================================================
+
+
+class TestCountUnsupportedFallback:
+    async def test_unsupported_count_falls_back_to_direct_fetch_and_caches(self) -> None:
+        """An 'unknown URL' count error falls back to a single direct fetch on
+        the SAME tid (no preceding cancel) and caches the per-client flag so a
+        second search skips the count probe entirely."""
+
+        class _NoCountEndpoint(_BaseFake):
+            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
+                self.counts.append(tid)
+                raise APIError("Unknown URL /logsearch/count/", code=-6)
+
+            async def logsearch_fetch(
+                self, *, adom: str, tid: int, limit: int, offset: int
+            ) -> dict:
+                self.fetches.append(tid)
+                return {"percentage": 100, "data": _rows(2), "total-count": 2}
+
+        fake = _NoCountEndpoint()
+        page = await _run(fake, limit=10)
+
+        assert page["timed_out"] is False
+        assert page["logs"] == _rows(2)
+        assert len(fake.counts) == 1  # probed once
+        assert fake.fetches == [fake.starts[0]]  # direct fetch on the same tid
+        assert fake.cancels == []  # delivered fetch -> no cancel before fallback
+        assert getattr(fake, "_logsearch_count_unsupported", False) is True
+
+        # A second search makes no further count attempt (cached).
+        page2 = await _run(fake, limit=10)
+        assert page2["logs"] == _rows(2)
+        assert len(fake.counts) == 1  # unchanged: no new count probe
+
+    async def test_invalid_tid_count_does_not_trigger_fallback(self) -> None:
+        """An invalid-tid count error re-issues (it is NOT an unsupported
+        endpoint) and must not set the count-unsupported cache flag."""
+
+        class _InvalidThenOk(_NormalFake):
+            def __init__(self) -> None:
+                super().__init__(_rows(3), polls_to_complete=1)
+                self._raised = False
+
+            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
+                if not self._raised:
+                    self._raised = True
+                    self.counts.append(tid)
+                    raise ResourceNotFoundError("Invalid tid reaped.", code=-1)
+                return await super().logsearch_count(adom, tid)
+
+        fake = _InvalidThenOk()
+        page = await _run(fake, limit=10)
+
+        assert page["logs"] == _rows(3)
+        assert len(fake.starts) == 2  # re-issued, not a fallback
+        assert getattr(fake, "_logsearch_count_unsupported", False) is False
+
+
+# =============================================================================
+# Concurrency cap
+# =============================================================================
+
+
+class TestConcurrencyCap:
+    async def test_in_flight_searches_bounded_by_limit(self) -> None:
+        """Launching more than LOGSEARCH_CONCURRENCY_LIMIT concurrent page runs,
+        each blocking inside logsearch_count on an Event, must SATURATE the
+        semaphore exactly to the cap: max in-flight == the limit (not less, which
+        would mean serialization or a too-small semaphore) and never > the limit
+        (the surplus is held back), while all eventually complete."""
+        limit = log_tools.LOGSEARCH_CONCURRENCY_LIMIT
+        release = asyncio.Event()
+        state = {"in_flight": 0, "max_in_flight": 0}
+
+        class _BlockingFake(_BaseFake):
+            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
+                state["in_flight"] += 1
+                state["max_in_flight"] = max(state["max_in_flight"], state["in_flight"])
+                try:
+                    await release.wait()
+                finally:
+                    state["in_flight"] -= 1
+                return {"progress-percent": 100, "scanned-logs": 1, "total-logs": 1}
+
+            async def logsearch_fetch(
+                self, *, adom: str, tid: int, limit: int, offset: int
+            ) -> dict:
+                self.fetches.append(tid)
+                return {"percentage": 100, "data": _rows(1), "total-count": 1}
+
+        # Launch strictly more than the cap so the surplus must wait on the
+        # semaphore while the first wave is blocked in logsearch_count.
+        fakes = [_BlockingFake() for _ in range(limit + 3)]
+        tasks = [asyncio.ensure_future(_run(f, limit=5, timeout=60)) for f in fakes]
+
+        # Let the first wave saturate the semaphore, then release everyone.
+        for _ in range(50):
+            await asyncio.sleep(0)
+            if state["in_flight"] >= limit:
+                break
+        # The cap must be SATURATED, not merely respected: exactly `limit`
+        # searches are concurrently blocked, and the surplus is held back.
+        assert state["in_flight"] == limit
+        assert state["max_in_flight"] == limit
+        release.set()
+
+        results = await asyncio.gather(*tasks)
+        assert all(r["timed_out"] is False for r in results)
+        assert all(r["logs"] == _rows(1) for r in results)
+        # Across the whole run the cap was hit exactly, never exceeded.
+        assert state["max_in_flight"] == limit
+
+
+# =============================================================================
+# Timeout clamp
+# =============================================================================
+
+
+class TestTimeoutClamp:
+    async def test_timeout_above_cap_is_clamped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A timeout far above MAX_SEARCH_TIMEOUT is clamped at the page runner:
+        with a tiny cap, a stalled scan times out within the cap even though a
+        huge timeout was requested (it cannot monopolize a slot indefinitely)."""
+        monkeypatch.setattr(log_tools, "MAX_SEARCH_TIMEOUT", 1)
+        monkeypatch.setattr(log_tools, "POLL_INTERVAL", 0.005)
+        monkeypatch.setattr(log_tools, "_INITIAL_POLL_DELAY", 0.005)
+
+        class _StallFake(_BaseFake):
+            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
+                self.counts.append(tid)
+                return {"progress-percent": 20, "scanned-logs": 0, "total-logs": 9}
+
+            async def logsearch_fetch(
+                self, *, adom: str, tid: int, limit: int, offset: int
+            ) -> dict:
+                raise AssertionError("must not fetch a stalled search")
+
+        fake = _StallFake()
+        loop = asyncio.get_event_loop()
+        before = loop.time()
+        page = await _run(fake, limit=10, timeout=10_000)
+        elapsed = loop.time() - before
+
+        assert page["timed_out"] is True
+        # Clamped to ~1s, not the requested 10_000s.
+        assert elapsed < 5
+        assert fake.cancels == [fake.starts[0]]

--- a/tests/test_pcap_tools.py
+++ b/tests/test_pcap_tools.py
@@ -6,7 +6,12 @@ Follows the same pattern as test_system_tools.py to avoid server initialization.
 
 import pytest
 
+import fortianalyzer_mcp.tools.log_tools as log_tools
+import fortianalyzer_mcp.tools.pcap_tools as pcap_tools
 from fortianalyzer_mcp.api.client import FortiAnalyzerClient
+from fortianalyzer_mcp.utils.errors import ResourceNotFoundError
+
+_CUSTOM_RANGE = "2024-01-01 00:00:00|2024-01-02 00:00:00"
 
 
 class TestPCAPHelpers:
@@ -259,12 +264,234 @@ class TestPCAPSearchWorkflow:
         max_downloads = min(max_downloads, 50)
         assert max_downloads == 10
 
-    def test_poll_interval_value(self) -> None:
-        """Test poll interval constant."""
-        POLL_INTERVAL = 1.0
-        assert POLL_INTERVAL == 1.0
-
     def test_default_search_timeout(self) -> None:
-        """Test default search timeout."""
-        DEFAULT_SEARCH_TIMEOUT = 60
-        assert DEFAULT_SEARCH_TIMEOUT == 60
+        """The module's default search timeout is 60 seconds."""
+        assert pcap_tools.DEFAULT_SEARCH_TIMEOUT == 60
+
+
+class _PollFetchFaz:
+    """PCAP-search fake enforcing poll-before-fetch.
+
+    logsearch_count climbs to 100% over two polls (a non-reaping GET);
+    logsearch_fetch raises invalid-tid if called before the scan completes, and
+    otherwise returns the IPS rows once. The runner must poll then fetch once.
+    """
+
+    def __init__(self, dataset: list[dict[str, object]]) -> None:
+        self.dataset = dataset
+        self.starts = 0
+        self.counts = 0
+        self.fetches = 0
+        self._polls: dict[int, int] = {}
+        self._next_tid = 900
+
+    async def ensure_connected(self) -> None:
+        return None
+
+    async def logsearch_start(self, **_kw: object) -> dict[str, int]:
+        self.starts += 1
+        self._next_tid += 1
+        self._polls[self._next_tid] = 0
+        return {"tid": self._next_tid}
+
+    async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
+        self.counts += 1
+        self._polls[tid] += 1
+        done = self._polls[tid] >= 2
+        total = len(self.dataset)
+        return {
+            "progress-percent": 100 if done else 40,
+            "scanned-logs": total if done else 0,
+            "total-logs": total,
+        }
+
+    async def logsearch_fetch(self, *, adom: str, tid: int, limit: int, offset: int) -> dict:
+        self.fetches += 1
+        if self._polls.get(tid, 0) < 2:
+            raise ResourceNotFoundError(f"Invalid tid {tid}: not complete.", code=-1)
+        return {
+            "percentage": 100,
+            "data": self.dataset[offset : offset + limit],
+            "total-count": len(self.dataset),
+        }
+
+    async def logsearch_cancel(self, adom: str, tid: int) -> dict[str, object]:
+        return {}
+
+
+class TestPCAPSearchPollPath:
+    """PCAP IPS searches route through the shared poll-before-fetch runner."""
+
+    @pytest.fixture(autouse=True)
+    def _fast_polls(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(log_tools, "_INITIAL_POLL_DELAY", 0)
+        monkeypatch.setattr(log_tools, "POLL_INTERVAL", 0)
+
+    async def test_search_ips_logs_returns_rows_via_poll_path(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        rows = [
+            {"sessionid": 1, "attack": "Test.Attack", "severity": "critical", "pcapurl": "u1"},
+            {"sessionid": 2, "attack": "Other.Attack", "severity": "high"},
+        ]
+        fake = _PollFetchFaz(rows)
+        monkeypatch.setattr(pcap_tools, "get_faz_client", lambda: fake)
+
+        result = await pcap_tools.search_ips_logs(
+            adom="root",
+            severity=["critical", "high"],
+            time_range=_CUSTOM_RANGE,
+            limit=50,
+        )
+
+        assert result["status"] == "success"
+        assert result["count"] == 2
+        assert result["total"] == 2
+        assert result["pcap_available_count"] == 1
+        assert result["logs"] == rows
+        # Poll-before-fetch contract: one start, >=1 count, exactly one fetch.
+        assert fake.starts == 1
+        assert fake.counts >= 1
+        assert fake.fetches == 1
+
+    async def test_search_ips_logs_empty_result_via_poll_path(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """An empty IPS search completes cleanly through the poll path: one
+        start, one fetch, zero rows -- not a raw invalid-tid string."""
+        fake = _PollFetchFaz([])
+        monkeypatch.setattr(pcap_tools, "get_faz_client", lambda: fake)
+
+        result = await pcap_tools.search_ips_logs(
+            adom="root",
+            severity=["critical"],
+            time_range=_CUSTOM_RANGE,
+        )
+
+        assert result["status"] == "success"
+        assert result["count"] == 0
+        assert result["logs"] == []
+        assert fake.starts == 1
+        assert fake.fetches == 1
+
+    async def test_get_pcap_by_session_found_via_poll_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        """get_pcap_by_session routes its session lookup through the poll path:
+        a matching row (without a pcapurl) returns the 'no_pcap' result after
+        exactly one start, >=1 count, and one fetch -- never a fetch-before-
+        complete invalid-tid string."""
+        monkeypatch.setenv("FAZ_ALLOWED_OUTPUT_DIRS", str(tmp_path))
+        rows = [
+            {
+                "sessionid": 906654,
+                "attack": "Test.Attack",
+                "severity": "critical",
+                "action": "blocked",
+                "srcip": "10.0.0.1",
+                "dstip": "10.0.0.2",
+            }
+        ]
+        fake = _PollFetchFaz(rows)
+        monkeypatch.setattr(pcap_tools, "get_faz_client", lambda: fake)
+
+        result = await pcap_tools.get_pcap_by_session(
+            session_id=906654,
+            adom="root",
+            time_range=_CUSTOM_RANGE,
+            output_dir=str(tmp_path),
+        )
+
+        # Row found, but no pcapurl -> the normal 'no_pcap' return.
+        assert result["status"] == "no_pcap"
+        assert result["session_id"] == 906654
+        assert result["attack_info"]["attack"] == "Test.Attack"
+        # Poll-before-fetch contract: one start, >=1 count, exactly one fetch.
+        assert fake.starts == 1
+        assert fake.counts >= 1
+        assert fake.fetches == 1
+
+    async def test_get_pcap_by_session_empty_via_poll_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        """An empty session lookup completes through the poll path and returns
+        the 'No IPS log found' message -- not a raw invalid-tid string."""
+        monkeypatch.setenv("FAZ_ALLOWED_OUTPUT_DIRS", str(tmp_path))
+        fake = _PollFetchFaz([])
+        monkeypatch.setattr(pcap_tools, "get_faz_client", lambda: fake)
+
+        result = await pcap_tools.get_pcap_by_session(
+            session_id=906654,
+            adom="root",
+            time_range=_CUSTOM_RANGE,
+            output_dir=str(tmp_path),
+        )
+
+        assert result["status"] == "error"
+        assert "No IPS log found" in result["message"]
+        assert fake.starts == 1
+        assert fake.fetches == 1
+
+    async def test_search_and_download_pcaps_proceeds_via_poll_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        """search_and_download_pcaps routes its search through the poll path:
+        with pcap-bearing rows it proceeds past the search into the download
+        loop after exactly one start, >=1 count, and one fetch. (The download
+        itself is stubbed to return no data, so it 'proceeds' but reports a
+        failed download -- the search contract is what we assert here.)"""
+        monkeypatch.setenv("FAZ_ALLOWED_OUTPUT_DIRS", str(tmp_path))
+
+        class _PollFetchWithPcap(_PollFetchFaz):
+            async def get_pcapfile(self, *, key_data: str, key_type: str) -> dict[str, object]:
+                # Proceeds into the download loop; no data -> graceful failure.
+                return {}
+
+        rows = [
+            {"sessionid": 1, "attack": "A", "severity": "critical", "pcapurl": "u1"},
+            {"sessionid": 2, "attack": "B", "severity": "critical", "pcapurl": "u2"},
+        ]
+        fake = _PollFetchWithPcap(rows)
+        monkeypatch.setattr(pcap_tools, "get_faz_client", lambda: fake)
+
+        result = await pcap_tools.search_and_download_pcaps(
+            adom="root",
+            severity=["critical"],
+            time_range=_CUSTOM_RANGE,
+            output_dir=str(tmp_path),
+            max_downloads=5,
+        )
+
+        assert result["status"] == "success"
+        assert result["search_results"] == 2
+        assert result["pcap_available"] == 2  # proceeded past the search
+        # Poll-before-fetch contract: one start, >=1 count, exactly one fetch.
+        assert fake.starts == 1
+        assert fake.counts >= 1
+        assert fake.fetches == 1
+
+    async def test_search_and_download_pcaps_empty_via_poll_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path
+    ) -> None:
+        """With no pcap-bearing rows, search_and_download_pcaps completes the
+        poll path and returns its empty result -- not a raw invalid-tid string."""
+        monkeypatch.setenv("FAZ_ALLOWED_OUTPUT_DIRS", str(tmp_path))
+        rows = [
+            {"sessionid": 1, "attack": "A", "severity": "critical"},  # no pcapurl
+        ]
+        fake = _PollFetchFaz(rows)
+        monkeypatch.setattr(pcap_tools, "get_faz_client", lambda: fake)
+
+        result = await pcap_tools.search_and_download_pcaps(
+            adom="root",
+            severity=["critical"],
+            time_range=_CUSTOM_RANGE,
+            output_dir=str(tmp_path),
+        )
+
+        assert result["status"] == "success"
+        assert result["pcap_available"] == 0
+        assert result["downloaded"] == 0
+        assert result["message"] == "No IPS events found with PCAP available"
+        assert fake.starts == 1
+        assert fake.fetches == 1

--- a/tests/test_response_contract.py
+++ b/tests/test_response_contract.py
@@ -11,6 +11,7 @@ from zoneinfo import ZoneInfo
 import pytest
 
 import fortianalyzer_mcp.tools.log_tools as log_tools
+from fortianalyzer_mcp.utils.errors import ResourceNotFoundError
 
 CUSTOM_RANGE = "2024-01-01 00:00:00|2024-01-02 00:00:00"
 _PACIFIC = ZoneInfo("US/Pacific")
@@ -21,7 +22,12 @@ def _rows(n: int) -> list[dict[str, object]]:
 
 
 class ContractFaz:
-    """Minimal log-search fake with a controllable total and forced errors."""
+    """Minimal log-search fake with a controllable total and forced errors.
+
+    Honors poll-before-fetch: ``logsearch_count`` reports the scan complete (a
+    cheap GET that does not reap), so the runner polls once and then fetches the
+    page exactly once.
+    """
 
     def __init__(
         self,
@@ -38,6 +44,8 @@ class ContractFaz:
         self.connected = True
         self.reconnects = 0
         self.start_calls: list[dict[str, object]] = []
+        self.count_calls: list[int] = []
+        self._complete_tids: set[int] = set()
         self._tid = 500
 
     @property
@@ -69,9 +77,27 @@ class ContractFaz:
         self._tid += 1
         return {"tid": self._tid}
 
+    async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
+        """Report the scan complete (does not reap the tid)."""
+        self.count_calls.append(tid)
+        self._complete_tids.add(tid)
+        rows = len(self.page)
+        total = self.total if self.total is not None else rows
+        return {
+            "progress-percent": 100,
+            "matched-logs": rows,
+            "scanned-logs": total,
+            "total-logs": total,
+        }
+
     async def logsearch_fetch(
         self, adom: str, tid: int, limit: int = 50, offset: int = 0
     ) -> dict[str, object]:
+        # Poll-before-fetch: a fetch before this tid's count has reported
+        # complete is an invalid-tid error (the live appliance reaps an
+        # un-ready single-use tid on a premature fetch).
+        if tid not in self._complete_tids:
+            raise ResourceNotFoundError(f"Invalid tid {tid}: not complete.", code=-1)
         result: dict[str, object] = {
             "percentage": 100,
             "data": list(self.page),
@@ -84,6 +110,13 @@ class ContractFaz:
 
     async def logsearch_cancel(self, adom: str, tid: int) -> dict[str, object]:
         return {"status": {"code": 0, "message": "ok"}}
+
+
+@pytest.fixture(autouse=True)
+def _fast_polls(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Drop the poll cadence to zero so start->poll->fetch is fast."""
+    monkeypatch.setattr(log_tools, "_INITIAL_POLL_DELAY", 0)
+    monkeypatch.setattr(log_tools, "POLL_INTERVAL", 0)
 
 
 @pytest.fixture(autouse=True)
@@ -109,10 +142,27 @@ class TestQueryLogsContractFields:
         assert r["limit"] == 10
         assert r["next_offset"] == 10  # offset + count, has_more
         assert r["warnings"] == []
+        # Poll-before-fetch: the count probe ran before the fetch (the fetch now
+        # raises invalid-tid if called before its count reports complete, so a
+        # successful page proves count was polled first).
+        assert len(fake.count_calls) >= 1
         # Old names are gone.
         assert "total_known" not in r
         assert "returned_offset" not in r
         assert "returned_limit" not in r
+
+    async def test_time_basis_fields_present(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """query_logs surfaces the time-basis source and clock skew."""
+        fake = ContractFaz(page=_rows(3), total=3)
+        _install(monkeypatch, fake)
+
+        r = await log_tools.query_logs(adom="root", time_range=CUSTOM_RANGE, limit=10)
+
+        # A custom absolute range carries explicit bounds -> "custom" basis.
+        assert r["time_basis_source"] == "custom"
+        assert r["clock_skew_seconds"] is None
+        # The FAZ tz is still reported for label purposes.
+        assert r["timezone"] == "US/Pacific"
 
     async def test_clean_query_has_empty_warnings(self, monkeypatch: pytest.MonkeyPatch) -> None:
         fake = ContractFaz(page=_rows(3), total=3)

--- a/tests/test_time_range.py
+++ b/tests/test_time_range.py
@@ -95,6 +95,36 @@ class TestParseTimeRangeCustom:
             parse_time_range("2024-01-02 00:00:00|2024-01-01 00:00:00")
 
 
+class TestParseTimeRangeAnchor:
+    """Explicit anchor support for LogView-clock alignment."""
+
+    def test_relative_window_ends_on_anchor(self) -> None:
+        anchor = datetime(2026, 6, 1, 12, 0, 0)
+        result = parse_time_range("1-hour", anchor=anchor)
+        assert result == {
+            "start": "2026-06-01 11:00:00",
+            "end": "2026-06-01 12:00:00",
+        }
+
+    def test_anchor_takes_precedence_over_faz_tz(self) -> None:
+        anchor = datetime(2026, 6, 1, 12, 0, 0)
+        # faz_tz is supplied but the explicit anchor must win.
+        result = parse_time_range("7-day", faz_tz=ZoneInfo("Europe/Zurich"), anchor=anchor)
+        assert result["end"] == "2026-06-01 12:00:00"
+        assert result["start"] == "2026-05-25 12:00:00"
+
+    def test_tz_aware_anchor_is_stripped_to_naive(self) -> None:
+        anchor = datetime(2026, 6, 1, 12, 0, 0, tzinfo=ZoneInfo("Europe/Zurich"))
+        result = parse_time_range("1-hour", anchor=anchor)
+        # Wall-clock components preserved; tzinfo stripped (naive FAZ-local).
+        assert result["end"] == "2026-06-01 12:00:00"
+
+    def test_anchor_ignored_for_custom_range(self) -> None:
+        anchor = datetime(2026, 6, 1, 12, 0, 0)
+        result = parse_time_range("2024-01-01 00:00:00|2024-01-02 00:00:00", anchor=anchor)
+        assert result == {"start": "2024-01-01 00:00:00", "end": "2024-01-02 00:00:00"}
+
+
 class TestParseTimeRangeTimezone:
     """Bug B regression: timestamps must align with FAZ TZ when provided."""
 

--- a/tests/test_traffic_tools.py
+++ b/tests/test_traffic_tools.py
@@ -6,7 +6,9 @@ without triggering server initialization.
 
 import pytest
 
+import fortianalyzer_mcp.tools.log_tools as log_tools
 import fortianalyzer_mcp.tools.traffic_tools as traffic_tools
+from fortianalyzer_mcp.tools.log_tools import _coerce_total as _coerce_log_total
 from fortianalyzer_mcp.tools.traffic_tools import (
     ANALYSIS_QUERY_BUDGET,
     LOG_FETCH_LIMIT,
@@ -17,7 +19,6 @@ from fortianalyzer_mcp.tools.traffic_tools import (
     _bounded_metadata,
     _build_bounded_time_slices,
     _build_policy_filter,
-    _coerce_log_total,
     _plan_policy_slice_count,
     _query_policy_log_slice,
     _query_policy_total_count,
@@ -26,10 +27,6 @@ from fortianalyzer_mcp.tools.traffic_tools import (
     validate_policy_ids,
 )
 from fortianalyzer_mcp.utils.validation import ValidationError
-
-
-async def _noop_sleep(_seconds: float) -> None:
-    """Async no-op to skip real polling delays in slice-reliability tests."""
 
 
 @pytest.fixture(autouse=True)
@@ -419,8 +416,14 @@ class TestPolicyPortAnalysisToolBounded:
         """Slice fetches should preserve FAZ total-count for the same filter/window."""
 
         class FakeClient:
+            async def ensure_connected(self) -> None:
+                return None
+
             async def logsearch_start(self, **_kwargs: object) -> dict[str, int]:
                 return {"tid": 123}
+
+            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
+                return {"progress-percent": 100, "total-logs": 25, "scanned-logs": 25}
 
             async def logsearch_fetch(self, **_kwargs: object) -> dict[str, object]:
                 return {
@@ -670,6 +673,8 @@ class TestPolicyToolAuditMetadata:
         }
         # Custom absolute range skips the TZ client lookup in unit tests.
         assert result["timezone"] == "unknown"
+        assert result["time_basis_source"] == "custom"
+        assert result["clock_skew_seconds"] is None
         assert result["results"][0]["filter"] == "policyid==2 and action==accept"
 
 
@@ -876,27 +881,42 @@ class TestCoerceLogTotal:
 
 
 class TestQueryPolicySliceReliability:
-    """A bounded slice query must re-issue a fresh search rather than re-fetch a
-    single-use (reaped) FortiAnalyzer tid, matching log_tools._run_search_page."""
+    """A bounded slice query routes through log_tools._run_logsearch_page, so it
+    polls logsearch_count (a non-reaping GET) until the scan is complete and then
+    fetches exactly once, re-issuing a fresh search instead of re-fetching a
+    single-use (reaped) FortiAnalyzer tid."""
 
     _WINDOW = {"start": "2024-01-01 00:00:00", "end": "2024-01-01 01:00:00"}
     _DEVICE = [{"devid": "All_FortiGate"}]
 
-    async def test_reissues_a_fresh_search_on_incomplete_fetch(
+    @pytest.fixture(autouse=True)
+    def _fast_polls(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(log_tools, "_INITIAL_POLL_DELAY", 0)
+        monkeypatch.setattr(log_tools, "POLL_INTERVAL", 0)
+
+    async def test_reissues_a_fresh_search_on_invalid_tid_during_count(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """An invalid-tid during count (appliance reaped the search mid-poll)
+        re-issues a fresh search rather than fetching a reaped tid."""
         starts: list[dict[str, object]] = []
-        fetches = {"n": 0}
+        counts = {"n": 0}
 
         class FakeClient:
+            async def ensure_connected(self) -> None:
+                return None
+
             async def logsearch_start(self, **kwargs: object) -> dict[str, int]:
                 starts.append(kwargs)
                 return {"tid": 100 + len(starts)}
 
+            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
+                counts["n"] += 1
+                if counts["n"] == 1:
+                    raise RuntimeError("Invalid tid reaped mid-poll.")
+                return {"progress-percent": 100, "total-logs": 7, "scanned-logs": 7}
+
             async def logsearch_fetch(self, **_kwargs: object) -> dict[str, object]:
-                fetches["n"] += 1
-                if fetches["n"] == 1:
-                    return {"percentage": 40, "data": []}  # incomplete -> task reaped
                 return {
                     "percentage": 100,
                     "total-count": "7",
@@ -906,7 +926,6 @@ class TestQueryPolicySliceReliability:
             async def logsearch_cancel(self, *_a: object, **_k: object) -> dict[str, object]:
                 return {}
 
-        monkeypatch.setattr(traffic_tools.asyncio, "sleep", _noop_sleep)
         monkeypatch.setattr(traffic_tools, "_get_client", lambda: FakeClient())
 
         result = await _query_policy_log_slice(
@@ -925,13 +944,21 @@ class TestQueryPolicySliceReliability:
     async def test_reissues_a_fresh_search_on_invalid_tid_error(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
+        """An invalid-tid race during fetch (reaped between count-complete and
+        the fetch) re-issues a fresh search and still completes."""
         starts: list[dict[str, object]] = []
         fetches = {"n": 0}
 
         class FakeClient:
+            async def ensure_connected(self) -> None:
+                return None
+
             async def logsearch_start(self, **kwargs: object) -> dict[str, int]:
                 starts.append(kwargs)
                 return {"tid": 200 + len(starts)}
+
+            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
+                return {"progress-percent": 100, "total-logs": 3, "scanned-logs": 3}
 
             async def logsearch_fetch(self, **_kwargs: object) -> dict[str, object]:
                 fetches["n"] += 1
@@ -946,7 +973,6 @@ class TestQueryPolicySliceReliability:
             async def logsearch_cancel(self, *_a: object, **_k: object) -> dict[str, object]:
                 return {}
 
-        monkeypatch.setattr(traffic_tools.asyncio, "sleep", _noop_sleep)
         monkeypatch.setattr(traffic_tools, "_get_client", lambda: FakeClient())
 
         result = await _query_policy_log_slice(
@@ -965,8 +991,14 @@ class TestQueryPolicySliceReliability:
         """A genuine error (not invalid-tid) must NOT be silently retried away."""
 
         class FakeClient:
+            async def ensure_connected(self) -> None:
+                return None
+
             async def logsearch_start(self, **_kwargs: object) -> dict[str, int]:
                 return {"tid": 1}
+
+            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
+                return {"progress-percent": 100, "total-logs": 1, "scanned-logs": 1}
 
             async def logsearch_fetch(self, **_kwargs: object) -> dict[str, object]:
                 raise RuntimeError("connection reset by peer")
@@ -974,7 +1006,6 @@ class TestQueryPolicySliceReliability:
             async def logsearch_cancel(self, *_a: object, **_k: object) -> dict[str, object]:
                 return {}
 
-        monkeypatch.setattr(traffic_tools.asyncio, "sleep", _noop_sleep)
         monkeypatch.setattr(traffic_tools, "_get_client", lambda: FakeClient())
 
         with pytest.raises(RuntimeError, match="connection reset"):
@@ -986,10 +1017,20 @@ class TestQueryPolicySliceReliability:
                 action=None,
             )
 
-    async def test_no_tid_returns_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_no_tid_degrades_to_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A start that returns no tid degrades one slice to empty/unknown (the
+        runner raises, but the policy slice swallows it) so the rest of the
+        policy fan-out still reports rather than the whole policy aborting."""
+
         class FakeClient:
+            async def ensure_connected(self) -> None:
+                return None
+
             async def logsearch_start(self, **_kwargs: object) -> dict[str, object]:
                 return {}
+
+            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
+                raise AssertionError("must not count without a tid")
 
             async def logsearch_fetch(self, **_kwargs: object) -> dict[str, object]:
                 raise AssertionError("must not fetch without a tid")
@@ -997,7 +1038,6 @@ class TestQueryPolicySliceReliability:
             async def logsearch_cancel(self, *_a: object, **_k: object) -> dict[str, object]:
                 return {}
 
-        monkeypatch.setattr(traffic_tools.asyncio, "sleep", _noop_sleep)
         monkeypatch.setattr(traffic_tools, "_get_client", lambda: FakeClient())
 
         result = await _query_policy_log_slice(
@@ -1007,24 +1047,32 @@ class TestQueryPolicySliceReliability:
             time_range=self._WINDOW,
             action=None,
         )
-
         assert result == {"logs": [], "total_hits": None, "total_hits_is_known": False}
 
     async def test_timeout_returns_empty_and_cancels(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A scan that never completes is bounded by the deadline; the slice
+        returns an empty/unknown result and the live tid is cancelled."""
         cancels: list[int] = []
 
         class FakeClient:
+            async def ensure_connected(self) -> None:
+                return None
+
             async def logsearch_start(self, **_kwargs: object) -> dict[str, int]:
                 return {"tid": 5}
 
+            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
+                return {"progress-percent": 10, "total-logs": 9, "scanned-logs": 0}
+
             async def logsearch_fetch(self, **_kwargs: object) -> dict[str, object]:
-                return {"percentage": 10, "data": []}  # never completes
+                raise AssertionError("must not fetch a still-running search")
 
             async def logsearch_cancel(self, adom: str, tid: int) -> dict[str, object]:
                 cancels.append(tid)
                 return {}
 
-        monkeypatch.setattr(traffic_tools.asyncio, "sleep", _noop_sleep)
+        monkeypatch.setattr(log_tools, "POLL_INTERVAL", 0.005)
+        monkeypatch.setattr(log_tools, "_INITIAL_POLL_DELAY", 0.005)
         monkeypatch.setattr(traffic_tools, "_get_client", lambda: FakeClient())
 
         result = await _query_policy_log_slice(
@@ -1033,7 +1081,7 @@ class TestQueryPolicySliceReliability:
             policy_id=2,
             time_range=self._WINDOW,
             action=None,
-            timeout=0,
+            timeout=1,
         )
 
         assert result == {"logs": [], "total_hits": None, "total_hits_is_known": False}
@@ -1174,6 +1222,10 @@ class TestPolicyPathEnsuresConnection:
                 events.append("start")
                 return {"tid": 1}
 
+            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
+                events.append("count")
+                return {"progress-percent": 100, "total-logs": 3, "scanned-logs": 3}
+
             async def logsearch_fetch(self, **_kwargs: object) -> dict[str, object]:
                 return {
                     "percentage": 100,
@@ -1186,7 +1238,8 @@ class TestPolicyPathEnsuresConnection:
 
         fake = FakeClient()
         monkeypatch.setattr(traffic_tools, "_get_client", lambda: fake)
-        monkeypatch.setattr(traffic_tools.asyncio, "sleep", _noop_sleep)
+        monkeypatch.setattr(log_tools, "_INITIAL_POLL_DELAY", 0)
+        monkeypatch.setattr(log_tools, "POLL_INTERVAL", 0)
 
         result = await traffic_tools.get_policy_port_analysis(
             adom="root",


### PR DESCRIPTION
## Problem

On FortiAnalyzer **7.6.7**, log search (`query_logs`, `fetch_more_logs`, the bounded policy slices, and the PCAP searches) returns **zero rows / `search_timeout` / `No available slot for searching`** across every window and logtype, even though FortiView sees the same traffic.

## Root cause

The page runner (`_run_search_page`) calls `logsearch_fetch` **immediately after** `logsearch_start`, before the async search has finished. On 7.6.7 that premature fetch returns an *incomplete* page **and reaps the single-use tid**, so the loop re-issues a fresh `logsearch_start` ~once/second for 60s — no search ever completes, and the ~60 starts **drain the appliance search-slot pool**. (The existing mocked tests pass because the fakes return `percentage:100` instantly, so the real async `start → poll → fetch` path is never exercised.)

## Fix — poll-before-fetch as the contract

A shared `_run_logsearch_page`: `ensure_connected → logsearch_start → poll logsearch_count` (a cheap GET that does **not** reap the tid) until the scan is complete `→ logsearch_fetch` exactly once. Readiness = `progress-percent >= 100` **OR** (`total-logs > 0` AND `scanned-logs >= total-logs`); `matched-logs` is deliberately *not* a readiness signal. Guards make the anti-exhaustion guarantee explicit:

- a global `asyncio.Semaphore` bounding concurrent in-flight appliance searches (a search now *holds* a slot until readiness);
- a **shared bounded recovery budget** across all reissue causes (invalid-tid during count, invalid-tid race during fetch, premature-100) so a reaping appliance can't spin `logsearch_start`;
- `asyncio.wait_for` deadline-bounding on every count/fetch, a shielded best-effort cleanup-cancel on non-delivered exits, and a timeout clamp.

`query_logs`, `fetch_more_logs`, the policy slices (`traffic_tools.py`), and the three PCAP searches (`pcap_tools.py`) all route through it.

## Also included (reliability hardening surfaced during live 7.6.7 testing)

- single server lifecycle owner + **reconnect-once** on idle-closed streamable-HTTP sessions (`api/client.py`, `server.py`);
- **LogView clock-anchored** relative time windows so a post-upgrade clock skew doesn't miss recent logs (`utils/log_clock.py`);
- defense-in-depth path-traversal guard on the report raw-save branch (`report_tools.py`).

## Testing

- **529 unit tests pass**; new regression coverage makes the fakes raise *invalid-tid on fetch-before-complete*, so the "exactly one start" assertions would fail against the old fetch-first runner.
- **Live-verified end-to-end on a 7.6.7 appliance**: `query_logs` returns real rows, 5 sequential queries with no slot exhaustion, 7-day & 30-day windows succeed, event/security/policy/PCAP all OK, and a raw single-search control over the same window matches.

This builds on the single-use-tid pagination work from #17. Lockfile/CI/internal-doc changes from our fork are intentionally left out to keep this focused on the fix; happy to add a CHANGELOG/README note in your preferred format if useful.