### PR TITLE
harden: redact remaining tool error messages + warn when TLS verification disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to FortiAnalyzer MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2026-06-10
+
+### Security
+- **Tool error responses no longer echo raw exception text.** The dvm/event/fortiview/incident/ioc/pcap/report/system and log tools returned `str(e)` directly in error responses, bypassing the `redact()` the log/traffic tools already applied; all such sites now route through `redact()` so echoed-back parameters and FortiAnalyzer internals (token, host, session id) cannot leak into a tool response.
+- **Warning when TLS verification is disabled.** Connecting with `FORTIANALYZER_VERIFY_SSL=false` now logs a one-time `WARNING` at connect time — the FortiAnalyzer API token and all log/PCAP data are exposed to man-in-the-middle interception — pointing operators toward trusting the FAZ CA instead.
+
 ## [2.1.0] - 2026-06-10
 
 Stable baseline `total` across pagination handles, plus drift observability and ADOM-bound handles. PR [#19](https://github.com/rstierli/fortianalyzer-mcp/pull/19) by [@inxbit](https://github.com/inxbit). 540 unit tests pass; live-verified end-to-end on a 7.6.7 appliance across 1d/7d/30d windows.

--- a/src/fortianalyzer_mcp/api/client.py
+++ b/src/fortianalyzer_mcp/api/client.py
@@ -101,6 +101,12 @@ class FortiAnalyzerClient:
             return
 
         logger.info("Connecting to FortiAnalyzer")
+        if not self.verify_ssl:
+            logger.warning(
+                "TLS verification is DISABLED (FORTIANALYZER_VERIFY_SSL=false) -- the FortiAnalyzer "
+                "API token and all log/PCAP data are exposed to man-in-the-middle interception. "
+                "Prefer trusting the FAZ CA (set the CA bundle) over disabling verification."
+            )
 
         try:
             if self.api_token:

--- a/src/fortianalyzer_mcp/tools/dvm_tools.py
+++ b/src/fortianalyzer_mcp/tools/dvm_tools.py
@@ -9,6 +9,7 @@ import logging
 from typing import Any
 
 from fortianalyzer_mcp.server import get_faz_client, mcp
+from fortianalyzer_mcp.utils.responses import redact
 from fortianalyzer_mcp.utils.validation import get_default_adom
 
 logger = logging.getLogger(__name__)
@@ -62,7 +63,7 @@ async def list_device_groups(
         }
     except Exception as e:
         logger.error(f"Failed to list device groups: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -103,7 +104,7 @@ async def list_device_vdoms(
         }
     except Exception as e:
         logger.error(f"Failed to list VDOMs for device {device}: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 # =============================================================================
@@ -216,7 +217,7 @@ async def add_device(
         }
     except Exception as e:
         logger.error(f"Failed to add device {name}: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -264,7 +265,7 @@ async def delete_device(
         }
     except Exception as e:
         logger.error(f"Failed to delete device {device}: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -328,7 +329,7 @@ async def add_devices_bulk(
         }
     except Exception as e:
         logger.error(f"Failed to add devices in bulk: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -380,7 +381,7 @@ async def delete_devices_bulk(
         }
     except Exception as e:
         logger.error(f"Failed to delete devices in bulk: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -427,7 +428,7 @@ async def get_device_info(
         return result
     except Exception as e:
         logger.error(f"Failed to get device info for {device}: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -490,4 +491,4 @@ async def search_devices(
         }
     except Exception as e:
         logger.error(f"Failed to search devices: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}

--- a/src/fortianalyzer_mcp/tools/event_tools.py
+++ b/src/fortianalyzer_mcp/tools/event_tools.py
@@ -8,6 +8,7 @@ import logging
 from typing import Any
 
 from fortianalyzer_mcp.server import get_faz_client, mcp
+from fortianalyzer_mcp.utils.responses import redact
 from fortianalyzer_mcp.utils.time_range import parse_time_range
 from fortianalyzer_mcp.utils.validation import get_default_adom
 
@@ -94,7 +95,7 @@ async def get_alerts(
         }
     except Exception as e:
         logger.error(f"Failed to get alerts: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -134,7 +135,7 @@ async def get_alert_count(
         }
     except Exception as e:
         logger.error(f"Failed to get alert count: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -176,7 +177,7 @@ async def acknowledge_alerts(
         }
     except Exception as e:
         logger.error(f"Failed to acknowledge alerts: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -218,7 +219,7 @@ async def unacknowledge_alerts(
         }
     except Exception as e:
         logger.error(f"Failed to unacknowledge alerts: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -262,7 +263,7 @@ async def get_alert_logs(
         }
     except Exception as e:
         logger.error(f"Failed to get alert logs: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -300,7 +301,7 @@ async def get_alert_details(
         }
     except Exception as e:
         logger.error(f"Failed to get alert details: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -345,7 +346,7 @@ async def add_alert_comment(
         }
     except Exception as e:
         logger.error(f"Failed to add alert comment: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -391,4 +392,4 @@ async def get_alert_incident_stats(
         }
     except Exception as e:
         logger.error(f"Failed to get alert-incident stats: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}

--- a/src/fortianalyzer_mcp/tools/fortiview_tools.py
+++ b/src/fortianalyzer_mcp/tools/fortiview_tools.py
@@ -9,6 +9,7 @@ import logging
 from typing import Any
 
 from fortianalyzer_mcp.server import get_faz_client, mcp
+from fortianalyzer_mcp.utils.responses import redact
 from fortianalyzer_mcp.utils.time_range import parse_time_range
 from fortianalyzer_mcp.utils.validation import (
     ValidationError,
@@ -141,7 +142,7 @@ async def run_fortiview(
         return {"status": "error", "message": f"Validation error: {e}"}
     except Exception as e:
         logger.error(f"Failed to start FortiView query: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -192,7 +193,7 @@ async def fetch_fortiview(
         }
     except Exception as e:
         logger.error(f"Failed to fetch FortiView results: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -319,7 +320,7 @@ async def get_fortiview_data(
         return {"status": "error", "message": f"Validation error: {e}"}
     except Exception as e:
         logger.error(f"Failed to get FortiView data: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()

--- a/src/fortianalyzer_mcp/tools/incident_tools.py
+++ b/src/fortianalyzer_mcp/tools/incident_tools.py
@@ -8,6 +8,7 @@ import logging
 from typing import Any
 
 from fortianalyzer_mcp.server import get_faz_client, mcp
+from fortianalyzer_mcp.utils.responses import redact
 from fortianalyzer_mcp.utils.time_range import parse_time_range
 from fortianalyzer_mcp.utils.validation import get_default_adom
 
@@ -95,7 +96,7 @@ async def get_incidents(
         }
     except Exception as e:
         logger.error(f"Failed to get incidents: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -137,7 +138,7 @@ async def get_incident(
         }
     except Exception as e:
         logger.error(f"Failed to get incident {incident_id}: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -181,7 +182,7 @@ async def get_incident_count(
         }
     except Exception as e:
         logger.error(f"Failed to get incident count: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -241,7 +242,7 @@ async def create_incident(
         }
     except Exception as e:
         logger.error(f"Failed to create incident: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -300,7 +301,7 @@ async def update_incident(
         }
     except Exception as e:
         logger.error(f"Failed to update incident {incident_id}: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -353,4 +354,4 @@ async def get_incident_stats(
         }
     except Exception as e:
         logger.error(f"Failed to get incident stats: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}

--- a/src/fortianalyzer_mcp/tools/ioc_tools.py
+++ b/src/fortianalyzer_mcp/tools/ioc_tools.py
@@ -9,6 +9,7 @@ import logging
 from typing import Any
 
 from fortianalyzer_mcp.server import get_faz_client, mcp
+from fortianalyzer_mcp.utils.responses import redact
 from fortianalyzer_mcp.utils.time_range import parse_time_range
 from fortianalyzer_mcp.utils.validation import get_default_adom
 
@@ -66,7 +67,7 @@ async def get_ioc_license_state() -> dict[str, Any]:
         }
     except Exception as e:
         logger.error(f"Failed to get IOC license state: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -114,7 +115,7 @@ async def acknowledge_ioc_events(
         }
     except Exception as e:
         logger.error(f"Failed to acknowledge IOC events: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -166,7 +167,7 @@ async def run_ioc_rescan(
         }
     except Exception as e:
         logger.error(f"Failed to start IOC rescan: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -208,7 +209,7 @@ async def get_ioc_rescan_status(
         }
     except Exception as e:
         logger.error(f"Failed to get IOC rescan status: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -260,7 +261,7 @@ async def get_ioc_rescan_history(
         }
     except Exception as e:
         logger.error(f"Failed to get IOC rescan history: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -350,4 +351,4 @@ async def run_and_wait_ioc_rescan(
 
     except Exception as e:
         logger.error(f"Failed to run and wait for IOC rescan: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}

--- a/src/fortianalyzer_mcp/tools/log_tools.py
+++ b/src/fortianalyzer_mcp/tools/log_tools.py
@@ -1145,7 +1145,7 @@ async def get_log_stats(
         }
     except Exception as e:
         logger.error(f"Failed to get log stats for ADOM {adom}: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -1184,7 +1184,7 @@ async def get_log_fields(
         }
     except Exception as e:
         logger.error(f"Failed to get log fields: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -1525,7 +1525,7 @@ async def get_logfiles_state(
         }
     except Exception as e:
         logger.error(f"Failed to get log files state: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -1578,4 +1578,4 @@ async def get_pcap_file(
         return {"status": "error", "message": f"Validation error: {e}"}
     except Exception as e:
         logger.error(f"Failed to get PCAP file: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}

--- a/src/fortianalyzer_mcp/tools/pcap_tools.py
+++ b/src/fortianalyzer_mcp/tools/pcap_tools.py
@@ -17,6 +17,7 @@ from typing import Any
 
 from fortianalyzer_mcp.server import get_faz_client, mcp
 from fortianalyzer_mcp.tools.log_tools import _clamp_timeout, _run_logsearch_page
+from fortianalyzer_mcp.utils.responses import redact
 from fortianalyzer_mcp.utils.time_range import parse_time_range
 from fortianalyzer_mcp.utils.validation import (
     ValidationError,
@@ -341,7 +342,7 @@ async def search_ips_logs(
         return {"status": "error", "message": f"Validation error: {e}"}
     except Exception as e:
         logger.error(f"Failed to search IPS logs: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -554,7 +555,7 @@ async def get_pcap_by_session(
         return {"status": "error", "message": f"Validation error: {e}"}
     except Exception as e:
         logger.error(f"Failed to download PCAP for session {session_id}: {e}")
-        return {"status": "error", "session_id": session_id, "message": str(e)}
+        return {"status": "error", "session_id": session_id, "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -672,7 +673,7 @@ async def download_pcap_by_url(
         return {"status": "error", "message": f"Validation error: {e}"}
     except Exception as e:
         logger.error(f"Failed to download PCAP: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -892,7 +893,7 @@ async def search_and_download_pcaps(
         return {"status": "error", "message": f"Validation error: {e}"}
     except Exception as e:
         logger.error(f"Failed to search and download PCAPs: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -995,4 +996,4 @@ async def list_available_pcaps(
         return {"status": "error", "message": f"Validation error: {e}"}
     except Exception as e:
         logger.error(f"Failed to list available PCAPs: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}

--- a/src/fortianalyzer_mcp/tools/report_tools.py
+++ b/src/fortianalyzer_mcp/tools/report_tools.py
@@ -13,6 +13,7 @@ import zipfile
 from typing import Any
 
 from fortianalyzer_mcp.server import get_faz_client, mcp
+from fortianalyzer_mcp.utils.responses import redact
 from fortianalyzer_mcp.utils.time_range import parse_time_range
 from fortianalyzer_mcp.utils.validation import (
     ValidationError,
@@ -228,7 +229,7 @@ async def list_report_layouts(adom: str | None = None) -> dict[str, Any]:
         }
     except Exception as e:
         logger.error(f"Failed to list report layouts: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -343,7 +344,7 @@ async def run_report(
         }
     except Exception as e:
         logger.error(f"Failed to run report '{layout}': {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -382,7 +383,7 @@ async def fetch_report(
         }
     except Exception as e:
         logger.error(f"Failed to fetch report status: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -432,7 +433,7 @@ async def get_report_data(
         }
     except Exception as e:
         logger.error(f"Failed to get report data: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -475,7 +476,7 @@ async def get_running_reports(
         }
     except Exception as e:
         logger.error(f"Failed to get running reports: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -527,7 +528,7 @@ async def get_report_history(
         }
     except Exception as e:
         logger.error(f"Failed to get report history: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -685,7 +686,7 @@ async def run_and_wait_report(
 
     except Exception as e:
         logger.error(f"Failed to run and wait for report '{layout}': {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -850,4 +851,4 @@ async def save_report(
         return {"status": "error", "message": f"Validation error: {e}"}
     except Exception as e:
         logger.error(f"Failed to save report: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}

--- a/src/fortianalyzer_mcp/tools/system_tools.py
+++ b/src/fortianalyzer_mcp/tools/system_tools.py
@@ -7,6 +7,7 @@ import logging
 from typing import Any
 
 from fortianalyzer_mcp.server import get_faz_client, mcp
+from fortianalyzer_mcp.utils.responses import redact
 from fortianalyzer_mcp.utils.validation import get_default_adom
 
 logger = logging.getLogger(__name__)
@@ -57,7 +58,7 @@ async def get_system_status() -> dict[str, Any]:
         }
     except Exception as e:
         logger.error(f"Failed to get system status: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -89,7 +90,7 @@ async def get_ha_status() -> dict[str, Any]:
         }
     except Exception as e:
         logger.error(f"Failed to get HA status: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 # =============================================================================
@@ -131,7 +132,7 @@ async def list_adoms(
         }
     except Exception as e:
         logger.error(f"Failed to list ADOMs: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -166,7 +167,7 @@ async def get_adom(
         }
     except Exception as e:
         logger.error(f"Failed to get ADOM {name}: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 # =============================================================================
@@ -211,7 +212,7 @@ async def list_devices(
         }
     except Exception as e:
         logger.error(f"Failed to list devices in ADOM {adom}: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -249,7 +250,7 @@ async def get_device(
         }
     except Exception as e:
         logger.error(f"Failed to get device {name}: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 # =============================================================================
@@ -307,7 +308,7 @@ async def list_tasks(
         }
     except Exception as e:
         logger.error(f"Failed to list tasks: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -349,7 +350,7 @@ async def get_task(
         return result
     except Exception as e:
         logger.error(f"Failed to get task {task_id}: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -412,7 +413,7 @@ async def wait_for_task(
 
     except Exception as e:
         logger.error(f"Failed to wait for task {task_id}: {e}")
-        return {"status": "error", "completed": False, "message": str(e)}
+        return {"status": "error", "completed": False, "message": redact(str(e))}
 
 
 # =============================================================================
@@ -452,7 +453,7 @@ async def get_api_ratelimit() -> dict[str, Any]:
         }
     except Exception as e:
         logger.error(f"Failed to get API rate limit: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}
 
 
 @mcp.tool()
@@ -518,4 +519,4 @@ async def update_api_ratelimit(
         }
     except Exception as e:
         logger.error(f"Failed to update API rate limit: {e}")
-        return {"status": "error", "message": str(e)}
+        return {"status": "error", "message": redact(str(e))}


### PR DESCRIPTION
Closes #22 — both items.

## Redact tool error messages

The dvm / event / fortiview / incident / ioc / pcap / report / system and log tools returned `str(e)` directly in their error responses, bypassing the `redact()` the log/traffic tools already apply. A FortiAnalyzer or HTTP error can carry the API token, host, or session id in its text, so those strings could leak into a tool response (and anything that captures it). Every such site now routes through `redact()` — no API-surface change, the error `message` is just scrubbed.

## Warn when `FORTIANALYZER_VERIFY_SSL=false`

Disabling TLS verification silently exposes the API token and all log/PCAP data to man-in-the-middle interception. Now that verification defaults to `true` (v1.3.0), anyone hitting this has explicitly opted into insecure — so a single `WARNING` at connect time (no log spam) makes the trade-off visible and points toward trusting the FAZ CA instead.

## Notes
- CHANGELOG entry under `[2.1.1]` per your note on #22.
- Full suite: **540 tests pass**.
- Atomic commit (code + CHANGELOG), same pattern as #19.
