### PR TITLE
feat(logs): stable baseline total across fetch_more_logs pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to FortiAnalyzer MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- **`query_logs` / `fetch_more_logs` now report a stable baseline `total` for a pagination session.** A FortiAnalyzer logsearch re-runs per page over a frozen window and the appliance re-counts `total-count` between pages, so the reported `total` could wobble within one pagination session (observed on 7.6.7: 230071 → 230741). `total` is now held as the handle's first-page baseline; `has_more` is decoupled from it and pages against the best observed figure so a short page never stops paging early. See [ADR-0002](docs/adr/0002-baseline-total-for-pagination-handle.md).
+
+### Added
+- `page_total` (live per-page count), `total_count_stability` (`single_observation` | `stable` | `drifted` | `unknown`), `total_drift_detected`, `total_delta`, and `has_more_basis` on log-query responses; an `adom_mismatch` guard binding a pagination handle to its ADOM. 11 regression tests against a drift-capable fake.
+
 ## [2.0.1] - 2026-06-09
 
 Reliability hardening for FortiAnalyzer 7.6.7. PR [#18](https://github.com/rstierli/fortianalyzer-mcp/pull/18) by [@inxbit](https://github.com/inxbit). 529 unit tests pass; live-verified end-to-end on a 7.6.7 appliance.

--- a/README.md
+++ b/README.md
@@ -430,6 +430,26 @@ networks:
 > `has_more:false`. Call `cancel_log_search(tid=<handle>)` when finished; an
 > expired/unknown handle returns `error:"tid_invalid_or_expired"`.
 >
+> **Totals across pages (`total` vs `page_total`):** because `fetch_more_logs`
+> re-runs the search for each page, FortiAnalyzer may report a different
+> `total-count` from one page to the next even for the same fixed window (rows
+> indexed after page 0). To keep the headline figure stable, `total` is the
+> handle's **first-page baseline** and stays fixed for every page; `page_total`
+> is the raw count observed on the current page. `total_count_stability` is
+> `single_observation` (page 0), `stable` (page matches the baseline), `drifted`
+> (it differs), or `unknown`; `total_drift_detected` and `total_delta`
+> (`page_total - initial_total`) quantify it. `has_more_basis` reports which
+> figure drove `has_more` (`stable_total`, `best_effort_max_observed_total`,
+> `best_effort_page_total`, or `full_page_heuristic`); it answers a different
+> question than `total_count_stability` and the two may legitimately differ. A
+> handle is bound to the ADOM `query_logs` ran under — paging it with a different
+> `adom` returns `error:"adom_mismatch"`. When a broad/high-volume window reports
+> `drifted`, treat the total as **non-exact**: the window is **not
+> snapshot-consistent**, so row offsets may shift and individual rows can be
+> duplicated or skipped across pages. For exact investigations prefer narrow
+> filters and fixed absolute windows away from "now", and rerun controls rather
+> than deep offset paging through a drifting high-volume window.
+>
 > **Time & timezone:** `time_range` accepts presets (`1-hour` … `24-hour`,
 > `7-day`, `30-day`, `90-day`) or a custom
 > `"YYYY-MM-DD HH:MM:SS|YYYY-MM-DD HH:MM:SS"` window. Timestamps are interpreted

--- a/docs/INTERNAL_ARCHITECTURE.md
+++ b/docs/INTERNAL_ARCHITECTURE.md
@@ -460,8 +460,25 @@ ERROR_CODE_MAP = {
 `query_logs` and `fetch_more_logs` return one self-describing shape:
 
 - `status`, `count`, `logs`
-- `total`, `total_is_known` — true match count from FAZ `total-count`;
-  `total_is_known=false` when the appliance omits it
+- `total`, `total_is_known` — the handle's **first-page Baseline total** (per ADR-0002),
+  held fixed for every page so it does not wobble as the appliance re-counts a frozen
+  window; `total_is_known=false` when no baseline was captured. `fetch_more_logs` never
+  promotes a later page's count into `total`
+- `page_total` — the raw FAZ `total-count` observed for the current page's re-run search
+  (the live per-page figure; equals `total` on page 0)
+- `initial_total` — the baseline `total` was derived from
+- `total_count_stability` — `single_observation` (page 0) | `stable` (page == baseline) |
+  `drifted` (page != baseline, same frozen window) | `unknown` (no comparable count)
+- `total_drift_detected`, `total_delta` — drift flag and `page_total - initial_total`
+  (when both known); a drift adds a warning that the broad total is non-exact and row
+  offsets may shift, and emits a redacted `logger.info` drift event
+- `has_more_basis` — which figure `has_more` was paged against: `stable_total` |
+  `best_effort_max_observed_total` (drift → `max(initial, page_total)`) |
+  `best_effort_page_total` (no baseline, this page has a count) | `full_page_heuristic`.
+  Distinct from `total_count_stability` and may differ (e.g. a later page omitting the
+  count is `stability=unknown` yet `basis=stable_total`)
+- A handle is bound to its ADOM — `fetch_more_logs` with a differing `adom` returns
+  `error="adom_mismatch"` (a cross-ADOM baseline/page comparison is meaningless)
 - `has_more`, `next_offset` — `next_offset = offset + count` while paging, `null`
   once `has_more` is false or a page returns `count == 0` (the count==0 guard
   prevents an infinite paging loop against an inconsistent total)

--- a/docs/adr/0002-baseline-total-for-pagination-handle.md
+++ b/docs/adr/0002-baseline-total-for-pagination-handle.md
@@ -1,0 +1,65 @@
+# Report the first-page Baseline total as a Pagination handle's `total`
+
+**Status:** accepted
+
+## Context
+
+`fetch_more_logs` pages a `query_logs` result by reconstructing and **re-running** the search at a new
+offset against the same frozen window (absolute `start`/`end` timestamps captured at page-0 time, using
+the single-use-tid poll-before-fetch search model). FortiAnalyzer's `total-count` is authoritative
+only for one completed search/page; across the independent re-run searches it can change as rows are
+indexed into the fixed window after page 0. Observed live on 7.6.7: page 0 unfiltered 1-hour traffic
+reported `total-count` 230071, page 1 of the same handle reported 230741.
+
+Until now the MCP echoed each page's raw `total-count` as the response `total`, so the headline match
+count wobbled between pages of one pagination session. That is a response-contract problem (which
+number is "the total" for this handle?), not a row-paging failure: the window bounds are fixed and
+offsets are stable.
+
+## Decision
+
+For a Pagination handle, the **first page's whole-window total-count is the Baseline total**, and the
+MCP reports it as `total` for every page of that handle. The raw per-page `total-count` is exposed
+separately as `page_total`, alongside `initial_total`, `total_count_stability`
+(`single_observation` | `stable` | `drifted` | `unknown`), `total_drift_detected`, `total_delta`
+(`page_total - initial_total` when both known), and `has_more_basis` — which figure `has_more` was
+computed against, one of `stable_total` | `best_effort_max_observed_total` | `best_effort_page_total` |
+`full_page_heuristic`.
+
+`total` and the `has_more` paging figure are deliberately decoupled (favor completeness without
+wobbling `total`):
+- Drift (both totals known, differ): `total` = baseline; `has_more` paged against
+  `max(initial_total, page_total)`; a warning states the broad total is non-exact and row offsets may
+  also shift. A downward-drift trailing empty page self-terminates via the `count == 0` guard.
+- Known baseline, this page omits `total-count`: `total` = baseline; paged against the baseline
+  (`stable_total`); `stability="unknown"` (the two fields answer different questions and may differ).
+- **No baseline** (page 0 had no `total-count`): `total` stays **`None`** for the whole handle — a
+  baseline-less handle never promotes a later page's count into `total`. `has_more` is still paged
+  against that page's own `page_total` when known (`best_effort_page_total`) so a short page does not
+  stop pagination early; only with no count at all does it fall back to the full-page heuristic.
+
+A handle is **bound to the ADOM** `query_logs` ran under: `fetch_more_logs` rejects a differing `adom`
+(`adom_mismatch`) because a cross-ADOM baseline/page comparison is meaningless.
+
+The registry stores only `initial_total`; `fetch_more_logs` is read-only on the handle context (no
+observation history, no write-back) so concurrent pages on one handle cannot race. The consequence is
+that `has_more` completeness is **best-effort, not guaranteed**: `max()` compares only the baseline vs
+the current page, so non-monotonic drift (high→low→high) can under/over-page by a bounded amount. We
+accept this over reintroducing registry mutation; the `best_effort_*` basis labels and the drift
+warning make the non-exactness explicit. A persisted running max is the documented escape hatch if a
+workload ever needs guaranteed completeness under non-monotonic drift.
+
+## Consequences
+
+- `total` is stable and auditable per handle; consumers comparing `total` across pages no longer see
+  it wobble. The live per-page figure is still available as `page_total`.
+- The meaning of `total` on page ≥ 1 changes from "this page's live count" to "page-0 baseline". This
+  is a public response-contract change; verified safe internally (no caller reads
+  `fetch_more_logs["total"]` — traffic uses its own `total_hits`, PCAP its own page total).
+- We do **not** attempt a FortiAnalyzer-side immutable snapshot (the API does not offer one) and do
+  **not** attempt row-level snapshot consistency (dedup/stable-sort). Broad drifting windows remain
+  non-snapshot-consistent by design; for exact investigations use narrow filters and fixed absolute
+  windows away from "now" rather than deep offset paging through a live high-volume window.
+- `total_count_stability` and `has_more_basis` answer different questions and may legitimately differ
+  (e.g. a later page omitting `total-count` is `stability="unknown"` while `has_more_basis` stays
+  `stable_total` because the baseline is still available).

--- a/src/fortianalyzer_mcp/tools/log_tools.py
+++ b/src/fortianalyzer_mcp/tools/log_tools.py
@@ -536,8 +536,20 @@ async def query_logs(
         dict: Log query results with keys:
             - status: "success" or "error"
             - count: Number of logs returned in this page
-            - total: Total logs matching the query (int), or None if unknown
+            - total: The handle's first-page Baseline total (int), or None if unknown.
+              Stays fixed across fetch_more_logs pages so it does not wobble as the
+              appliance re-counts a frozen window (see page_total for the live count).
             - total_is_known: Whether `total` is authoritative (False => unknown)
+            - page_total: The raw FortiAnalyzer total-count observed for this page's
+              search (the live per-page figure; equals total on page 0)
+            - initial_total: The first-page baseline (equals total on page 0)
+            - total_count_stability: "single_observation" on page 0 (or "unknown" when
+              no count was returned)
+            - total_drift_detected: False on page 0; see fetch_more_logs for drift
+            - total_delta: 0 on page 0 when known, else None
+            - has_more_basis: which figure has_more was computed against
+              ("stable_total" | "best_effort_max_observed_total" |
+              "best_effort_page_total" | "full_page_heuristic")
             - percentage: Search completion percentage (100 on success)
             - tid: Reusable pagination handle (pass to fetch_more_logs)
             - has_more: Whether more results remain beyond this page
@@ -643,6 +655,12 @@ async def query_logs(
         next_offset = offset + count if has_more else None
         handle = page["tid"]
 
+        # Page 0 is the Baseline total for this handle; there is nothing to
+        # compare against yet (see ADR-0002 / fetch_more_logs for drift handling).
+        page0_stability = "single_observation" if total_is_known else "unknown"
+        page0_basis = "stable_total" if total_is_known else "full_page_heuristic"
+        page0_delta = 0 if total_is_known else None
+
         warnings = build_warnings(
             requested_limit=requested_limit,
             limit=limit,
@@ -671,6 +689,7 @@ async def query_logs(
                 "timezone": tz_name,
                 "time_basis_source": time_basis_source,
                 "clock_skew_seconds": clock_skew_seconds,
+                "initial_total": total,
             },
         )
 
@@ -679,6 +698,12 @@ async def query_logs(
             "count": count,
             "total": total,
             "total_is_known": total_is_known,
+            "page_total": total,
+            "initial_total": total,
+            "total_count_stability": page0_stability,
+            "total_drift_detected": False,
+            "total_delta": page0_delta,
+            "has_more_basis": page0_basis,
             "percentage": 100,
             "tid": handle,
             "has_more": has_more,
@@ -798,13 +823,28 @@ async def fetch_more_logs(
             - count: Number of logs returned in this page
             - logs: List of log entries
             - tid, adom, logtype, filter, device: Echoed pagination context
-            - total, total_is_known, has_more: Pagination metadata
+            - total: The handle's first-page Baseline total (stays fixed across pages;
+              None if no baseline was ever captured). It is NOT this page's live count.
+            - page_total: The raw FortiAnalyzer total-count observed for THIS page's
+              re-run search (the live figure; may differ from total on a busy window)
+            - initial_total: The first-page baseline `total` was derived from
+            - total_count_stability: "stable" (page == baseline) | "drifted" (page !=
+              baseline) | "unknown" (no comparable count this page)
+            - total_drift_detected: True when this page's count disagrees with the baseline
+            - total_delta: page_total - initial_total when both known, else None
+            - has_more_basis: which figure has_more was computed against
+              ("stable_total" | "best_effort_max_observed_total" |
+              "best_effort_page_total" | "full_page_heuristic")
+            - total_is_known, has_more: Pagination metadata (total_is_known reflects the
+              baseline `total`)
             - next_offset: Offset for the next page, or None when has_more is False
             - offset, limit: Paging echoes (the clamped values actually used)
             - timezone, time_basis: FAZ timezone context
-            - warnings: Advisory strings
+            - warnings: Advisory strings (incl. a drift notice when total_drift_detected)
         On error, a structured envelope: {status: "error", error: <machine code>,
         message, operation, retry_count, plus tid/adom/recommendation where relevant}.
+        A handle is bound to its ADOM: passing a different `adom` returns
+        error="adom_mismatch".
 
     Example:
         >>> # Get first 100 logs
@@ -831,8 +871,21 @@ async def fetch_more_logs(
                 "search handle is not known to this server process",
             )
 
+        # The handle is bound to the ADOM query_logs ran under: comparing a
+        # baseline from one ADOM against a page from another is meaningless.
         if adom is None:
             adom = context["adom"]
+        elif adom != context["adom"]:
+            return error_response(
+                error="adom_mismatch",
+                message=(
+                    f"This handle is bound to ADOM {context['adom']!r}; it cannot be paged under "
+                    f"ADOM {adom!r}. Re-run query_logs to search a different ADOM."
+                ),
+                operation="fetch_more_logs",
+                adom=adom,
+                tid=tid,
+            )
         adom = validate_adom(adom)
 
         requested_limit = limit
@@ -867,26 +920,86 @@ async def fetch_more_logs(
 
         logs = page["logs"]
         count = len(logs)
-        total = page["total"]
-        total_is_known = total is not None
-        has_more = _compute_has_more(offset, count, limit, total)
-        next_offset = offset + count if has_more else None
+        page_total = page["total"]
+        initial_total = context.get("initial_total")
         timezone = context.get("timezone", "unknown")
         time_basis_source = context.get("time_basis_source", "unknown")
         clock_skew_seconds = context.get("clock_skew_seconds")
 
+        # Compare this page's raw total-count against the first-page Baseline
+        # total. The response `total` is always the baseline (or None when no
+        # baseline was ever captured); `page_total` carries the live observation.
+        # See ADR-0002 for the full branch table.
+        if initial_total is not None and page_total is not None and page_total != initial_total:
+            response_total = initial_total
+            total_count_stability = "drifted"
+            total_drift_detected = True
+            total_delta = page_total - initial_total
+        elif initial_total is not None and page_total == initial_total:
+            response_total = initial_total
+            total_count_stability = "stable"
+            total_drift_detected = False
+            total_delta = 0
+        else:
+            # No comparable pair: either no baseline, or this page omitted the
+            # count. Keep the baseline if we have one, else stay None (unknown).
+            response_total = initial_total
+            total_count_stability = "unknown"
+            total_drift_detected = False
+            total_delta = None
+        total_is_known = response_total is not None
+
+        # has_more is decoupled from the response `total`: page against the best
+        # available figure so a short page never stops paging early (favor
+        # completeness, best-effort -- see ADR-0002).
+        if total_drift_detected:
+            paging_total = max(initial_total, page_total)
+            has_more_basis = "best_effort_max_observed_total"
+        elif initial_total is not None:
+            paging_total = initial_total
+            has_more_basis = "stable_total"
+        elif page_total is not None:
+            paging_total = page_total
+            has_more_basis = "best_effort_page_total"
+        else:
+            paging_total = None
+            has_more_basis = "full_page_heuristic"
+        has_more = _compute_has_more(offset, count, limit, paging_total)
+        next_offset = offset + count if has_more else None
+
+        # Size the high-volume warning on the largest observed total, not the
+        # (possibly smaller) baseline returned as `total`.
         warnings = build_warnings(
             requested_limit=requested_limit,
             limit=limit,
-            total=total,
-            total_is_known=total_is_known,
+            total=paging_total,
+            total_is_known=paging_total is not None,
             timezone=timezone,
             has_more=has_more,
         )
-        if count == 0 and total_is_known and total is not None and total > offset:
+        if count == 0 and paging_total is not None and paging_total > offset:
             warnings.append(
                 "FortiAnalyzer reports more matching rows beyond this offset but returned "
                 "an empty page; the search task may have been reaped -- re-run query_logs."
+            )
+        if total_drift_detected:
+            warnings.append(
+                "FortiAnalyzer total-count changed between pages for this fixed window; total is "
+                "the first-page baseline and page_total is the latest observation. Because this "
+                "query is being re-run for pagination, row offsets may also shift, so duplicate or "
+                "skipped rows are possible. Treat this broad/high-volume result as non-exact."
+            )
+            logger.info(
+                "logsearch total-count drift on handle %s: adom=%s logtype=%s offset=%s "
+                "initial_total=%s page_total=%s delta=%s window=%s",
+                tid,
+                adom,
+                context.get("logtype"),
+                offset,
+                initial_total,
+                page_total,
+                total_delta,
+                redact(str(context.get("time_range"))),
             )
 
         return {
@@ -899,8 +1012,14 @@ async def fetch_more_logs(
             "filter": context.get("filter"),
             "device": context.get("device"),
             "time_range": context.get("time_range"),
-            "total": total,
+            "total": response_total,
             "total_is_known": total_is_known,
+            "page_total": page_total,
+            "initial_total": initial_total,
+            "total_count_stability": total_count_stability,
+            "total_drift_detected": total_drift_detected,
+            "total_delta": total_delta,
+            "has_more_basis": has_more_basis,
             "has_more": has_more,
             "next_offset": next_offset,
             "offset": offset,

--- a/tests/test_log_pagination.py
+++ b/tests/test_log_pagination.py
@@ -72,6 +72,7 @@ class FakeFaz:
         complete_on_attempt: int = 1,
         omit_total: bool = False,
         stall: bool = False,
+        total_overrides: list[int | None] | None = None,
     ) -> None:
         self.dataset = dataset
         self.tz = tz
@@ -79,6 +80,11 @@ class FakeFaz:
         self.complete_on_attempt = complete_on_attempt
         self.omit_total = omit_total
         self.stall = stall
+        # Per-fetch ``total-count`` sequence (models the appliance re-counting a
+        # frozen window across re-run page searches). Each successful fetch pops
+        # the next entry: an int sets ``total-count``; ``None`` omits it entirely
+        # (exercising the unknown path). Exhausted/absent -> len(dataset).
+        self.total_overrides = list(total_overrides) if total_overrides is not None else None
         self.reconnects = 0
         self._tasks: dict[int, dict[str, object]] = {}
         self._next_tid = 1000
@@ -113,7 +119,14 @@ class FakeFaz:
     ) -> dict[str, object]:
         self._start_count += 1
         self.start_calls.append(
-            {"adom": adom, "logtype": logtype, "filter": filter, "offset": offset, "limit": limit}
+            {
+                "adom": adom,
+                "logtype": logtype,
+                "filter": filter,
+                "offset": offset,
+                "limit": limit,
+                "time_range": time_range,
+            }
         )
         tid = self._next_tid
         self._next_tid += 1
@@ -164,7 +177,12 @@ class FakeFaz:
             "tid": tid,
             "status": {"code": 0, "message": "succeeded"},
         }
-        if not self.omit_total:
+        if self.total_overrides:
+            override = self.total_overrides.pop(0)
+            if override is not None:
+                result["total-count"] = override
+            # None -> omit total-count entirely (unknown path)
+        elif not self.omit_total:
             result["total-count"] = len(self.dataset)
         return result
 
@@ -541,3 +559,214 @@ class TestReconnectOnce:
 
         assert more["status"] == "success"
         assert fake.reconnects == 1
+
+
+class TestTotalStability:
+    """Baseline-total contract across re-run pages (ADR-0002).
+
+    A pagination handle's ``total`` is the first-page Baseline total and stays
+    fixed; the raw per-page ``total-count`` is exposed as ``page_total`` and the
+    page is labelled stable/drifted/unknown against the baseline.
+    """
+
+    async def test_stable_total_no_drift(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Equal page totals -> stable; total == baseline, no drift warning."""
+        fake = FakeFaz(_rows(25), total_overrides=[25, 25])
+        _install(monkeypatch, fake)
+
+        first = await log_tools.query_logs(adom="root", time_range=CUSTOM_RANGE, limit=10)
+        more = await log_tools.fetch_more_logs(tid=first["tid"], offset=10, limit=10)
+
+        assert more["status"] == "success"
+        assert more["total"] == 25
+        assert more["page_total"] == 25
+        assert more["initial_total"] == 25
+        assert more["total_count_stability"] == "stable"
+        assert more["total_drift_detected"] is False
+        assert more["total_delta"] == 0
+        assert more["has_more_basis"] == "stable_total"
+        assert not any("baseline" in w for w in more["warnings"])
+
+    async def test_drifted_total_keeps_baseline(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A higher later total -> total stays the page-0 baseline; page_total is
+        the latest; drift is flagged and warned (incl. row-shift caveat)."""
+        fake = FakeFaz(_rows(25), total_overrides=[230071, 230741])
+        _install(monkeypatch, fake)
+
+        first = await log_tools.query_logs(adom="root", time_range=CUSTOM_RANGE, limit=5)
+        assert first["total"] == 230071
+        assert first["initial_total"] == 230071
+        assert first["page_total"] == 230071
+
+        more = await log_tools.fetch_more_logs(tid=first["tid"], offset=5, limit=5)
+
+        assert more["total"] == 230071
+        assert more["page_total"] == 230741
+        assert more["initial_total"] == 230071
+        assert more["total_count_stability"] == "drifted"
+        assert more["total_drift_detected"] is True
+        assert more["total_delta"] == 670
+        assert more["has_more_basis"] == "best_effort_max_observed_total"
+        assert any("row offsets may also shift" in w for w in more["warnings"])
+        assert any("baseline" in w for w in more["warnings"])
+
+    async def test_drifted_has_more_uses_max_observed(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """has_more on drift is computed from max(initial, page_total): a baseline
+        of 10 must not stop paging when the page reports 1000 rows."""
+        fake = FakeFaz(_rows(10), total_overrides=[10, 1000])
+        _install(monkeypatch, fake)
+
+        first = await log_tools.query_logs(adom="root", time_range=CUSTOM_RANGE, limit=5)
+        more = await log_tools.fetch_more_logs(tid=first["tid"], offset=5, limit=5)
+
+        assert more["page_total"] == 1000
+        assert more["total"] == 10  # baseline preserved
+        assert more["has_more_basis"] == "best_effort_max_observed_total"
+        # (offset+count)=10 < max(10,1000) -> keep paging (baseline alone would stop).
+        assert more["has_more"] is True
+
+    async def test_query_logs_unknown_total_fields(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Page 0 with no total-count: total None, unknown stability, heuristic basis."""
+        fake = FakeFaz(_rows(50), omit_total=True)
+        _install(monkeypatch, fake)
+
+        r = await log_tools.query_logs(adom="root", time_range=CUSTOM_RANGE, limit=10)
+
+        assert r["total"] is None
+        assert r["page_total"] is None
+        assert r["initial_total"] is None
+        assert r["total_count_stability"] == "unknown"
+        assert r["total_drift_detected"] is False
+        assert r["total_delta"] is None
+        assert r["has_more_basis"] == "full_page_heuristic"
+
+    async def test_query_logs_page0_single_observation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Page 0 with a known total -> single_observation, delta 0, stable_total basis."""
+        fake = FakeFaz(_rows(25))
+        _install(monkeypatch, fake)
+
+        r = await log_tools.query_logs(adom="root", time_range=CUSTOM_RANGE, limit=10)
+
+        assert r["page_total"] == 25
+        assert r["initial_total"] == 25
+        assert r["total_count_stability"] == "single_observation"
+        assert r["total_drift_detected"] is False
+        assert r["total_delta"] == 0
+        assert r["has_more_basis"] == "stable_total"
+
+    async def test_no_baseline_never_promotes(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Page 0 omits total-count: total stays None for the whole handle even
+        when a later page returns a count (page_total still surfaced)."""
+        fake = FakeFaz(_rows(8), total_overrides=[None, 230741])
+        _install(monkeypatch, fake)
+
+        first = await log_tools.query_logs(adom="root", time_range=CUSTOM_RANGE, limit=5)
+        assert first["total"] is None
+        assert first["page_total"] is None
+
+        more = await log_tools.fetch_more_logs(tid=first["tid"], offset=5, limit=5)
+
+        assert more["total"] is None
+        assert more["page_total"] == 230741
+        assert more["initial_total"] is None
+        assert more["total_count_stability"] == "unknown"
+        assert more["total_drift_detected"] is False
+        assert more["has_more_basis"] == "best_effort_page_total"
+
+    async def test_no_baseline_short_page_does_not_stop_early(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No baseline + a short page must page off page_total, not the full-page
+        heuristic (which would stop early and hide rows)."""
+        fake = FakeFaz(_rows(8), total_overrides=[None, 1000])
+        _install(monkeypatch, fake)
+
+        first = await log_tools.query_logs(adom="root", time_range=CUSTOM_RANGE, limit=5)
+        more = await log_tools.fetch_more_logs(tid=first["tid"], offset=5, limit=5)
+
+        assert more["count"] < 5  # rows[5:8] -> 3 rows, a short page
+        assert more["total"] is None
+        assert more["page_total"] == 1000
+        assert more["has_more_basis"] == "best_effort_page_total"
+        assert more["has_more"] is True  # 8 < 1000, would be False under the heuristic
+
+    async def test_known_baseline_page_omits_total(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Known baseline + a later page missing total-count: total stays the
+        baseline, stability unknown, has_more paged against the baseline."""
+        fake = FakeFaz(_rows(25), total_overrides=[25, None])
+        _install(monkeypatch, fake)
+
+        first = await log_tools.query_logs(adom="root", time_range=CUSTOM_RANGE, limit=10)
+        more = await log_tools.fetch_more_logs(tid=first["tid"], offset=10, limit=10)
+
+        assert more["total"] == 25
+        assert more["page_total"] is None
+        assert more["initial_total"] == 25
+        assert more["total_count_stability"] == "unknown"
+        assert more["total_drift_detected"] is False
+        assert more["total_delta"] is None
+        assert more["has_more_basis"] == "stable_total"
+
+    async def test_adom_mismatch_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A differing ADOM is rejected (the handle is bound to its ADOM); reuse
+        and exact-match proceed."""
+        fake = FakeFaz(_rows(25))
+        _install(monkeypatch, fake)
+
+        first = await log_tools.query_logs(adom="root", time_range=CUSTOM_RANGE, limit=10)
+        tid = first["tid"]
+        assert len(fake.start_calls) == 1
+
+        bad = await log_tools.fetch_more_logs(tid=tid, adom="other", offset=10, limit=10)
+        assert bad["status"] == "error"
+        assert bad["error"] == "adom_mismatch"
+        assert len(fake.start_calls) == 1  # no search was issued
+
+        ok = await log_tools.fetch_more_logs(tid=tid, adom="root", offset=10, limit=10)
+        assert ok["status"] == "success"
+        assert len(fake.start_calls) == 2
+
+    async def test_frozen_window_relative_preset(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A relative preset is resolved to an absolute window at page 0 and the
+        same absolute window is re-sent on later pages (frozen, not sliding)."""
+        fake = FakeFaz(_rows(25), tz=ZoneInfo("UTC"))
+        _install(monkeypatch, fake)
+
+        first = await log_tools.query_logs(adom="root", time_range="1-hour", limit=10)
+        tid = first["tid"]
+        ctx = log_tools._SEARCH_REGISTRY[tid]
+        assert set(ctx["time_range"].keys()) == {"start", "end"}  # resolved, not "1-hour"
+
+        await log_tools.fetch_more_logs(tid=tid, offset=10, limit=10)
+
+        # The page-1 re-run search carries the same frozen absolute window.
+        assert fake.start_calls[1]["time_range"] == ctx["time_range"]
+
+    async def test_non_monotonic_drift_is_bounded(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """high -> low -> high totals: total stays the baseline, has_more pages
+        against max(initial, current) each page, no crash, clean stop on empty."""
+        fake = FakeFaz(_rows(20), total_overrides=[240000, 230000, 240500])
+        _install(monkeypatch, fake)
+
+        first = await log_tools.query_logs(adom="root", time_range=CUSTOM_RANGE, limit=5)
+        assert first["initial_total"] == 240000
+
+        more1 = await log_tools.fetch_more_logs(tid=first["tid"], offset=5, limit=5)
+        assert more1["total"] == 240000
+        assert more1["page_total"] == 230000
+        assert more1["total_delta"] == -10000
+        assert more1["has_more_basis"] == "best_effort_max_observed_total"
+
+        more2 = await log_tools.fetch_more_logs(tid=first["tid"], offset=10, limit=5)
+        assert more2["total"] == 240000
+        assert more2["page_total"] == 240500
+        assert more2["total_delta"] == 500
+
+        # Beyond the dataset: an empty page stops paging cleanly regardless of total.
+        more3 = await log_tools.fetch_more_logs(tid=first["tid"], offset=20, limit=5)
+        assert more3["count"] == 0
+        assert more3["has_more"] is False


### PR DESCRIPTION
## Summary

`query_logs` / `fetch_more_logs` now report a `total` that stays fixed for the life of a pagination session, instead of echoing each page's freshly-counted `total-count`. The live per-page count is still available as `page_total`, and any drift between them is surfaced explicitly rather than silently changing the headline number.

## Background

Since #18, paging a log result re-runs the underlying search per page over a frozen absolute window (single-use-tid, poll-before-fetch). FortiAnalyzer's `total-count` is only authoritative for one completed search; across the independent per-page re-runs it can move as rows keep indexing into that fixed window after page 0.

Observed on a 7.6.7 appliance: an unfiltered 1-hour traffic query reported `total-count` 230071 on page 0 and 230741 on page 1 of the same handle. The window bounds never changed and no rows were dropped or duplicated — only the appliance's running count moved. So the symptom was a wobbling headline `total` within one session: a response-contract question (which number is "the total" for this handle?), not a row-paging bug.

## What this changes

**Baseline `total`.** Page 0's `total-count` is captured as the handle's baseline and returned as `total` for every later page. A handle that never captured a baseline returns `total: null` rather than promoting a later page's count into the slot.

**New response fields** (additive — existing fields unchanged):
- `page_total` — live `total-count` for the current page.
- `total_count_stability` — `single_observation` (page 0), `stable`, `drifted`, or `unknown` (no baseline).
- `total_drift_detected` — boolean shortcut for `stability == drifted`.
- `total_delta` — `page_total − baseline` when drift is seen.
- `has_more_basis` — which figure `has_more` was computed against (`stable_total` / `best_effort_max_observed_total` / `best_effort_page_total` / `full_page_heuristic`).

**`has_more` decoupled from `total`.** Paging compares rows-so-far against the best figure observed (the max when the count drifts upward, `page_total` when there's no baseline), so a transiently smaller count never stops pagination early and hides rows.

**ADOM-bound handles.** A handle is tied to the ADOM it was created in; reuse against a different ADOM returns `adom_mismatch`, since comparing a baseline from one ADOM to a page from another is meaningless.

**Drift stays visible.** When a later page's count diverges from the baseline, the response carries a non-exact warning (row offsets may shift under an actively-growing window) and emits a redacted `logger.info`. The high-volume warning is sized on the largest count seen.

Scope: response-contract only — no FortiAnalyzer-side snapshotting or row-level cross-page consistency. The window is already frozen; this just stops the reported count from misrepresenting it.

## Testing

- 11 new regression tests using a drift-capable fake (different `total-count` per page), covering baseline capture/hold, drift detection and stability transitions, `has_more` basis selection (including short-page-doesn't-stop-early), the `total: null` no-baseline path, and the ADOM guard. Full suite: **540 passed**.
- Verified end-to-end on a live 7.6.7 appliance across 1-day / 7-day / 30-day windows. In the 30-day run the appliance re-counted mid-pagination (`page_total` +703) while `total` held the baseline and the change surfaced as `total_count_stability=drifted`, `total_delta=703`, `has_more_basis=best_effort_max_observed_total`. Pagination stayed page-consistent (no duplicated or skipped rows), and the #18 search-slot behaviour was unaffected.

Decision record: `docs/adr/0002-baseline-total-for-pagination-handle.md`.
