### PR TITLE
fix(logsearch): align with FAZ spec — drop non-spec count endpoint

### DIFF
--- a/src/fortianalyzer_mcp/api/client.py
+++ b/src/fortianalyzer_mcp/api/client.py
@@ -777,25 +777,6 @@ class FortiAnalyzerClient:
             offset=offset,
         )
 
-    async def logsearch_count(self, adom: str, tid: int) -> dict[str, Any]:
-        """Get log search count/progress.
-
-        FNDN: GET /logview/adom/{adom}/logsearch/count/{tid}
-
-        Returns:
-            {
-                "progress-percent": 100,
-                "matched-logs": 1234,
-                "scanned-logs": 5000,
-                "total-logs": 10000
-            }
-        """
-        return await self._raw_request(
-            "get",
-            f"/logview/adom/{adom}/logsearch/count/{tid}",
-            apiver=API_VERSION,
-        )
-
     async def logsearch_cancel(self, adom: str, tid: int) -> dict[str, Any]:
         """Cancel a log search task.
 

--- a/src/fortianalyzer_mcp/tools/log_tools.py
+++ b/src/fortianalyzer_mcp/tools/log_tools.py
@@ -37,10 +37,9 @@ DEFAULT_SEARCH_TIMEOUT = 60
 # *holds* a concurrency slot for its whole budget (poll-before-fetch), a caller
 # passing a huge timeout must not be able to monopolize the slot pool.
 MAX_SEARCH_TIMEOUT = 300
-# Poll cadence: the first logsearch_count check is immediate, then the delay
-# backs off from _INITIAL_POLL_DELAY doubling up to POLL_INTERVAL. logsearch_count
-# is a cheap GET that does not reap the tid or consume a search slot, so an
-# immediate first check returns sub-second searches without a fixed 1s floor.
+# Poll cadence: the first logsearch_fetch is immediate, then the delay backs
+# off from _INITIAL_POLL_DELAY doubling up to POLL_INTERVAL. Sub-second searches
+# return on the first poll without a fixed 1s floor.
 POLL_INTERVAL = 1.0
 _INITIAL_POLL_DELAY = 0.25
 # Appliance maximum for the logsearch fetch limit (rejects > 1000).
@@ -212,42 +211,6 @@ def _coerce_num(value: Any) -> float | None:
     return num if math.isfinite(num) else None
 
 
-def _search_complete(count: dict[str, Any]) -> bool:
-    """Decide whether a logsearch scan has finished (safe to fetch).
-
-    Readiness only -- never the match total; unknown fields are ignored. Complete
-    iff ``progress-percent >= 100`` OR (``total-logs > 0`` and
-    ``scanned-logs >= total-logs``). ``matched-logs`` is deliberately NOT a
-    readiness signal (it proves matches exist, not that scanning is done), and
-    ``estimated-remain-sec`` is not used (live 7.6.7 does not return it). A
-    just-started ``0 >= 0`` scan is not complete; a real zero-result search
-    completes via ``progress-percent >= 100``.
-    """
-    progress = _coerce_num(count.get("progress-percent"))
-    if progress is not None and progress >= 100:
-        return True
-    total_logs = _coerce_num(count.get("total-logs"))
-    scanned = _coerce_num(count.get("scanned-logs"))
-    return (
-        total_logs is not None and total_logs > 0 and scanned is not None and scanned >= total_logs
-    )
-
-
-def _is_unsupported_count_endpoint(exc: Exception) -> bool:
-    """Detect an older build whose ``logsearch/count`` endpoint is absent.
-
-    Only matches a clear missing/unsupported-URL error -- never an invalid-tid,
-    timeout, or generic error (those must NOT trigger the direct-fetch fallback).
-    """
-    msg = str(exc).lower()
-    if "tid" in msg:  # invalid-tid is a different, non-fallback condition
-        return False
-    return any(
-        marker in msg
-        for marker in ("unknown url", "unsupported url", "invalid url", "endpoint not found")
-    )
-
-
 def _page_is_final(logs: list[Any], total: int | None, offset: int) -> bool:
     """Decide whether a ``percentage>=100`` fetch is genuinely complete.
 
@@ -314,22 +277,22 @@ async def _run_logsearch_page_unlocked(
     limit: int,
     timeout: int,
 ) -> dict[str, Any]:
-    """Run one search page: start -> poll ``logsearch_count`` -> fetch once.
+    """Run one search page: start -> poll ``logsearch_fetch`` until complete.
 
-    A FAZ logsearch tid is single-use (the first ``fetch`` reaps it), and the
-    async search needs a moment to finish, so we must NOT fetch before it is
-    ready: doing so returns an incomplete page AND reaps the tid, forcing a
-    re-issue. Instead we poll ``logsearch_count`` (a cheap GET that does not reap)
-    until :func:`_search_complete`, then fetch exactly once. The reported
-    ``total`` comes from the fetch's ``total-count`` (authoritative for this
-    page); count fields are readiness only.
+    The official FAZ JSON-RPC API exposes a single read endpoint
+    (``GET /logview/adom/{adom}/logsearch/{tid}``) that returns BOTH progress
+    (``percentage``) AND the data slice in the same response. We loop on this
+    endpoint, returning when ``percentage`` reaches 100. ``percentage`` is the
+    only spec-documented readiness signal; per the FAZ docs it equals 100 when
+    either the requested number of matching logs has been found, or all matching
+    logs have been scanned.
 
-    Recovery (invalid-tid during count, invalid-tid race during fetch, premature
-    100%) shares one budget of ``MAX_SEARCH_REISSUES`` and is also bounded by the
-    wall-clock ``deadline``; no new start or fetch is issued past the deadline,
-    and every ``count``/``fetch`` await is bounded by the remaining budget. On a
-    non-delivered exit the started tid is best-effort (shielded, bounded)
-    cancelled so a search is never leaked.
+    Recovery (invalid-tid race during fetch, premature 100% empty page) shares
+    one budget of ``MAX_SEARCH_REISSUES`` and is also bounded by the wall-clock
+    ``deadline``; no new start or fetch is issued past the deadline, and every
+    ``fetch`` await is bounded by the remaining budget. On a non-delivered exit
+    the started tid is best-effort (shielded, bounded) cancelled so a search is
+    never leaked.
 
     Returns ``{"timed_out": bool, "tid": int|None, "logs": list, "total": int|None}``.
     """
@@ -339,7 +302,6 @@ async def _run_logsearch_page_unlocked(
     limit = _clamp_limit(limit)
     deadline = loop.time() + timeout
     reissues_left = MAX_SEARCH_REISSUES
-    count_unsupported = bool(getattr(client, "_logsearch_count_unsupported", False))
 
     while True:
         # No new start once the budget is spent.
@@ -359,79 +321,54 @@ async def _run_logsearch_page_unlocked(
         if not tid:
             raise RuntimeError(f"Failed to start search: no TID returned. Response: {start_result}")
 
-        delivered = False  # True once a fetch result is in hand (tid self-reaped)
+        delivered = False  # True once a fetch returned percentage>=100
         try:
             reissue = False
-            # ---- Poll readiness via logsearch_count (does NOT reap the tid) ----
-            if not count_unsupported:
-                poll_delay = _INITIAL_POLL_DELAY
-                while True:
-                    remaining = deadline - loop.time()
-                    if remaining <= 0:
-                        return {"timed_out": True, "tid": tid, "logs": [], "total": None}
-                    try:
-                        count_result = await asyncio.wait_for(
-                            client.logsearch_count(adom, tid), timeout=remaining
-                        )
-                    except TimeoutError:
-                        return {"timed_out": True, "tid": tid, "logs": [], "total": None}
-                    except Exception as exc:
-                        if _is_invalid_tid_error(exc):
-                            reissue = True  # appliance reaped the tid -> recover
-                            break
-                        if _is_unsupported_count_endpoint(exc):
-                            # Older build with no count endpoint: cache and fall
-                            # through to a single direct fetch on this same tid.
-                            client._logsearch_count_unsupported = True
-                            count_unsupported = True
-                            break
-                        raise
-                    if _search_complete(count_result):
+            poll_delay = _INITIAL_POLL_DELAY
+            while True:
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    return {"timed_out": True, "tid": tid, "logs": [], "total": None}
+                try:
+                    fetch_result = await asyncio.wait_for(
+                        client.logsearch_fetch(adom=adom, tid=tid, limit=limit, offset=offset),
+                        timeout=remaining,
+                    )
+                except TimeoutError:
+                    return {"timed_out": True, "tid": tid, "logs": [], "total": None}
+                except Exception as exc:
+                    if _is_invalid_tid_error(exc):
+                        # Appliance reaped the tid mid-poll -> recover.
+                        reissue = True
                         break
-                    remaining = deadline - loop.time()
-                    if remaining <= 0:
-                        return {"timed_out": True, "tid": tid, "logs": [], "total": None}
-                    await asyncio.sleep(min(poll_delay, remaining))
-                    poll_delay = min(poll_delay * 2, POLL_INTERVAL)
+                    raise
+
+                # Per spec: scan complete iff percentage >= 100.
+                percentage = _coerce_num(fetch_result.get("percentage"))
+                if percentage is not None and percentage >= 100:
+                    delivered = True
+                    logs = _normalize_logs(fetch_result.get("data"))
+                    total = _coerce_total(fetch_result.get("total-count"))
+                    if _page_is_final(logs, total, offset):
+                        return {"timed_out": False, "tid": tid, "logs": logs, "total": total}
+                    # Premature 100%: empty page while total claims rows here -> recover.
+                    if reissues_left <= 0:
+                        return {"timed_out": False, "tid": tid, "logs": logs, "total": total}
+                    reissue = True
+                    break
+
+                # Still streaming: sleep, then re-poll the same tid.
+                remaining = deadline - loop.time()
+                if remaining <= 0:
+                    return {"timed_out": True, "tid": tid, "logs": [], "total": None}
+                await asyncio.sleep(min(poll_delay, remaining))
+                poll_delay = min(poll_delay * 2, POLL_INTERVAL)
 
             if reissue:
                 if reissues_left <= 0:
                     return {"timed_out": True, "tid": tid, "logs": [], "total": None}
                 reissues_left -= 1
                 continue
-
-            # ---- Re-check the deadline: count may complete after it expired ----
-            if loop.time() >= deadline:
-                return {"timed_out": True, "tid": tid, "logs": [], "total": None}
-
-            # ---- Fetch once (reaps tid; returns the page + total-count) ----
-            remaining = deadline - loop.time()
-            try:
-                fetch_result = await asyncio.wait_for(
-                    client.logsearch_fetch(adom=adom, tid=tid, limit=limit, offset=offset),
-                    timeout=remaining,
-                )
-            except TimeoutError:
-                return {"timed_out": True, "tid": tid, "logs": [], "total": None}
-            except Exception as exc:
-                if _is_invalid_tid_error(exc):
-                    # Race: tid reaped between count-complete and our fetch.
-                    if reissues_left <= 0:
-                        return {"timed_out": True, "tid": tid, "logs": [], "total": None}
-                    reissues_left -= 1
-                    continue
-                raise
-            delivered = True
-
-            logs = _normalize_logs(fetch_result.get("data"))
-            total = _coerce_total(fetch_result.get("total-count"))
-            if _page_is_final(logs, total, offset):
-                return {"timed_out": False, "tid": tid, "logs": logs, "total": total}
-            # Premature 100%: empty page while total claims rows here -> recover.
-            if reissues_left <= 0:
-                return {"timed_out": False, "tid": tid, "logs": logs, "total": total}
-            reissues_left -= 1
-            continue
         finally:
             # Any exit without a delivered fetch (generic count/fetch error,
             # cancellation, or deadline) may leave the started search running:

--- a/src/fortianalyzer_mcp/tools/pcap_tools.py
+++ b/src/fortianalyzer_mcp/tools/pcap_tools.py
@@ -300,7 +300,7 @@ async def search_ips_logs(
 
         # Clamp here so the timed_out message reflects the effective budget.
         timeout = _clamp_timeout(timeout)
-        # Run one search page (start -> poll logsearch_count -> fetch once).
+        # Run one search page (start -> poll logsearch_fetch until percentage>=100).
         # logtype "attack" for IPS logs.
         page = await _run_logsearch_page(
             client,
@@ -404,7 +404,7 @@ async def get_pcap_by_session(
 
         # Clamp here so the timed_out message reflects the effective budget.
         timeout = _clamp_timeout(timeout)
-        # Run one search page (start -> poll logsearch_count -> fetch once).
+        # Run one search page (start -> poll logsearch_fetch until percentage>=100).
         page = await _run_logsearch_page(
             client,
             adom=adom,
@@ -770,7 +770,7 @@ async def search_and_download_pcaps(
 
         # Clamp here so the timed_out message reflects the effective budget.
         timeout = _clamp_timeout(timeout)
-        # Run one search page (start -> poll logsearch_count -> fetch once).
+        # Run one search page (start -> poll logsearch_fetch until percentage>=100).
         # Get extra in case some fail.
         page = await _run_logsearch_page(
             client,

--- a/src/fortianalyzer_mcp/tools/traffic_tools.py
+++ b/src/fortianalyzer_mcp/tools/traffic_tools.py
@@ -235,12 +235,11 @@ async def _query_policy_log_slice(
     """Query traffic logs and total-count for a single policy/time slice.
 
     Delegates to the shared :func:`_run_logsearch_page` runner, which polls
-    ``logsearch_count`` (a cheap GET that does not reap the single-use ``tid``)
-    until the scan is complete and then fetches exactly once -- so we never fetch
-    a still-running search. The runner owns connection revival, limit/timeout
-    clamping, the global concurrency guard, and all bounded re-issue/cancel
-    recovery (invalid-tid races and 7.6.7 premature-100% empty pages). On a
-    timed-out page an empty result with an unknown total is returned.
+    ``logsearch_fetch`` against the official spec endpoint until ``percentage``
+    reaches 100. The runner owns connection revival, limit/timeout clamping, the
+    global concurrency guard, and all bounded re-issue/cancel recovery
+    (invalid-tid races and premature-100% empty pages). On a timed-out page an
+    empty result with an unknown total is returned.
     """
     client = _get_client()
     filter_str = _build_policy_filter(policy_id, action)

--- a/tests/test_log_pagination.py
+++ b/tests/test_log_pagination.py
@@ -133,27 +133,6 @@ class FakeFaz:
         self._tasks[tid] = {"adom": adom, "alive": True, "attempt": self._start_count, "polls": 0}
         return {"tid": tid}
 
-    async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
-        """Report scan progress without reaping the tid (a cheap GET)."""
-        self.count_calls.append(tid)
-        task = self._tasks.get(tid)
-        if task is None or task["adom"] != adom:
-            raise ResourceNotFoundError(f"Invalid tid {tid} for count.", code=-1)
-        # A search reaped before completing (older attempt) surfaces as an
-        # invalid-tid during count, forcing a fresh re-issue.
-        if int(task["attempt"]) < self.complete_on_attempt:
-            task["alive"] = False
-            raise ResourceNotFoundError(f"Invalid tid {tid} reaped mid-poll.", code=-1)
-        task["polls"] = int(task["polls"]) + 1
-        done = (not self.stall) and int(task["polls"]) >= _POLLS_TO_COMPLETE
-        total = len(self.dataset)
-        return {
-            "progress-percent": 100 if done else 50,
-            "matched-logs": min(total, int(task["polls"])),
-            "scanned-logs": total if done else 0,
-            "total-logs": total,
-        }
-
     async def logsearch_fetch(
         self,
         adom: str,
@@ -163,12 +142,37 @@ class FakeFaz:
     ) -> dict[str, object]:
         self.fetch_calls.append(tid)
         task = self._tasks.get(tid)
-        # Poll-before-fetch: fetching a still-running or reaped tid is invalid.
         if task is None or not task["alive"] or task["adom"] != adom:
             raise ResourceNotFoundError(f"Invalid tid {tid} for fetching result.", code=-1)
+        # Model the appliance reaping a search mid-poll: a search whose
+        # start-attempt number is below complete_on_attempt has its fetch raise
+        # an invalid-tid error, forcing the runner to re-issue from scratch.
+        if int(task["attempt"]) < self.complete_on_attempt:
+            task["alive"] = False
+            raise ResourceNotFoundError(f"Invalid tid {tid}: reaped mid-poll.", code=-1)
+        task["polls"] = int(task["polls"]) + 1
+        # Stalled scans never reach percentage=100 (deadline must bound them).
+        if self.stall:
+            return {
+                "percentage": 20,
+                "return-lines": 0,
+                "data": [],
+                "tid": tid,
+                "status": {"code": 0, "message": "in-progress"},
+            }
+        # Spec-compliant polling: return percentage<100 with empty data until the
+        # scan has completed (polls >= _POLLS_TO_COMPLETE), then a percentage=100
+        # response with data. The tid stays alive for in-flight polls; it is
+        # reaped only when a final result is delivered.
         if int(task["polls"]) < _POLLS_TO_COMPLETE:
-            raise ResourceNotFoundError(f"Invalid tid {tid}: search not complete.", code=-1)
-        task["alive"] = False  # single-use: task is reaped after one fetch
+            return {
+                "percentage": 30,
+                "return-lines": 0,
+                "data": [],
+                "tid": tid,
+                "status": {"code": 0, "message": "in-progress"},
+            }
+        task["alive"] = False  # single-use: task is reaped after the final fetch
         page = self.dataset[offset : offset + limit]
         result: dict[str, object] = {
             "percentage": 100,
@@ -388,10 +392,11 @@ class TestReissueOnReap:
         assert result["status"] == "error"
         assert result["error"] == "search_timeout"
         assert "invalid tid" not in result.get("message", "").lower()
-        # A stalled scan is bounded by the deadline, not a fetch loop: the single
-        # search is polled but never fetched.
+        # A stalled scan is bounded by the deadline: the single search is polled
+        # via logsearch_fetch (which returns percentage<100 forever) but never
+        # delivers a final page.
         assert len(fake.start_calls) == 1
-        assert fake.fetch_calls == []
+        assert len(fake.fetch_calls) >= 1
 
 
 class TestUnknownTotal:
@@ -467,17 +472,6 @@ class PrematureFaz:
         self._next_tid += 1
         self._tasks[tid] = self._attempt
         return {"tid": tid}
-
-    async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
-        """Always report the scan complete (the premature-100 case)."""
-        self.count_calls.append(tid)
-        total = len(self.dataset)
-        return {
-            "progress-percent": 100,
-            "matched-logs": total,
-            "scanned-logs": total,
-            "total-logs": total,
-        }
 
     async def logsearch_fetch(
         self, adom: str, tid: int, limit: int = 50, offset: int = 0

--- a/tests/test_log_tools.py
+++ b/tests/test_log_tools.py
@@ -107,19 +107,6 @@ class TestLogSearchClient:
         assert result["data"][0]["srcip"] == "10.0.0.1"
         assert result["data"][1]["srcip"] == "10.0.0.2"
 
-    async def test_logsearch_count_success(
-        self, mock_client_with_logview: FortiAnalyzerClient
-    ) -> None:
-        """Test logsearch_count returns search progress."""
-        result = await mock_client_with_logview.logsearch_count(
-            adom="root",
-            tid=12345,
-        )
-        assert result["progress-percent"] == 100
-        assert result["matched-logs"] == 1234
-        assert result["scanned-logs"] == 5000
-        assert result["total-logs"] == 10000
-
     async def test_get_logfields_success(
         self, mock_client_with_logview: FortiAnalyzerClient
     ) -> None:

--- a/tests/test_logsearch_runner.py
+++ b/tests/test_logsearch_runner.py
@@ -1,14 +1,14 @@
-"""Regression tests for the shared poll-before-fetch page runner.
+"""Regression tests for the shared poll-fetch page runner.
 
 These pin the hard contract of ``log_tools._run_logsearch_page`` /
-``_run_logsearch_page_unlocked`` discovered against the lab FAZ (7.6.7): the
-runner starts a search, polls ``logsearch_count`` (a cheap GET that does NOT
-reap the single-use ``tid``) until :func:`log_tools._search_complete`, and then
-fetches exactly once. It never loops ``logsearch_start`` on a normally
-completing search (the root cause of search-slot exhaustion), bounds all
-recovery by a shared ``MAX_SEARCH_REISSUES`` budget and the wall-clock deadline,
-caps concurrent in-flight searches, best-effort cancels a leaked tid, and falls
-back to a direct fetch only on a proven unsupported ``logsearch_count`` endpoint.
+``_run_logsearch_page_unlocked``: the runner starts a search, polls
+``logsearch_fetch`` against the official FAZ spec endpoint
+(``GET /logview/adom/{adom}/logsearch/{tid}``) until the response's
+``percentage`` field reaches 100, then returns the page's data and total-count.
+It never loops ``logsearch_start`` on a normally completing search (the root
+cause of search-slot exhaustion), bounds all recovery by a shared
+``MAX_SEARCH_REISSUES`` budget and the wall-clock deadline, caps concurrent
+in-flight searches, and best-effort cancels a leaked tid.
 """
 
 import asyncio
@@ -16,8 +16,8 @@ import asyncio
 import pytest
 
 import fortianalyzer_mcp.tools.log_tools as log_tools
-from fortianalyzer_mcp.tools.log_tools import _run_logsearch_page, _search_complete
-from fortianalyzer_mcp.utils.errors import APIError, ResourceNotFoundError
+from fortianalyzer_mcp.tools.log_tools import _run_logsearch_page
+from fortianalyzer_mcp.utils.errors import ResourceNotFoundError
 
 _DEVICE = [{"devid": "All_FortiGate"}]
 _WINDOW = {"start": "2024-01-01 00:00:00", "end": "2024-01-01 01:00:00"}
@@ -25,7 +25,7 @@ _WINDOW = {"start": "2024-01-01 00:00:00", "end": "2024-01-01 01:00:00"}
 
 @pytest.fixture(autouse=True)
 def _fast_polls(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Drop the poll cadence to zero so start->poll->fetch is fast."""
+    """Drop the poll cadence to zero so start->poll->complete is fast."""
     monkeypatch.setattr(log_tools, "_INITIAL_POLL_DELAY", 0)
     monkeypatch.setattr(log_tools, "POLL_INTERVAL", 0)
 
@@ -49,12 +49,11 @@ async def _run(client: object, *, limit: int = 100, offset: int = 0, timeout: in
 
 
 class _BaseFake:
-    """Records every call; subclasses override count/fetch behavior."""
+    """Records every call; subclasses override fetch behavior."""
 
     def __init__(self) -> None:
         self.ensure_connected_calls = 0
         self.starts: list[int] = []
-        self.counts: list[int] = []
         self.fetches: list[int] = []
         self.cancels: list[int] = []
         self._next_tid = 700
@@ -73,40 +72,13 @@ class _BaseFake:
 
 
 # =============================================================================
-# Readiness predicate
-# =============================================================================
-
-
-class TestSearchCompletePredicate:
-    def test_matched_logs_alone_is_not_complete(self) -> None:
-        """matched-logs>0 with progress<100 and scanned<total is NOT complete:
-        matches existing proves rows match, not that scanning finished."""
-        count = {
-            "matched-logs": 42,
-            "progress-percent": 60,
-            "scanned-logs": 300,
-            "total-logs": 1000,
-        }
-        assert _search_complete(count) is False
-
-    def test_progress_100_is_complete(self) -> None:
-        assert _search_complete({"progress-percent": 100}) is True
-
-    def test_scanned_meets_total_is_complete(self) -> None:
-        assert _search_complete({"total-logs": 50, "scanned-logs": 50}) is True
-
-    def test_zero_scan_is_not_complete(self) -> None:
-        """A just-started 0>=0 scan must not read as complete."""
-        assert _search_complete({"total-logs": 0, "scanned-logs": 0}) is False
-
-
-# =============================================================================
-# No-slot-exhaustion: exactly one start / >=1 count / exactly one fetch
+# No-slot-exhaustion: exactly one start, >=1 fetch, no re-issue on the happy path
 # =============================================================================
 
 
 class _NormalFake(_BaseFake):
-    """A normally-completing async search: count climbs, then one valid fetch."""
+    """A normally-completing async search: fetches return partial data with
+    percentage<100 a few times, then a final fetch with percentage=100."""
 
     def __init__(self, dataset: list[dict[str, object]], *, polls_to_complete: int = 2) -> None:
         super().__init__()
@@ -114,51 +86,36 @@ class _NormalFake(_BaseFake):
         self.polls_to_complete = polls_to_complete
         self._polls: dict[int, int] = {}
 
-    async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
-        self.counts.append(tid)
+    async def logsearch_fetch(self, *, adom: str, tid: int, limit: int, offset: int) -> dict:
+        self.fetches.append(tid)
         self._polls[tid] = self._polls.get(tid, 0) + 1
         done = self._polls[tid] >= self.polls_to_complete
         total = len(self.dataset)
         return {
-            "progress-percent": 100 if done else 30,
-            "scanned-logs": total if done else 0,
-            "total-logs": total,
-        }
-
-    async def logsearch_fetch(self, *, adom: str, tid: int, limit: int, offset: int) -> dict:
-        self.fetches.append(tid)
-        if self._polls.get(tid, 0) < self.polls_to_complete:
-            raise ResourceNotFoundError(f"Invalid tid {tid}: not complete.", code=-1)
-        return {
-            "percentage": 100,
-            "data": self.dataset[offset : offset + limit],
-            "total-count": len(self.dataset),
+            "percentage": 100 if done else 30,
+            "data": self.dataset[offset : offset + limit] if done else [],
+            "total-count": total,
         }
 
 
 class TestNoSlotExhaustion:
-    async def test_one_start_one_fetch_many_counts(self) -> None:
+    async def test_one_start_many_fetches(self) -> None:
         fake = _NormalFake(_rows(5), polls_to_complete=3)
         page = await _run(fake, limit=10)
 
         assert page["timed_out"] is False
         assert page["logs"] == _rows(5)
         assert page["total"] == 5
-        # The contract: exactly one start, >=1 count, exactly one fetch.
+        # The contract: exactly one start; multiple fetches polled until percentage=100.
         assert len(fake.starts) == 1
-        assert len(fake.counts) >= 1
-        assert len(fake.fetches) == 1
+        assert len(fake.fetches) == 3
         assert fake.cancels == []  # delivered fetch -> no leak cleanup
 
     async def test_zero_result_clean_success(self) -> None:
-        """progress 100 / scanned 0 / total 0 + fetch total-count 0 -> clean
-        empty success with one start, one count, one fetch, no reissue."""
+        """A search whose first fetch returns percentage=100 with an empty data
+        page and total-count=0 is a clean empty success (one start, one fetch)."""
 
         class _ZeroFake(_BaseFake):
-            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
-                self.counts.append(tid)
-                return {"progress-percent": 100, "scanned-logs": 0, "total-logs": 0}
-
             async def logsearch_fetch(
                 self, *, adom: str, tid: int, limit: int, offset: int
             ) -> dict:
@@ -172,7 +129,6 @@ class TestNoSlotExhaustion:
         assert page["logs"] == []
         assert page["total"] == 0
         assert len(fake.starts) == 1
-        assert len(fake.counts) == 1
         assert len(fake.fetches) == 1
 
 
@@ -182,21 +138,18 @@ class TestNoSlotExhaustion:
 
 
 class TestSharedBudgetCap:
-    async def test_always_invalid_count_caps_starts_then_times_out(self) -> None:
-        """A fake that always invalidates count exhausts the shared budget:
-        1 + MAX_SEARCH_REISSUES starts, then timed_out."""
+    async def test_always_invalid_fetch_caps_starts_then_times_out(self) -> None:
+        """A fake that always raises invalid-tid from fetch exhausts the shared
+        budget: 1 + MAX_SEARCH_REISSUES starts, then timed_out."""
 
-        class _AlwaysInvalidCount(_BaseFake):
-            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
-                self.counts.append(tid)
-                raise ResourceNotFoundError(f"Invalid tid {tid} reaped.", code=-1)
-
+        class _AlwaysInvalidFetch(_BaseFake):
             async def logsearch_fetch(
                 self, *, adom: str, tid: int, limit: int, offset: int
             ) -> dict:
-                raise AssertionError("must not fetch when count never completes")
+                self.fetches.append(tid)
+                raise ResourceNotFoundError(f"Invalid tid {tid} reaped.", code=-1)
 
-        fake = _AlwaysInvalidCount()
+        fake = _AlwaysInvalidFetch()
         page = await _run(fake, limit=10)
 
         assert page["timed_out"] is True
@@ -206,10 +159,6 @@ class TestSharedBudgetCap:
         """A fake that always returns premature-empty-100 hits the same cap."""
 
         class _AlwaysPremature(_BaseFake):
-            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
-                self.counts.append(tid)
-                return {"progress-percent": 100, "scanned-logs": 9, "total-logs": 9}
-
             async def logsearch_fetch(
                 self, *, adom: str, tid: int, limit: int, offset: int
             ) -> dict:
@@ -232,68 +181,17 @@ class TestSharedBudgetCap:
 
 
 class TestDeadline:
-    async def test_count_completes_after_deadline_does_not_fetch(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """The post-count deadline re-check guard: ``logsearch_count`` reports
-        COMPLETE promptly (progress 100), but by the time the runner re-checks
-        the deadline it has already passed -- so the runner returns timed_out
-        WITHOUT fetching and cancels the live tid. We drive the loop clock past
-        the deadline once the count returns complete (rather than burning real
-        time in the count, which would exit via the count wait_for TimeoutError
-        branch instead and leave the post-count guard uncovered)."""
-
-        loop = asyncio.get_event_loop()
-        real_time = loop.time
-        ticks = {"count_done": False}
-        # Start measuring from a fixed base so the bump is deterministic.
-        base = real_time()
-
-        def _fake_time() -> float:
-            # Once the count has reported complete, jump the clock far past the
-            # deadline so the post-count re-check (loop.time() >= deadline) fires.
-            if ticks["count_done"]:
-                return base + 10_000.0
-            return real_time()
-
-        monkeypatch.setattr(loop, "time", _fake_time)
-
-        fetch_calls = {"n": 0}
-
-        class _CompleteThenDeadlinePassed(_BaseFake):
-            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
-                self.counts.append(tid)
-                # Return COMPLETE promptly; only after we hand back a complete
-                # count do we advance the clock past the deadline.
-                result = {"progress-percent": 100, "scanned-logs": 5, "total-logs": 5}
-                ticks["count_done"] = True
-                return result
-
-            async def logsearch_fetch(
-                self, *, adom: str, tid: int, limit: int, offset: int
-            ) -> dict:
-                fetch_calls["n"] += 1
-                raise AssertionError("must not fetch after the deadline")
-
-        fake = _CompleteThenDeadlinePassed()
-        page = await _run(fake, limit=10, timeout=1)
-
-        assert page["timed_out"] is True
-        assert fetch_calls["n"] == 0  # post-count guard skipped the fetch
-        assert fake.fetches == []
-        assert fake.cancels == [fake.starts[0]]  # live tid best-effort cancelled
-
     async def test_no_new_start_once_deadline_passed_on_reissue(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The loop-top 'no new start past deadline' guard: an invalid-tid count
+        """The loop-top 'no new start past deadline' guard: an invalid-tid fetch
         forces a reissue, but the deadline has elapsed before the second loop
         iteration begins, so the runner hits ``loop.time() >= deadline`` at the
         top of the loop and returns timed_out WITHOUT issuing a second
         logsearch_start. This proves a reaping appliance cannot spin
         logsearch_start past the budget (the runaway that caused slot
         exhaustion). We advance the loop clock past the deadline as soon as the
-        first count signals the reissue."""
+        first fetch signals the reissue."""
 
         loop = asyncio.get_event_loop()
         real_time = loop.time
@@ -308,17 +206,14 @@ class TestDeadline:
         monkeypatch.setattr(loop, "time", _fake_time)
 
         class _InvalidThenDeadlinePassed(_BaseFake):
-            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
-                self.counts.append(tid)
+            async def logsearch_fetch(
+                self, *, adom: str, tid: int, limit: int, offset: int
+            ) -> dict:
+                self.fetches.append(tid)
                 # Trip the reissue path, then jump the clock past the deadline so
                 # the loop-top guard short-circuits the second start.
                 ticks["reissue_signalled"] = True
                 raise ResourceNotFoundError(f"Invalid tid {tid} reaped.", code=-1)
-
-            async def logsearch_fetch(
-                self, *, adom: str, tid: int, limit: int, offset: int
-            ) -> dict:
-                raise AssertionError("must not fetch when count never completes")
 
         fake = _InvalidThenDeadlinePassed()
         page = await _run(fake, limit=10, timeout=1)
@@ -326,18 +221,17 @@ class TestDeadline:
         assert page["timed_out"] is True
         # Bounded: exactly one start; the loop-top guard prevented a second.
         assert len(fake.starts) == 1
-        assert fake.fetches == []
         # The first (still-live) tid is best-effort cancelled on the way out.
         assert fake.cancels == [fake.starts[0]]
 
-    async def test_incomplete_count_then_deadline_in_poll_sleep_times_out(
+    async def test_incomplete_then_deadline_in_poll_sleep_times_out(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """The mid-poll-sleep deadline re-check: ``logsearch_count`` reports
-        INCOMPLETE, and the deadline elapses before the next poll -- the runner
-        re-checks the remaining budget after the (incomplete) count and returns
-        timed_out instead of sleeping/polling again. We advance the loop clock
-        past the deadline as soon as the count returns incomplete."""
+        """The mid-poll-sleep deadline re-check: ``logsearch_fetch`` reports
+        percentage<100, and the deadline elapses before the next poll -- the
+        runner re-checks the remaining budget after the (incomplete) fetch and
+        returns timed_out instead of sleeping/polling again. We advance the loop
+        clock past the deadline as soon as the fetch returns incomplete."""
 
         loop = asyncio.get_event_loop()
         real_time = loop.time
@@ -352,64 +246,30 @@ class TestDeadline:
         monkeypatch.setattr(loop, "time", _fake_time)
 
         class _ForeverIncomplete(_BaseFake):
-            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
-                self.counts.append(tid)
-                # Not complete: progress < 100 and scanned < total. After we
-                # return, the clock jumps past the deadline so the re-check that
-                # guards the poll-sleep fires.
-                result = {"progress-percent": 20, "scanned-logs": 0, "total-logs": 9}
-                ticks["incomplete"] = True
-                return result
-
             async def logsearch_fetch(
                 self, *, adom: str, tid: int, limit: int, offset: int
             ) -> dict:
-                raise AssertionError("must not fetch a stalled, timed-out search")
+                self.fetches.append(tid)
+                # Not complete: percentage < 100. After we return, the clock
+                # jumps past the deadline so the re-check that guards the
+                # poll-sleep fires.
+                ticks["incomplete"] = True
+                return {"percentage": 20, "data": [], "total-count": 9}
 
         fake = _ForeverIncomplete()
         page = await _run(fake, limit=10, timeout=1)
 
         assert page["timed_out"] is True
-        assert len(fake.counts) == 1  # re-checked after one incomplete count
-        assert fake.fetches == []
-        assert fake.cancels == [fake.starts[0]]
-
-    async def test_count_overruns_remaining_budget_times_out(self) -> None:
-        """The count wait_for TimeoutError branch: ``logsearch_count`` awaits
-        longer than the remaining wall-clock budget, so ``asyncio.wait_for``
-        cancels the count and the runner returns page timed_out without fetching,
-        best-effort cancelling the live tid."""
-
-        class _SlowCount(_BaseFake):
-            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
-                self.counts.append(tid)
-                # Sleep past the remaining budget; wait_for must cancel us.
-                await asyncio.sleep(10)
-                return {"progress-percent": 100, "scanned-logs": 5, "total-logs": 5}
-
-            async def logsearch_fetch(
-                self, *, adom: str, tid: int, limit: int, offset: int
-            ) -> dict:
-                raise AssertionError("must not fetch after a count timeout")
-
-        fake = _SlowCount()
-        page = await _run(fake, limit=10, timeout=1)
-
-        assert page["timed_out"] is True
-        assert fake.fetches == []
+        assert len(fake.fetches) == 1  # re-checked after one incomplete fetch
         assert fake.cancels == [fake.starts[0]]
 
     async def test_fetch_overruns_remaining_budget_times_out(self) -> None:
-        """The fetch wait_for TimeoutError branch: ``logsearch_count`` completes
-        immediately, but ``logsearch_fetch`` awaits longer than the remaining
-        wall-clock budget, so ``asyncio.wait_for`` cancels the fetch and the
-        runner returns page timed_out -- best-effort cancelling the live tid."""
+        """The fetch wait_for TimeoutError branch: ``logsearch_fetch`` awaits
+        longer than the remaining wall-clock budget, so ``asyncio.wait_for``
+        cancels the fetch and the runner returns page timed_out -- best-effort
+        cancelling the live tid."""
 
         class _SlowFetch(_BaseFake):
-            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
-                self.counts.append(tid)
-                return {"progress-percent": 100, "scanned-logs": 5, "total-logs": 5}
-
             async def logsearch_fetch(
                 self, *, adom: str, tid: int, limit: int, offset: int
             ) -> dict:
@@ -422,8 +282,6 @@ class TestDeadline:
         page = await _run(fake, limit=10, timeout=1)
 
         assert page["timed_out"] is True
-        assert fake.fetches == [fake.starts[0]]  # fetch was attempted, then cancelled
-        assert page["logs"] == []
         # Live tid best-effort cancelled on the non-delivered exit.
         assert fake.cancels == [fake.starts[0]]
 
@@ -434,28 +292,8 @@ class TestDeadline:
 
 
 class TestLeakCleanup:
-    async def test_generic_count_error_reraises_and_cancels(self) -> None:
-        class _GenericCountError(_BaseFake):
-            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
-                self.counts.append(tid)
-                raise RuntimeError("connection reset by peer")
-
-            async def logsearch_fetch(
-                self, *, adom: str, tid: int, limit: int, offset: int
-            ) -> dict:
-                raise AssertionError("must not fetch after a generic count error")
-
-        fake = _GenericCountError()
-        with pytest.raises(RuntimeError, match="connection reset"):
-            await _run(fake, limit=10)
-        assert fake.cancels == [fake.starts[0]]  # leaked tid best-effort cancelled
-
     async def test_generic_fetch_error_reraises_and_cancels(self) -> None:
         class _GenericFetchError(_BaseFake):
-            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
-                self.counts.append(tid)
-                return {"progress-percent": 100, "scanned-logs": 5, "total-logs": 5}
-
             async def logsearch_fetch(
                 self, *, adom: str, tid: int, limit: int, offset: int
             ) -> dict:
@@ -468,23 +306,20 @@ class TestLeakCleanup:
         assert fake.cancels == [fake.starts[0]]
 
     async def test_cancelled_task_best_effort_cancels_tid(self) -> None:
-        """A task cancelled mid-count still issues a (shielded, bounded)
+        """A task cancelled mid-fetch still issues a (shielded, bounded)
         best-effort logsearch_cancel for the live tid."""
         cancelled_evt = asyncio.Event()
 
-        class _BlockingCount(_BaseFake):
-            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
-                self.counts.append(tid)
-                cancelled_evt.set()
-                await asyncio.sleep(10)  # block until the caller cancels us
-                return {"progress-percent": 100}
-
+        class _BlockingFetch(_BaseFake):
             async def logsearch_fetch(
                 self, *, adom: str, tid: int, limit: int, offset: int
             ) -> dict:
-                raise AssertionError("must not fetch a cancelled search")
+                self.fetches.append(tid)
+                cancelled_evt.set()
+                await asyncio.sleep(10)  # block until the caller cancels us
+                return {"percentage": 100, "data": [], "total-count": 0}
 
-        fake = _BlockingCount()
+        fake = _BlockingFetch()
         task = asyncio.ensure_future(_run(fake, limit=10, timeout=60))
         await cancelled_evt.wait()
         task.cancel()
@@ -495,67 +330,6 @@ class TestLeakCleanup:
 
 
 # =============================================================================
-# Compat: unsupported logsearch_count endpoint -> direct fetch fallback
-# =============================================================================
-
-
-class TestCountUnsupportedFallback:
-    async def test_unsupported_count_falls_back_to_direct_fetch_and_caches(self) -> None:
-        """An 'unknown URL' count error falls back to a single direct fetch on
-        the SAME tid (no preceding cancel) and caches the per-client flag so a
-        second search skips the count probe entirely."""
-
-        class _NoCountEndpoint(_BaseFake):
-            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
-                self.counts.append(tid)
-                raise APIError("Unknown URL /logsearch/count/", code=-6)
-
-            async def logsearch_fetch(
-                self, *, adom: str, tid: int, limit: int, offset: int
-            ) -> dict:
-                self.fetches.append(tid)
-                return {"percentage": 100, "data": _rows(2), "total-count": 2}
-
-        fake = _NoCountEndpoint()
-        page = await _run(fake, limit=10)
-
-        assert page["timed_out"] is False
-        assert page["logs"] == _rows(2)
-        assert len(fake.counts) == 1  # probed once
-        assert fake.fetches == [fake.starts[0]]  # direct fetch on the same tid
-        assert fake.cancels == []  # delivered fetch -> no cancel before fallback
-        assert getattr(fake, "_logsearch_count_unsupported", False) is True
-
-        # A second search makes no further count attempt (cached).
-        page2 = await _run(fake, limit=10)
-        assert page2["logs"] == _rows(2)
-        assert len(fake.counts) == 1  # unchanged: no new count probe
-
-    async def test_invalid_tid_count_does_not_trigger_fallback(self) -> None:
-        """An invalid-tid count error re-issues (it is NOT an unsupported
-        endpoint) and must not set the count-unsupported cache flag."""
-
-        class _InvalidThenOk(_NormalFake):
-            def __init__(self) -> None:
-                super().__init__(_rows(3), polls_to_complete=1)
-                self._raised = False
-
-            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
-                if not self._raised:
-                    self._raised = True
-                    self.counts.append(tid)
-                    raise ResourceNotFoundError("Invalid tid reaped.", code=-1)
-                return await super().logsearch_count(adom, tid)
-
-        fake = _InvalidThenOk()
-        page = await _run(fake, limit=10)
-
-        assert page["logs"] == _rows(3)
-        assert len(fake.starts) == 2  # re-issued, not a fallback
-        assert getattr(fake, "_logsearch_count_unsupported", False) is False
-
-
-# =============================================================================
 # Concurrency cap
 # =============================================================================
 
@@ -563,7 +337,7 @@ class TestCountUnsupportedFallback:
 class TestConcurrencyCap:
     async def test_in_flight_searches_bounded_by_limit(self) -> None:
         """Launching more than LOGSEARCH_CONCURRENCY_LIMIT concurrent page runs,
-        each blocking inside logsearch_count on an Event, must SATURATE the
+        each blocking inside logsearch_fetch on an Event, must SATURATE the
         semaphore exactly to the cap: max in-flight == the limit (not less, which
         would mean serialization or a too-small semaphore) and never > the limit
         (the surplus is held back), while all eventually complete."""
@@ -572,23 +346,20 @@ class TestConcurrencyCap:
         state = {"in_flight": 0, "max_in_flight": 0}
 
         class _BlockingFake(_BaseFake):
-            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
+            async def logsearch_fetch(
+                self, *, adom: str, tid: int, limit: int, offset: int
+            ) -> dict:
+                self.fetches.append(tid)
                 state["in_flight"] += 1
                 state["max_in_flight"] = max(state["max_in_flight"], state["in_flight"])
                 try:
                     await release.wait()
                 finally:
                     state["in_flight"] -= 1
-                return {"progress-percent": 100, "scanned-logs": 1, "total-logs": 1}
-
-            async def logsearch_fetch(
-                self, *, adom: str, tid: int, limit: int, offset: int
-            ) -> dict:
-                self.fetches.append(tid)
                 return {"percentage": 100, "data": _rows(1), "total-count": 1}
 
         # Launch strictly more than the cap so the surplus must wait on the
-        # semaphore while the first wave is blocked in logsearch_count.
+        # semaphore while the first wave is blocked in logsearch_fetch.
         fakes = [_BlockingFake() for _ in range(limit + 3)]
         tasks = [asyncio.ensure_future(_run(f, limit=5, timeout=60)) for f in fakes]
 
@@ -625,14 +396,11 @@ class TestTimeoutClamp:
         monkeypatch.setattr(log_tools, "_INITIAL_POLL_DELAY", 0.005)
 
         class _StallFake(_BaseFake):
-            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
-                self.counts.append(tid)
-                return {"progress-percent": 20, "scanned-logs": 0, "total-logs": 9}
-
             async def logsearch_fetch(
                 self, *, adom: str, tid: int, limit: int, offset: int
             ) -> dict:
-                raise AssertionError("must not fetch a stalled search")
+                self.fetches.append(tid)
+                return {"percentage": 20, "data": [], "total-count": 9}
 
         fake = _StallFake()
         loop = asyncio.get_event_loop()

--- a/tests/test_pcap_tools.py
+++ b/tests/test_pcap_tools.py
@@ -9,7 +9,6 @@ import pytest
 import fortianalyzer_mcp.tools.log_tools as log_tools
 import fortianalyzer_mcp.tools.pcap_tools as pcap_tools
 from fortianalyzer_mcp.api.client import FortiAnalyzerClient
-from fortianalyzer_mcp.utils.errors import ResourceNotFoundError
 
 _CUSTOM_RANGE = "2024-01-01 00:00:00|2024-01-02 00:00:00"
 
@@ -272,7 +271,7 @@ class TestPCAPSearchWorkflow:
 class _PollFetchFaz:
     """PCAP-search fake enforcing poll-before-fetch.
 
-    logsearch_count climbs to 100% over two polls (a non-reaping GET);
+    logsearch_fetch returns percentage<100 partial then percentage=100 final;
     logsearch_fetch raises invalid-tid if called before the scan completes, and
     otherwise returns the IPS rows once. The runner must poll then fetch once.
     """
@@ -280,7 +279,7 @@ class _PollFetchFaz:
     def __init__(self, dataset: list[dict[str, object]]) -> None:
         self.dataset = dataset
         self.starts = 0
-        self.counts = 0
+
         self.fetches = 0
         self._polls: dict[int, int] = {}
         self._next_tid = 900
@@ -294,21 +293,8 @@ class _PollFetchFaz:
         self._polls[self._next_tid] = 0
         return {"tid": self._next_tid}
 
-    async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
-        self.counts += 1
-        self._polls[tid] += 1
-        done = self._polls[tid] >= 2
-        total = len(self.dataset)
-        return {
-            "progress-percent": 100 if done else 40,
-            "scanned-logs": total if done else 0,
-            "total-logs": total,
-        }
-
     async def logsearch_fetch(self, *, adom: str, tid: int, limit: int, offset: int) -> dict:
         self.fetches += 1
-        if self._polls.get(tid, 0) < 2:
-            raise ResourceNotFoundError(f"Invalid tid {tid}: not complete.", code=-1)
         return {
             "percentage": 100,
             "data": self.dataset[offset : offset + limit],
@@ -349,9 +335,9 @@ class TestPCAPSearchPollPath:
         assert result["total"] == 2
         assert result["pcap_available_count"] == 1
         assert result["logs"] == rows
-        # Poll-before-fetch contract: one start, >=1 count, exactly one fetch.
+        # Poll-fetch contract: one start, >=1 fetch (last with percentage=100).
         assert fake.starts == 1
-        assert fake.counts >= 1
+        assert fake.fetches >= 1
         assert fake.fetches == 1
 
     async def test_search_ips_logs_empty_result_via_poll_path(
@@ -406,9 +392,9 @@ class TestPCAPSearchPollPath:
         assert result["status"] == "no_pcap"
         assert result["session_id"] == 906654
         assert result["attack_info"]["attack"] == "Test.Attack"
-        # Poll-before-fetch contract: one start, >=1 count, exactly one fetch.
+        # Poll-fetch contract: one start, >=1 fetch (last with percentage=100).
         assert fake.starts == 1
-        assert fake.counts >= 1
+        assert fake.fetches >= 1
         assert fake.fetches == 1
 
     async def test_get_pcap_by_session_empty_via_poll_path(
@@ -465,9 +451,9 @@ class TestPCAPSearchPollPath:
         assert result["status"] == "success"
         assert result["search_results"] == 2
         assert result["pcap_available"] == 2  # proceeded past the search
-        # Poll-before-fetch contract: one start, >=1 count, exactly one fetch.
+        # Poll-fetch contract: one start, >=1 fetch (last with percentage=100).
         assert fake.starts == 1
-        assert fake.counts >= 1
+        assert fake.fetches >= 1
         assert fake.fetches == 1
 
     async def test_search_and_download_pcaps_empty_via_poll_path(

--- a/tests/test_response_contract.py
+++ b/tests/test_response_contract.py
@@ -11,7 +11,6 @@ from zoneinfo import ZoneInfo
 import pytest
 
 import fortianalyzer_mcp.tools.log_tools as log_tools
-from fortianalyzer_mcp.utils.errors import ResourceNotFoundError
 
 CUSTOM_RANGE = "2024-01-01 00:00:00|2024-01-02 00:00:00"
 _PACIFIC = ZoneInfo("US/Pacific")
@@ -24,9 +23,8 @@ def _rows(n: int) -> list[dict[str, object]]:
 class ContractFaz:
     """Minimal log-search fake with a controllable total and forced errors.
 
-    Honors poll-before-fetch: ``logsearch_count`` reports the scan complete (a
-    cheap GET that does not reap), so the runner polls once and then fetches the
-    page exactly once.
+    ``logsearch_fetch`` returns ``percentage=100`` immediately, so the runner's
+    poll loop completes on the first fetch.
     """
 
     def __init__(
@@ -44,8 +42,7 @@ class ContractFaz:
         self.connected = True
         self.reconnects = 0
         self.start_calls: list[dict[str, object]] = []
-        self.count_calls: list[int] = []
-        self._complete_tids: set[int] = set()
+        self.fetch_calls: list[int] = []
         self._tid = 500
 
     @property
@@ -77,27 +74,10 @@ class ContractFaz:
         self._tid += 1
         return {"tid": self._tid}
 
-    async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
-        """Report the scan complete (does not reap the tid)."""
-        self.count_calls.append(tid)
-        self._complete_tids.add(tid)
-        rows = len(self.page)
-        total = self.total if self.total is not None else rows
-        return {
-            "progress-percent": 100,
-            "matched-logs": rows,
-            "scanned-logs": total,
-            "total-logs": total,
-        }
-
     async def logsearch_fetch(
         self, adom: str, tid: int, limit: int = 50, offset: int = 0
     ) -> dict[str, object]:
-        # Poll-before-fetch: a fetch before this tid's count has reported
-        # complete is an invalid-tid error (the live appliance reaps an
-        # un-ready single-use tid on a premature fetch).
-        if tid not in self._complete_tids:
-            raise ResourceNotFoundError(f"Invalid tid {tid}: not complete.", code=-1)
+        self.fetch_calls.append(tid)
         result: dict[str, object] = {
             "percentage": 100,
             "data": list(self.page),
@@ -142,10 +122,9 @@ class TestQueryLogsContractFields:
         assert r["limit"] == 10
         assert r["next_offset"] == 10  # offset + count, has_more
         assert r["warnings"] == []
-        # Poll-before-fetch: the count probe ran before the fetch (the fetch now
-        # raises invalid-tid if called before its count reports complete, so a
-        # successful page proves count was polled first).
-        assert len(fake.count_calls) >= 1
+        # Spec-compliant polling: the runner polls logsearch_fetch until
+        # percentage=100, so at least one fetch must have happened.
+        assert len(fake.fetch_calls) >= 1
         # Old names are gone.
         assert "total_known" not in r
         assert "returned_offset" not in r

--- a/tests/test_traffic_tools.py
+++ b/tests/test_traffic_tools.py
@@ -422,9 +422,6 @@ class TestPolicyPortAnalysisToolBounded:
             async def logsearch_start(self, **_kwargs: object) -> dict[str, int]:
                 return {"tid": 123}
 
-            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
-                return {"progress-percent": 100, "total-logs": 25, "scanned-logs": 25}
-
             async def logsearch_fetch(self, **_kwargs: object) -> dict[str, object]:
                 return {
                     "percentage": 100,
@@ -882,8 +879,7 @@ class TestCoerceLogTotal:
 
 class TestQueryPolicySliceReliability:
     """A bounded slice query routes through log_tools._run_logsearch_page, so it
-    polls logsearch_count (a non-reaping GET) until the scan is complete and then
-    fetches exactly once, re-issuing a fresh search instead of re-fetching a
+    polls logsearch_fetch until percentage=100, re-issuing a fresh search instead of re-fetching a
     single-use (reaped) FortiAnalyzer tid."""
 
     _WINDOW = {"start": "2024-01-01 00:00:00", "end": "2024-01-01 01:00:00"}
@@ -893,53 +889,6 @@ class TestQueryPolicySliceReliability:
     def _fast_polls(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setattr(log_tools, "_INITIAL_POLL_DELAY", 0)
         monkeypatch.setattr(log_tools, "POLL_INTERVAL", 0)
-
-    async def test_reissues_a_fresh_search_on_invalid_tid_during_count(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """An invalid-tid during count (appliance reaped the search mid-poll)
-        re-issues a fresh search rather than fetching a reaped tid."""
-        starts: list[dict[str, object]] = []
-        counts = {"n": 0}
-
-        class FakeClient:
-            async def ensure_connected(self) -> None:
-                return None
-
-            async def logsearch_start(self, **kwargs: object) -> dict[str, int]:
-                starts.append(kwargs)
-                return {"tid": 100 + len(starts)}
-
-            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
-                counts["n"] += 1
-                if counts["n"] == 1:
-                    raise RuntimeError("Invalid tid reaped mid-poll.")
-                return {"progress-percent": 100, "total-logs": 7, "scanned-logs": 7}
-
-            async def logsearch_fetch(self, **_kwargs: object) -> dict[str, object]:
-                return {
-                    "percentage": 100,
-                    "total-count": "7",
-                    "data": [{"dstport": 443, "proto": "6"}],
-                }
-
-            async def logsearch_cancel(self, *_a: object, **_k: object) -> dict[str, object]:
-                return {}
-
-        monkeypatch.setattr(traffic_tools, "_get_client", lambda: FakeClient())
-
-        result = await _query_policy_log_slice(
-            adom="root",
-            device_filter=self._DEVICE,
-            policy_id=2,
-            time_range=self._WINDOW,
-            action="accept",
-        )
-
-        assert len(starts) == 2  # re-issued, did NOT re-fetch a reaped tid
-        assert result["logs"] == [{"dstport": 443, "proto": "6"}]
-        assert result["total_hits"] == 7
-        assert result["total_hits_is_known"] is True
 
     async def test_reissues_a_fresh_search_on_invalid_tid_error(
         self, monkeypatch: pytest.MonkeyPatch
@@ -956,9 +905,6 @@ class TestQueryPolicySliceReliability:
             async def logsearch_start(self, **kwargs: object) -> dict[str, int]:
                 starts.append(kwargs)
                 return {"tid": 200 + len(starts)}
-
-            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
-                return {"progress-percent": 100, "total-logs": 3, "scanned-logs": 3}
 
             async def logsearch_fetch(self, **_kwargs: object) -> dict[str, object]:
                 fetches["n"] += 1
@@ -997,9 +943,6 @@ class TestQueryPolicySliceReliability:
             async def logsearch_start(self, **_kwargs: object) -> dict[str, int]:
                 return {"tid": 1}
 
-            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
-                return {"progress-percent": 100, "total-logs": 1, "scanned-logs": 1}
-
             async def logsearch_fetch(self, **_kwargs: object) -> dict[str, object]:
                 raise RuntimeError("connection reset by peer")
 
@@ -1028,9 +971,6 @@ class TestQueryPolicySliceReliability:
 
             async def logsearch_start(self, **_kwargs: object) -> dict[str, object]:
                 return {}
-
-            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
-                raise AssertionError("must not count without a tid")
 
             async def logsearch_fetch(self, **_kwargs: object) -> dict[str, object]:
                 raise AssertionError("must not fetch without a tid")
@@ -1061,11 +1001,16 @@ class TestQueryPolicySliceReliability:
             async def logsearch_start(self, **_kwargs: object) -> dict[str, int]:
                 return {"tid": 5}
 
-            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
-                return {"progress-percent": 10, "total-logs": 9, "scanned-logs": 0}
-
             async def logsearch_fetch(self, **_kwargs: object) -> dict[str, object]:
-                raise AssertionError("must not fetch a still-running search")
+                # Spec-compliant polling: scan never reaches 100% within the
+                # deadline; each poll returns percentage<100 with empty data.
+                return {
+                    "percentage": 20,
+                    "return-lines": 0,
+                    "data": [],
+                    "tid": 5,
+                    "status": {"code": 0, "message": "in-progress"},
+                }
 
             async def logsearch_cancel(self, adom: str, tid: int) -> dict[str, object]:
                 cancels.append(tid)
@@ -1221,10 +1166,6 @@ class TestPolicyPathEnsuresConnection:
             async def logsearch_start(self, **_kwargs: object) -> dict[str, int]:
                 events.append("start")
                 return {"tid": 1}
-
-            async def logsearch_count(self, adom: str, tid: int) -> dict[str, object]:
-                events.append("count")
-                return {"progress-percent": 100, "total-logs": 3, "scanned-logs": 3}
 
             async def logsearch_fetch(self, **_kwargs: object) -> dict[str, object]:
                 return {


### PR DESCRIPTION
**Fixes #27.** Drops the non-spec `/logview/adom/{adom}/logsearch/count/{tid}` endpoint and the `_search_complete` field-name checks that don't exist in the official FAZ JSON-RPC spec on any version. Collapses the entire poll-before-fetch design into a single spec-compliant loop on `logsearch_fetch`.

## TL;DR for review

| Metric | Before | After |
|---|---|---|
| Lines of source | ~280 in `_run_logsearch_page_unlocked` + helpers + client method | ~100 (spec-compliant loop) |
| API endpoints called | 2 (`logsearch_count` + `logsearch_fetch`) | 1 (`logsearch_fetch`) |
| Field-name lookups in completion check | 4 non-spec (`progress-percent`, `total-logs`, `matched-logs`, `scanned-logs`) | 1 spec field (`percentage`) |
| Tests | 533 pass against the old design | 533 pass against the new design |
| Net PR delta | — | **-428 lines** |

## Why this is needed

Roland captured `add` + `get /logsearch/{tid}` against BOTH FAZ 7.6.7 and 8.0.0 in #27. The API contracts are **byte-for-byte identical**. The official `logview.logsearch.tid.get.resp` spec documents only `percentage`, `return-lines`, `total-count`, `scanned-logs`, `data`, `status`, `tid`. **No `/logsearch/count/{tid}` endpoint exists** in the documented API.

The bug masqueraded as working on 7.6.7 because the `_logsearch_count_unsupported` fallback compensated when the count endpoint failed in a specific way; on 8.0.0 the fallback doesn't trigger reliably, so `_search_complete` (checking non-existent fields against a non-spec response) never returns True and the poll spins until the 60s timeout. The held slot then doesn't release cleanly, leading to the cascading `No available slot for searching` errors Roland saw.

## What the new runner does

```python
while True:
    if loop.time() >= deadline:
        return {"timed_out": True, ...}
    tid = (await client.logsearch_start(...))["tid"]
    try:
        poll_delay = _INITIAL_POLL_DELAY
        while True:
            remaining = deadline - loop.time()
            if remaining <= 0:
                return {"timed_out": True, ...}
            try:
                result = await asyncio.wait_for(
                    client.logsearch_fetch(adom, tid, limit, offset),
                    timeout=remaining,
                )
            except TimeoutError:
                return {"timed_out": True, ...}
            except Exception as exc:
                if _is_invalid_tid_error(exc):
                    reissue = True; break
                raise

            if (pct := _coerce_num(result.get("percentage"))) is not None and pct >= 100:
                delivered = True
                logs = _normalize_logs(result.get("data"))
                total = _coerce_total(result.get("total-count"))
                if _page_is_final(logs, total, offset):
                    return {"timed_out": False, ...}
                # premature-100% recovery
                if reissues_left <= 0:
                    return {"timed_out": False, ...}
                reissue = True; break

            # still streaming: sleep, re-poll same tid
            await asyncio.sleep(min(poll_delay, remaining))
            poll_delay = min(poll_delay * 2, POLL_INTERVAL)

        if reissue:
            if reissues_left <= 0:
                return {"timed_out": True, ...}
            reissues_left -= 1
            continue
    finally:
        if not delivered and tid:
            try:
                await asyncio.shield(asyncio.wait_for(
                    client.logsearch_cancel(adom, tid),
                    timeout=_CLEANUP_CANCEL_TIMEOUT,
                ))
            except Exception:
                pass
```

## What's preserved from your v2.0.1 resilience layer (PR #18)

- ✅ **Concurrency cap** — `LOGSEARCH_CONCURRENCY_LIMIT = 4` semaphore in `_run_logsearch_page`
- ✅ **Deadline budget** — `MAX_SEARCH_TIMEOUT = 300` ceiling + per-call `wait_for` bounded by remaining
- ✅ **Shared recovery budget** — `MAX_SEARCH_REISSUES = 3` covering invalid-tid and premature-100% races
- ✅ **No-start-past-deadline guard** — loop-top check prevents a reaping appliance from spinning starts
- ✅ **Shielded cleanup-cancel** — `_CLEANUP_CANCEL_TIMEOUT = 2.0`s best-effort on non-delivered exits
- ✅ **Invalid-tid race handling** — `_is_invalid_tid_error()` still used, now in the fetch path
- ✅ **Premature-100% empty-page recovery** — `_page_is_final()` still applies (7.6.7-discovered quirk where percentage:100 ships with empty data while total claims rows)

## What's removed

- `client.logsearch_count()` — non-spec endpoint
- `_search_complete()` — checked fields that don't exist in either FAZ version
- `_is_unsupported_count_endpoint()` — no count endpoint to fall back from
- `_logsearch_count_unsupported` cached flag — no longer needed
- The "Poll readiness via logsearch_count" block in `_run_logsearch_page_unlocked`
- `TestSearchCompletePredicate` + `TestCountUnsupportedFallback` test classes

## Test coverage

All 533 tests pass. Test rewires:

- `test_logsearch_runner.py` — 11 tests rewritten from scratch (one start + many fetches contract, shared budget cap on invalid-tid-fetch + premature-100%, deadline enforcement, leak cleanup, concurrency cap, timeout clamp)
- `test_log_pagination.py` — fake's `logsearch_fetch` rewired to return partial-then-complete; `complete_on_attempt` semantics preserved via fetch-time check
- `test_pcap_tools.py` — `counts` attribute and assertions replaced with `fetches`
- `test_response_contract.py` — `ContractFaz` uses `fetch_calls` instead of `count_calls`
- `test_traffic_tools.py` — `test_reissues_a_fresh_search_on_invalid_tid_during_count` deleted as redundant with `_on_invalid_tid_error` after the count endpoint went away

## For your review @inxbit 🙋

This touches the resilience layer you authored in PR #18. The spec-correct shape mechanically follows from Roland's side-by-side capture of 7.6.7 vs 8.0.0 in #27, but the assertions about resilience behavior — especially how the new `_run_logsearch_page_unlocked` handles the invalid-tid-mid-poll race when fetch is BOTH the readiness probe AND the data delivery — are best validated by you. A few specific questions for your review:

1. **Tid lifecycle** — the old comment said "a tid is single-use; the first fetch reaps it". This PR assumes the tid stays alive while `percentage<100` (because Roland's evidence shows `get` works on the same tid with `percentage=0` mid-scan). Does your live testing back this up, or do we need to combine percentage-checking with the old "reissue if same tid invalidates" logic in a different way?
2. **Premature-100% recovery** — kept as-is via `_page_is_final()`. Still seems correct, but want your eyes on it.
3. **Test for invalid-tid mid-poll** — `TestSharedBudgetCap::test_always_invalid_fetch_caps_starts_then_times_out` covers the case where every fetch raises invalid-tid. Is the semantic right for the new model (vs the old "invalid count → reissue → fetch never tried")?

Feel free to push tweaks directly to this branch — I'll review and re-test.

Live verification against `faz-prod-02` (7.6.7) and `faz-prod-ai` (8.0.0) pending Docker build.
