### PR TITLE
ci: security job (bandit + pip-audit) + SHA-pinned 3rd-party actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "latest"
 
@@ -49,7 +49,7 @@ jobs:
           uv run pytest tests/ --ignore=tests/integration --cov=src/fortianalyzer_mcp --cov-report=xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@f2274c2c340e0c81c8f7dc407b2a477b8935f171 # v6
         if: matrix.python-version == '3.12'
         with:
           files: ./coverage.xml
@@ -66,7 +66,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           version: "latest"
 
@@ -82,3 +82,31 @@ jobs:
       - name: Check linting
         run: |
           uv run ruff check src/ tests/
+
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version: "latest"
+
+      - name: Install dependencies
+        run: |
+          uv venv
+          uv sync --all-extras
+
+      - name: Dependency vulnerability audit (pip-audit)
+        run: |
+          uv run --with pip-audit -- pip-audit --desc
+
+      - name: Static security analysis (bandit)
+        run: |
+          uv run --with bandit -- bandit -r src/ -ll -ii

--- a/src/fortianalyzer_mcp/utils/config.py
+++ b/src/fortianalyzer_mcp/utils/config.py
@@ -72,7 +72,10 @@ class Settings(BaseSettings):
 
     # MCP Server Settings
     MCP_SERVER_HOST: str = Field(
-        default="0.0.0.0",
+        # Operator-controlled bind. 0.0.0.0 is intended for Docker / reverse-proxy
+        # deployments; pair it with MCP_AUTH_TOKEN so the HTTP transport requires
+        # Bearer auth on a non-loopback bind.
+        default="0.0.0.0",  # nosec B104
         description="MCP server bind address",
     )
 


### PR DESCRIPTION
Closes #21 — both items.

## `security` CI job

Adds a `security` job running `pip-audit` (dependency CVEs) and `bandit -r src/ -ll -ii` (SAST) on every push/PR.

First run is green: pip-audit finds no known vulnerabilities, and bandit's only `-ll -ii` finding is the `0.0.0.0` default bind (B104). I've annotated that inline with a justification rather than suppressing globally — it's an operator-controlled bind intended for Docker/reverse-proxy, meant to be paired with `MCP_AUTH_TOKEN`. If you'd rather raise the bar later (`-l -i`), it'll surface a couple of low-severity items (e.g. a best-effort `try/except/pass`) to annotate.

## SHA-pinned 3rd-party actions

Pins `codecov/codecov-action` and `astral-sh/setup-uv` to commit SHAs, with the version kept in a trailing `# vX.Y.Z` comment so Renovate-bumped PRs stay readable in review. First-party `actions/*` left on tags per your note.

## Notes
- Internal CI only — no version bump, no CHANGELOG entry.
- Full suite: **540 tests pass**; bandit and pip-audit both green locally.
