### PR TITLE
harden(http): fail closed when MCP_AUTH_TOKEN is unset (v2.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to FortiAnalyzer MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.0] - 2026-06-11
+
+Fail closed: the streamable-HTTP transport now refuses to start without `MCP_AUTH_TOKEN` unless the operator explicitly opts out with `MCP_ALLOW_NO_AUTH=true`. PR [#25](https://github.com/rstierli/fortianalyzer-mcp/pull/25) by [@inxbit](https://github.com/inxbit). Closes [#20](https://github.com/rstierli/fortianalyzer-mcp/issues/20). 544 unit tests pass.
+
+### Changed
+- **The HTTP transport now fails closed when `MCP_AUTH_TOKEN` is unset.** The streamable-HTTP server fronts the full tool surface (including device add/delete and PCAP download), so it previously could serve everything unauthenticated if the token was simply forgotten. `run_http()` now refuses to start without a token and exits with a message that names the fix, unless the operator explicitly opts out with `MCP_ALLOW_NO_AUTH=true` (logged at CRITICAL; intended only for a trusted, isolated bind such as 127.0.0.1 behind a gateway). **Upgrade note:** a deployment that ran on a `0.0.0.0` bind without a token must now set either `MCP_AUTH_TOKEN` or `MCP_ALLOW_NO_AUTH=true` to keep starting.
+
+### Added
+- `MCP_ALLOW_NO_AUTH` setting (default `false`) — the explicit opt-out for running HTTP without a token. 4 tests cover token-set start, no-token fail-closed, empty-token fail-closed, and the explicit opt-out.
+
 ## [2.1.1] - 2026-06-11
 
 Security hardening: redact remaining tool error messages + warn when TLS verification is disabled. PR [#23](https://github.com/rstierli/fortianalyzer-mcp/pull/23) by [@inxbit](https://github.com/inxbit). Closes [#22](https://github.com/rstierli/fortianalyzer-mcp/issues/22). 540 unit tests pass.

--- a/src/fortianalyzer_mcp/server.py
+++ b/src/fortianalyzer_mcp/server.py
@@ -463,8 +463,39 @@ def run_stdio() -> None:
     asyncio.run(stdio_main())
 
 
+def _ensure_http_auth_or_die() -> None:
+    """Fail closed: refuse to expose the HTTP transport without authentication.
+
+    The HTTP server fronts the full tool surface (including destructive device
+    add/delete and PCAP download), so it must never run unauthenticated. Require
+    ``MCP_AUTH_TOKEN`` unless the operator explicitly opts out with
+    ``MCP_ALLOW_NO_AUTH=true`` (only safe on a trusted, isolated bind such as
+    127.0.0.1 behind a gateway), in which case we log a CRITICAL warning.
+
+    Raises ``SystemExit`` when no token is configured and the opt-out is not set.
+    """
+    if settings.MCP_AUTH_TOKEN:
+        return
+    if not settings.MCP_ALLOW_NO_AUTH:
+        raise SystemExit(
+            "FATAL: refusing to start the HTTP transport without MCP_AUTH_TOKEN -- every "
+            "tool (including device add/delete and PCAP download) would be exposed "
+            "unauthenticated. Set a token (e.g. `openssl rand -hex 32`), or set "
+            "MCP_ALLOW_NO_AUTH=true to explicitly run without auth (not recommended; only "
+            "safe on a trusted, isolated bind such as 127.0.0.1 behind a gateway)."
+        )
+    logger.critical(
+        "MCP_ALLOW_NO_AUTH=true: HTTP transport is running WITHOUT authentication on "
+        "%s:%s -- every tool is exposed to anyone who can reach this port.",
+        settings.MCP_SERVER_HOST,
+        settings.MCP_SERVER_PORT,
+    )
+
+
 def run_http() -> None:
     """Run MCP server in HTTP mode for Docker deployment."""
+    _ensure_http_auth_or_die()
+
     import json
     from contextlib import asynccontextmanager
 
@@ -487,7 +518,9 @@ def run_http() -> None:
                 await self.app(scope, receive, send)
                 return
 
-            # Skip auth if no token configured (backwards compatible)
+            # No token => unauthenticated mode. run_http() only reaches here when
+            # the operator explicitly set MCP_ALLOW_NO_AUTH=true (otherwise it
+            # refuses to start), so this is an acknowledged, logged opt-out.
             if not settings.MCP_AUTH_TOKEN:
                 await self.app(scope, receive, send)
                 return

--- a/src/fortianalyzer_mcp/utils/config.py
+++ b/src/fortianalyzer_mcp/utils/config.py
@@ -99,6 +99,14 @@ class Settings(BaseSettings):
         "must include Authorization: Bearer <token>",
     )
 
+    MCP_ALLOW_NO_AUTH: bool = Field(
+        default=False,
+        description="Explicit opt-out to run the HTTP transport WITHOUT authentication when "
+        "MCP_AUTH_TOKEN is unset. Default False = fail closed: the HTTP server refuses to start "
+        "without a token, so destructive tools are never exposed unauthenticated. Only enable on "
+        "a trusted, isolated bind (e.g. 127.0.0.1 behind a gateway).",
+    )
+
     # MCP Allowed Hosts (for reverse proxy / Docker deployments)
     MCP_ALLOWED_HOSTS: list[str] = Field(
         default_factory=list,

--- a/tests/test_server_auth.py
+++ b/tests/test_server_auth.py
@@ -1,0 +1,39 @@
+"""Fail-closed HTTP auth guard (security regression).
+
+The HTTP transport fronts the full tool surface (incl. destructive device
+add/delete and PCAP download), so it must refuse to start unauthenticated unless
+the operator explicitly opts out with MCP_ALLOW_NO_AUTH=true.
+"""
+
+import pytest
+
+import fortianalyzer_mcp.server as server
+
+
+class TestHttpAuthFailClosed:
+    def test_token_set_allows_start(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A configured token satisfies the guard."""
+        monkeypatch.setattr(server.settings, "MCP_AUTH_TOKEN", "secret-token")
+        monkeypatch.setattr(server.settings, "MCP_ALLOW_NO_AUTH", False)
+        server._ensure_http_auth_or_die()  # must not raise
+
+    def test_no_token_no_optout_fails_closed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No token + no opt-out => refuse to start (SystemExit)."""
+        monkeypatch.setattr(server.settings, "MCP_AUTH_TOKEN", None)
+        monkeypatch.setattr(server.settings, "MCP_ALLOW_NO_AUTH", False)
+        with pytest.raises(SystemExit) as exc:
+            server._ensure_http_auth_or_die()
+        assert "MCP_AUTH_TOKEN" in str(exc.value)
+
+    def test_no_token_empty_string_fails_closed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An empty-string token (the Docker default) is treated as unset."""
+        monkeypatch.setattr(server.settings, "MCP_AUTH_TOKEN", "")
+        monkeypatch.setattr(server.settings, "MCP_ALLOW_NO_AUTH", False)
+        with pytest.raises(SystemExit):
+            server._ensure_http_auth_or_die()
+
+    def test_explicit_optout_allows_no_auth(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Explicit MCP_ALLOW_NO_AUTH=true permits unauthenticated start (logged)."""
+        monkeypatch.setattr(server.settings, "MCP_AUTH_TOKEN", None)
+        monkeypatch.setattr(server.settings, "MCP_ALLOW_NO_AUTH", True)
+        server._ensure_http_auth_or_die()  # must not raise


### PR DESCRIPTION
Closes #20.

Following up on our discussion in #20 — here's the fail-closed auth change, tagged **v2.2.0** as you suggested, with the startup error naming the `MCP_ALLOW_NO_AUTH=true` escape hatch by name.

## The problem

The streamable-HTTP transport fronts the entire tool surface — including device add/delete and PCAP download. Today, if an operator simply forgets to set `MCP_AUTH_TOKEN`, the server starts anyway and serves all of that unauthenticated. On a `0.0.0.0` bind that's one port-scan away from a credential leak, exactly as you put it in #20.

## The change

`run_http()` now refuses to start when `MCP_AUTH_TOKEN` is unset. It exits with a message that tells the operator precisely how to fix it:

- set `MCP_AUTH_TOKEN` (the right answer for any non-loopback bind), **or**
- set `MCP_ALLOW_NO_AUTH=true` to explicitly opt out — logged at CRITICAL, and meant only for a trusted, isolated bind (e.g. `127.0.0.1` behind a gateway that terminates auth).

The default stance flips from fail-open to fail-closed; the legitimate trusted-localhost / behind-a-gateway use case is preserved cleanly through the explicit opt-out. `stdio` mode is untouched — this guard is HTTP-only.

## Upgrade note

This is a behavior change on the unset-token path, hence the SemVer minor. An existing deployment running on `0.0.0.0` with no token must now set either `MCP_AUTH_TOKEN` or `MCP_ALLOW_NO_AUTH=true` to keep starting. That's called out in the CHANGELOG entry too.

## Tests

Four new tests in `tests/test_server_auth.py` cover the matrix: token set → starts; no token → fails closed; empty token → fails closed; `MCP_ALLOW_NO_AUTH=true` → starts with the CRITICAL warning. Full suite is green at **544 passing**, ruff clean.

Same atomic-commit + CHANGELOG-entry shape as #18 / #19 / #23. The `[2.2.0]` heading sits cleanly above `[2.1.1]` after rebasing onto current `main` — no conflict to untangle on your end.
