### PR TITLE
feat(reports): add list_report_templates against dedicated /template/list endpoint

### DIFF
--- a/src/fortianalyzer_mcp/server.py
+++ b/src/fortianalyzer_mcp/server.py
@@ -143,10 +143,8 @@ def register_dynamic_tools(mcp_server: FastMCP) -> None:
                 ("get_policy_hits", "Get policy hit statistics"),
             ],
             "reports": [
-                # list_report_templates removed pending API verification --
-                # see Roland's investigation plan; will be reinstated as either
-                # an alias to list_report_layouts or as a distinct templates-
-                # only tool depending on the live API behavior.
+                ("list_report_layouts", "List runnable report layouts"),
+                ("list_report_templates", "List read-only report templates (blueprints)"),
                 ("run_report", "Run a report"),
                 ("fetch_report", "Fetch report status"),
                 ("get_report_data", "Download report data"),
@@ -281,10 +279,8 @@ def register_dynamic_tools(mcp_server: FastMCP) -> None:
             "get_top_cloud_applications": fortiview_tools.get_top_cloud_applications,
             "get_policy_hits": fortiview_tools.get_policy_hits,
             # Report tools
-            # list_report_templates removed pending API verification --
-            # see Roland's investigation plan; will be reinstated as either
-            # an alias to list_report_layouts or as a distinct templates-only
-            # tool depending on the live API behavior.
+            "list_report_layouts": report_tools.list_report_layouts,
+            "list_report_templates": report_tools.list_report_templates,
             "run_report": report_tools.run_report,
             "fetch_report": report_tools.fetch_report,
             "get_report_data": report_tools.get_report_data,

--- a/src/fortianalyzer_mcp/tools/report_tools.py
+++ b/src/fortianalyzer_mcp/tools/report_tools.py
@@ -233,6 +233,70 @@ async def list_report_layouts(adom: str | None = None) -> dict[str, Any]:
 
 
 @mcp.tool()
+async def list_report_templates(adom: str | None = None) -> dict[str, Any]:
+    """List available read-only report templates in FortiAnalyzer.
+
+    IMPORTANT: Templates are protected blueprints, not runnable reports. To run
+    a report use list_report_layouts() + run_report() instead. Templates are
+    typically cloned into custom layouts via the FortiAnalyzer GUI/CLI.
+
+    Returns templates served by the dedicated FAZ endpoint
+    GET /report/adom/{adom}/template/list, which is distinct from the
+    layout endpoint that list_report_layouts() uses.
+
+    Args:
+        adom: ADOM name (default: from config DEFAULT_ADOM)
+
+    Returns:
+        dict with report templates list including:
+        - layout-id: Template ID (NOT directly runnable — clone first)
+        - title: Human-readable name (e.g., "Template - Security Analysis")
+        - description: Template description
+        - category: Report category (Security, Application, System, ...)
+        - language: Template language (e.g., "en")
+        - content-pack-uuid: Content pack UUID if from a content pack
+
+    Example:
+        >>> result = await list_report_templates("root")
+        >>> for tmpl in result["data"]:
+        ...     print(f"[{tmpl['layout-id']}] {tmpl['title']}")
+    """
+    try:
+        adom = adom or get_default_adom()
+        client = _get_client()
+
+        logger.info(f"Listing report templates in ADOM {adom}")
+
+        result = await client.report_list_templates(adom=adom)
+
+        data = result.get("data", []) if isinstance(result, dict) else result
+        if not isinstance(data, list):
+            data = [data] if data else []
+
+        simplified = [
+            {
+                "layout-id": tmpl.get("layout-id"),
+                "title": tmpl.get("title"),
+                "description": tmpl.get("description", ""),
+                "category": tmpl.get("category", ""),
+                "language": tmpl.get("language", "en"),
+                "content-pack-uuid": tmpl.get("content-pack-uuid", ""),
+            }
+            for tmpl in data
+        ]
+
+        return {
+            "status": "success",
+            "adom": adom,
+            "count": len(simplified),
+            "data": simplified,
+        }
+    except Exception as e:
+        logger.error(f"Failed to list report templates: {e}")
+        return {"status": "error", "message": redact(str(e))}
+
+
+@mcp.tool()
 async def run_report(
     layout: str,
     adom: str | None = None,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -224,9 +224,30 @@ MOCK_FORTIVIEW_RESULTS = {
 
 MOCK_REPORT_TEMPLATES = {
     "data": [
-        {"tid": "template-001", "name": "Security Report"},
-        {"tid": "template-002", "name": "Traffic Analysis"},
+        {
+            "layout-id": 1000050001,
+            "title": "Template - Security Analysis",
+            "language": "en",
+            "content-pack-uuid": "",
+            "content-pack-id": "",
+            "category": "Security",
+            "description": "Security Analysis of traffic, applications, users, threats.",
+            "font-family": "Open Sans",
+            "protected": "enable",
+        },
+        {
+            "layout-id": 1000060002,
+            "title": "Template - Bandwidth and Applications Report",
+            "language": "en",
+            "content-pack-uuid": "",
+            "content-pack-id": "",
+            "category": "Application",
+            "description": "Traffic, Bandwidth, Sessions summaries by users and applications.",
+            "font-family": "Open Sans",
+            "protected": "enable",
+        },
     ],
+    "status": {"code": 0, "message": "Get 2 report templates."},
 }
 
 MOCK_REPORT_LAYOUTS = {

--- a/tests/test_report_tools.py
+++ b/tests/test_report_tools.py
@@ -125,6 +125,34 @@ class TestReportClient:
         assert layouts[0]["layout-id"] == 1
         assert layouts[0]["title"] == "Executive Summary"
 
+    async def test_report_list_templates_success(
+        self, mock_client_with_reports: FortiAnalyzerClient
+    ) -> None:
+        """Test report_list_templates returns template list with API shape."""
+        result = await mock_client_with_reports.report_list_templates(adom="root")
+        assert "data" in result
+        templates = result["data"]
+        assert len(templates) == 2
+        # Confirm the spec shape (layout-id, title, content-pack-uuid, protected)
+        # is preserved end-to-end from the dedicated /template/list endpoint.
+        assert templates[0]["layout-id"] == 1000050001
+        assert templates[0]["title"] == "Template - Security Analysis"
+        assert templates[0]["protected"] == "enable"
+        assert templates[0]["content-pack-uuid"] == ""
+        assert templates[1]["category"] == "Application"
+
+    async def test_report_list_templates_not_connected(self) -> None:
+        """Test report_list_templates raises when not connected."""
+        from fortianalyzer_mcp.utils.errors import ConnectionError
+
+        client = FortiAnalyzerClient(
+            host="test-faz.example.com",
+            username="admin",
+            password="password",
+        )
+        with pytest.raises(ConnectionError, match="Not connected"):
+            await client.report_list_templates(adom="root")
+
     async def test_report_run_success(self, mock_client_with_reports: FortiAnalyzerClient) -> None:
         """Test report_run returns TID."""
         result = await mock_client_with_reports.report_run(


### PR DESCRIPTION
**For Christian's review.**

## Background

PR #26 by @sanderzegers raised the original concern: the server registered a `list_report_templates` tool that didn't actually exist, causing AttributeError at startup. His proposed fix was a 2-line alias to `list_report_layouts`. We yanked v2.2.1 from that PR to verify whether an alias was the right semantic.

## Why an alias would have been wrong

Live JSON-RPC probes against FAZ 8.0 confirmed FortiAnalyzer exposes **two distinct endpoints**, returning different shapes:

| Endpoint | Returns | Shape |
|---|---|---|
| `GET /report/adom/{adom}/template/list` | 91 protected templates (blueprints) | `{layout-id, title, language, content-pack-uuid, content-pack-id, category, description, font-family, protected}` |
| `GET /config/adom/{adom}/sql-report/layout` | runnable layouts + embedded templates | `is-template=1` for templates, plus full HTML `body`, styling, etc. — already filtered out by `list_report_layouts` |

An alias would have returned the wrong shape (full HTML bodies) and the wrong subset (only templates that happen to be embedded in the layout response, not the full 91-template FortiGuard catalog).

## What this PR does

- **`tools/report_tools.py`**: adds `list_report_templates()` MCP tool wired to the existing `report_list_templates()` client method (which was already calling the correct endpoint).
- **`server.py`**: restores `list_report_templates` registration in both the search catalog and the `execute_advanced_tool` dynamic map. Also adds `list_report_layouts` to both (it was missing — small consistency fix).
- **`tests/conftest.py`**: `MOCK_REPORT_TEMPLATES` was a placeholder with `{tid, name}` shape; updated to match the real API spec shape so tests are realistic.
- **`tests/test_report_tools.py`**: adds success + disconnected coverage for `report_list_templates`.

## Test status

- 546/546 unit tests pass.
- `ruff check` + `ruff format --check` clean.
- The 5 failing `tests/integration/test_real_logs.py` cases on main are **unrelated** — they're the FAZ 8.0 logsearch bug being fixed in PR #28.

## Verification probe used

```json
{
  "method": "get",
  "jsonrpc": "2.0",
  "params": [{"apiver": 3, "url": "/report/adom/root/template/list"}],
  "session": "{{session}}",
  "id": 1
}
```

Against `faz-prod-ai` (FAZ 8.0.0). Response: `status.code=0`, `Get 91 report templates.`, identical shape to the FAZ 7.x library reference.

## Credits

Original concern + PR #26 from @sanderzegers (added as `Co-authored-by`).