### PR TITLE
fix: add list_report_templates alias for server.py compatibility

### DIFF
--- a/src/fortianalyzer_mcp/tools/report_tools.py
+++ b/src/fortianalyzer_mcp/tools/report_tools.py
@@ -852,3 +852,5 @@ async def save_report(
     except Exception as e:
         logger.error(f"Failed to save report: {e}")
         return {"status": "error", "message": redact(str(e))}
+
+list_report_templates = list_report_layouts


### PR DESCRIPTION
server.py references list_report_templates but report_tools.py only defines list_report_layouts. Add alias to fix AttributeError at runtime.