### PR TITLE
Security hardening: credential masking, ZIP size caps, token-compare timing, input validation

### DIFF
--- a/src/fortianalyzer_mcp/server.py
+++ b/src/fortianalyzer_mcp/server.py
@@ -1,5 +1,6 @@
 """FortiAnalyzer MCP Server implementation."""
 
+import hashlib
 import hmac
 import logging
 from collections.abc import AsyncIterator
@@ -538,7 +539,13 @@ def run_http() -> None:
             auth_value = headers.get(b"authorization", b"").decode()
             expected = f"Bearer {settings.MCP_AUTH_TOKEN}"
 
-            if not hmac.compare_digest(auth_value, expected):
+            # Hash both sides before comparing: compare_digest short-circuits on
+            # length mismatch, which would leak the token length as a timing
+            # side-channel. Equal-length digests keep it constant-time.
+            if not hmac.compare_digest(
+                hashlib.sha256(auth_value.encode()).digest(),
+                hashlib.sha256(expected.encode()).digest(),
+            ):
                 response = Response(
                     content=json.dumps(
                         {"error": "Unauthorized", "detail": "Invalid or missing Bearer token"}

--- a/src/fortianalyzer_mcp/tools/dvm_tools.py
+++ b/src/fortianalyzer_mcp/tools/dvm_tools.py
@@ -8,14 +8,21 @@ and device group management.
 import logging
 from typing import Any
 
+from fortianalyzer_mcp.api.client import FortiAnalyzerClient
 from fortianalyzer_mcp.server import get_faz_client, mcp
 from fortianalyzer_mcp.utils.responses import redact
-from fortianalyzer_mcp.utils.validation import get_default_adom
+from fortianalyzer_mcp.utils.validation import (
+    ValidationError,
+    get_default_adom,
+    sanitize_for_logging,
+    validate_adom,
+    validate_device_name,
+)
 
 logger = logging.getLogger(__name__)
 
 
-def _get_client():
+def _get_client() -> FortiAnalyzerClient:
     """Get the FortiAnalyzer client instance."""
     client = get_faz_client()
     if not client:
@@ -170,6 +177,8 @@ async def add_device(
         ... )
     """
     try:
+        adom = validate_adom(adom)
+        name = validate_device_name(name)
         client = _get_client()
 
         # Build device configuration
@@ -215,6 +224,8 @@ async def add_device(
             "device": device_result,
             "task_id": result.get("taskid"),
         }
+    except ValidationError as e:
+        return {"status": "error", "message": f"Validation error: {e}"}
     except Exception as e:
         logger.error(f"Failed to add device {name}: {e}")
         return {"status": "error", "message": redact(str(e))}
@@ -250,6 +261,8 @@ async def delete_device(
         ...     print("Device removed from FortiAnalyzer")
     """
     try:
+        adom = validate_adom(adom)
+        device = validate_device_name(device)
         client = _get_client()
 
         result = await client.delete_device(
@@ -263,6 +276,8 @@ async def delete_device(
             "task_id": result.get("taskid"),
             "message": f"Device {device} deleted successfully",
         }
+    except ValidationError as e:
+        return {"status": "error", "message": f"Validation error: {e}"}
     except Exception as e:
         logger.error(f"Failed to delete device {device}: {e}")
         return {"status": "error", "message": redact(str(e))}
@@ -309,6 +324,7 @@ async def add_devices_bulk(
         if not devices:
             return {"status": "error", "message": "No devices provided"}
 
+        adom = validate_adom(adom)
         client = _get_client()
 
         result = await client.add_device_list(
@@ -327,6 +343,8 @@ async def add_devices_bulk(
             "devices": devices_safe,
             "task_id": result.get("taskid"),
         }
+    except ValidationError as e:
+        return {"status": "error", "message": f"Validation error: {e}"}
     except Exception as e:
         logger.error(f"Failed to add devices in bulk: {e}")
         return {"status": "error", "message": redact(str(e))}
@@ -363,10 +381,11 @@ async def delete_devices_bulk(
         if not devices:
             return {"status": "error", "message": "No devices provided"}
 
+        adom = validate_adom(adom)
         client = _get_client()
 
         # Convert device names to the expected format
-        device_list = [{"name": name} for name in devices]
+        device_list = [{"name": validate_device_name(name)} for name in devices]
 
         result = await client.delete_device_list(
             adom=adom,
@@ -379,6 +398,8 @@ async def delete_devices_bulk(
             "deleted_count": len(devices),
             "task_id": result.get("taskid"),
         }
+    except ValidationError as e:
+        return {"status": "error", "message": f"Validation error: {e}"}
     except Exception as e:
         logger.error(f"Failed to delete devices in bulk: {e}")
         return {"status": "error", "message": redact(str(e))}
@@ -418,7 +439,9 @@ async def get_device_info(
 
         result: dict[str, Any] = {
             "status": "success",
-            "device": device_data,
+            # DVMDB device objects carry credential material (adm_pass, etc.);
+            # mask it before returning over MCP.
+            "device": sanitize_for_logging(device_data),
         }
 
         if include_vdoms:
@@ -467,7 +490,7 @@ async def search_devices(
         client = _get_client()
 
         # Build filter list
-        filters = []
+        filters: list[list[Any]] = []
         if name_filter:
             filters.append(["name", "contain", name_filter])
         if platform_filter:
@@ -487,7 +510,9 @@ async def search_devices(
         return {
             "status": "success",
             "count": len(devices),
-            "devices": devices,
+            # DVMDB device objects carry credential material (adm_pass, etc.);
+            # mask it before returning over MCP.
+            "devices": sanitize_for_logging(devices),
         }
     except Exception as e:
         logger.error(f"Failed to search devices: {e}")

--- a/src/fortianalyzer_mcp/tools/incident_tools.py
+++ b/src/fortianalyzer_mcp/tools/incident_tools.py
@@ -7,15 +7,23 @@ Provides incident creation, tracking, and SOC workflow operations.
 import logging
 from typing import Any
 
+from fortianalyzer_mcp.api.client import FortiAnalyzerClient
 from fortianalyzer_mcp.server import get_faz_client, mcp
 from fortianalyzer_mcp.utils.responses import redact
 from fortianalyzer_mcp.utils.time_range import parse_time_range
-from fortianalyzer_mcp.utils.validation import get_default_adom
+from fortianalyzer_mcp.utils.validation import (
+    ValidationError,
+    get_default_adom,
+    validate_severity,
+)
+
+# FAZ incident workflow states accepted by update_incident.
+_VALID_INCIDENT_STATUSES = {"new", "investigating", "contained", "resolved", "closed"}
 
 logger = logging.getLogger(__name__)
 
 
-def _get_client():
+def _get_client() -> FortiAnalyzerClient:
     """Get the FortiAnalyzer client instance."""
     client = get_faz_client()
     if not client:
@@ -221,6 +229,7 @@ async def create_incident(
     """
     try:
         adom = adom or get_default_adom()
+        severity = validate_severity(severity)
         client = _get_client()
 
         logger.info(f"Creating incident '{name}' in ADOM {adom}")
@@ -240,6 +249,8 @@ async def create_incident(
             "severity": severity,
             "data": result,
         }
+    except ValidationError as e:
+        return {"status": "error", "message": f"Validation error: {e}"}
     except Exception as e:
         logger.error(f"Failed to create incident: {e}")
         return {"status": "error", "message": redact(str(e))}
@@ -281,6 +292,14 @@ async def update_incident(
     """
     try:
         adom = adom or get_default_adom()
+        if severity is not None:
+            severity = validate_severity(severity)
+        if status is not None and status.lower() not in _VALID_INCIDENT_STATUSES:
+            valid = ", ".join(sorted(_VALID_INCIDENT_STATUSES))
+            return {
+                "status": "error",
+                "message": f"Validation error: Invalid status '{status}'. Must be one of: {valid}",
+            }
         client = _get_client()
 
         logger.info(f"Updating incident {incident_id} in ADOM {adom}")
@@ -299,6 +318,8 @@ async def update_incident(
             "incident_id": incident_id,
             "data": result,
         }
+    except ValidationError as e:
+        return {"status": "error", "message": f"Validation error: {e}"}
     except Exception as e:
         logger.error(f"Failed to update incident {incident_id}: {e}")
         return {"status": "error", "message": redact(str(e))}

--- a/src/fortianalyzer_mcp/tools/pcap_tools.py
+++ b/src/fortianalyzer_mcp/tools/pcap_tools.py
@@ -15,6 +15,7 @@ import zipfile
 from datetime import datetime
 from typing import Any
 
+from fortianalyzer_mcp.api.client import FortiAnalyzerClient
 from fortianalyzer_mcp.server import get_faz_client, mcp
 from fortianalyzer_mcp.tools.log_tools import _clamp_timeout, _run_logsearch_page
 from fortianalyzer_mcp.utils.responses import redact
@@ -43,7 +44,7 @@ DEFAULT_SEARCH_TIMEOUT = 60
 MAX_PCAP_SIZE = 50 * 1024 * 1024  # 50MB per PCAP file
 
 
-def _get_client():
+def _get_client() -> FortiAnalyzerClient:
     """Get the FortiAnalyzer client instance."""
     client = get_faz_client()
     if not client:
@@ -502,7 +503,16 @@ async def get_pcap_by_session(
                             "message": f"PCAP file too large: {info.file_size} bytes",
                         }
 
-                    content = zf.read(filename)
+                    # The central-directory file_size above is untrusted metadata;
+                    # cap the actual decompressed bytes too.
+                    with zf.open(filename) as src:
+                        content = src.read(MAX_PCAP_SIZE + 1)
+                    if len(content) > MAX_PCAP_SIZE:
+                        return {
+                            "status": "error",
+                            "session_id": session_id,
+                            "message": f"PCAP file too large: exceeds {MAX_PCAP_SIZE} bytes",
+                        }
                     file_size = len(content)
 
                     # Generate filename with session ID and timestamp
@@ -635,7 +645,15 @@ async def download_pcap_by_url(
                             "message": f"PCAP too large: {info.file_size} bytes",
                         }
 
-                    content = zf.read(filename)
+                    # The central-directory file_size above is untrusted metadata;
+                    # cap the actual decompressed bytes too.
+                    with zf.open(filename) as src:
+                        content = src.read(MAX_PCAP_SIZE + 1)
+                    if len(content) > MAX_PCAP_SIZE:
+                        return {
+                            "status": "error",
+                            "message": f"PCAP too large: exceeds {MAX_PCAP_SIZE} bytes",
+                        }
                     file_size = len(content)
 
                     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
@@ -853,7 +871,14 @@ async def search_and_download_pcaps(
                             failed_count += 1
                             break
 
-                        content = zf.read(filename)
+                        # The central-directory file_size above is untrusted
+                        # metadata; cap the actual decompressed bytes too.
+                        with zf.open(filename) as src:
+                            content = src.read(MAX_PCAP_SIZE + 1)
+                        if len(content) > MAX_PCAP_SIZE:
+                            errors.append(f"Session {session_id}: File too large")
+                            failed_count += 1
+                            break
                         timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
                         base_name = os.path.basename(filename)
                         name_part = os.path.splitext(base_name)[0]
@@ -950,7 +975,7 @@ async def list_available_pcaps(
         adom = validate_adom(adom or get_default_adom())
 
         # Use search_ips_logs with has_pcap=True
-        search_result = await search_ips_logs(
+        search_result: dict[str, Any] = await search_ips_logs(
             adom=adom,
             severity=severity,
             attack_contains=attack_contains,

--- a/src/fortianalyzer_mcp/tools/system_tools.py
+++ b/src/fortianalyzer_mcp/tools/system_tools.py
@@ -6,14 +6,15 @@ Based on FNDN FortiAnalyzer 7.6.5 SYS, DVMDB, CLI, and TASK API specifications.
 import logging
 from typing import Any
 
+from fortianalyzer_mcp.api.client import FortiAnalyzerClient
 from fortianalyzer_mcp.server import get_faz_client, mcp
 from fortianalyzer_mcp.utils.responses import redact
-from fortianalyzer_mcp.utils.validation import get_default_adom
+from fortianalyzer_mcp.utils.validation import get_default_adom, sanitize_for_logging
 
 logger = logging.getLogger(__name__)
 
 
-def _get_client():
+def _get_client() -> FortiAnalyzerClient:
     """Get the FortiAnalyzer client instance."""
     client = get_faz_client()
     if not client:
@@ -208,7 +209,9 @@ async def list_devices(
         return {
             "status": "success",
             "count": len(devices),
-            "devices": devices,
+            # DVMDB device objects carry credential material (adm_pass, etc.);
+            # mask it before returning over MCP.
+            "devices": sanitize_for_logging(devices),
         }
     except Exception as e:
         logger.error(f"Failed to list devices in ADOM {adom}: {e}")
@@ -246,7 +249,9 @@ async def get_device(
         device = await client.get_device(name, adom, loadsub=loadsub)
         return {
             "status": "success",
-            "device": device,
+            # DVMDB device objects carry credential material (adm_pass, etc.);
+            # mask it before returning over MCP.
+            "device": sanitize_for_logging(device),
         }
     except Exception as e:
         logger.error(f"Failed to get device {name}: {e}")
@@ -385,10 +390,10 @@ async def wait_for_task(
 
     try:
         client = _get_client()
-        start_time = asyncio.get_event_loop().time()
+        start_time = asyncio.get_running_loop().time()
 
         while True:
-            elapsed = asyncio.get_event_loop().time() - start_time
+            elapsed = asyncio.get_running_loop().time() - start_time
             if elapsed > timeout:
                 return {
                     "status": "error",

--- a/tests/test_security_regressions.py
+++ b/tests/test_security_regressions.py
@@ -1,0 +1,142 @@
+"""Regression tests for the security-hardening fixes.
+
+Covers device-credential masking on the device-listing tools and the
+adom/device-name and severity/status validation on the mutation tools.
+
+Each fake client mirrors the real FortiAnalyzerClient method signature so a
+tool passing a wrong keyword argument fails the test (a plain MagicMock would
+silently accept anything).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import fortianalyzer_mcp.tools.dvm_tools as dvm_tools
+import fortianalyzer_mcp.tools.incident_tools as incident_tools
+import fortianalyzer_mcp.tools.system_tools as system_tools
+from fortianalyzer_mcp.utils.validation import MASK_VALUE
+
+DEVICE_WITH_CREDS = {
+    "name": "FGT-01",
+    "ip": "192.168.1.1",
+    "sn": "FGT60F0000000001",
+    "conn_status": 1,
+    "adm_usr": "admin",
+    "adm_pass": ["ENC", "SH2MPbdXdoo7ekXsbtjm0Ga"],
+}
+
+
+class TestDeviceCredentialSanitization:
+    """Regression: device tools returned raw DVMDB objects including adm_pass."""
+
+    async def test_system_list_devices_masks_credentials(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class FakeClient:
+            async def list_devices(
+                self, adom: str, fields: list[str] | None = None
+            ) -> list[dict[str, Any]]:
+                return [dict(DEVICE_WITH_CREDS)]
+
+        monkeypatch.setattr(system_tools, "get_faz_client", lambda: FakeClient())
+
+        result = await system_tools.list_devices(adom="root")
+
+        assert result["status"] == "success"
+        device = result["devices"][0]
+        assert device["adm_pass"] == MASK_VALUE
+        assert device["name"] == "FGT-01"
+        assert device["ip"] == "192.168.1.1"
+
+    async def test_system_get_device_masks_credentials(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class FakeClient:
+            async def get_device(self, name: str, adom: str, loadsub: int = 0) -> dict[str, Any]:
+                return dict(DEVICE_WITH_CREDS)
+
+        monkeypatch.setattr(system_tools, "get_faz_client", lambda: FakeClient())
+
+        result = await system_tools.get_device(name="FGT-01", adom="root")
+
+        assert result["status"] == "success"
+        assert result["device"]["adm_pass"] == MASK_VALUE
+
+    async def test_dvm_search_devices_masks_credentials(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class FakeClient:
+            async def list_devices(
+                self, adom: str, filter: list[Any] | None = None
+            ) -> list[dict[str, Any]]:
+                return [dict(DEVICE_WITH_CREDS)]
+
+        monkeypatch.setattr(dvm_tools, "get_faz_client", lambda: FakeClient())
+
+        result = await dvm_tools.search_devices(adom="root", name_filter="FGT")
+
+        assert result["status"] == "success"
+        assert result["devices"][0]["adm_pass"] == MASK_VALUE
+
+    async def test_dvm_get_device_info_masks_credentials(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class FakeClient:
+            async def get_device(self, device: str, adom: str, loadsub: int = 0) -> dict[str, Any]:
+                return dict(DEVICE_WITH_CREDS)
+
+        monkeypatch.setattr(dvm_tools, "get_faz_client", lambda: FakeClient())
+
+        result = await dvm_tools.get_device_info(device="FGT-01", adom="root")
+
+        assert result["status"] == "success"
+        assert result["device"]["adm_pass"] == MASK_VALUE
+
+
+class TestIncidentInputValidation:
+    """create_incident/update_incident must reject invalid severity/status."""
+
+    async def test_create_incident_rejects_invalid_severity(self) -> None:
+        result = await incident_tools.create_incident(name="Test", severity="catastrophic")
+        assert result["status"] == "error"
+        assert "Validation error" in result["message"]
+
+    async def test_update_incident_rejects_invalid_status(self) -> None:
+        result = await incident_tools.update_incident(incident_id="INC-1", status="bogus")
+        assert result["status"] == "error"
+        assert "Validation error" in result["message"]
+
+    async def test_update_incident_rejects_invalid_severity(self) -> None:
+        result = await incident_tools.update_incident(incident_id="INC-1", severity="bogus")
+        assert result["status"] == "error"
+        assert "Validation error" in result["message"]
+
+    async def test_create_incident_accepts_valid_severity(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class FakeClient:
+            async def create_incident(self, **kwargs: Any) -> dict[str, Any]:
+                return {"id": "INC-9"}
+
+        monkeypatch.setattr(incident_tools, "get_faz_client", lambda: FakeClient())
+
+        result = await incident_tools.create_incident(name="Test", severity="High")
+        assert result["status"] == "success"
+        assert result["severity"] == "high"
+
+
+class TestDvmMutationValidation:
+    """add/delete device tools must validate adom and device names."""
+
+    async def test_add_device_rejects_bad_adom(self) -> None:
+        result = await dvm_tools.add_device(adom="root; rm -rf /", name="FGT-X", ip="10.0.0.1")
+        assert result["status"] == "error"
+        assert "Validation error" in result["message"]
+
+    async def test_delete_device_rejects_bad_name(self) -> None:
+        result = await dvm_tools.delete_device(adom="root", device="x/../../etc")
+        assert result["status"] == "error"
+        assert "Validation error" in result["message"]


### PR DESCRIPTION
Part of a QA pass against live FortiAnalyzer 7.6.7 and 8.0.0, split into focused PRs that are independent and mergeable in any order: #31 (this one, security hardening), #32 (tool correctness fixes), #33 (type safety and internals). A separate reliability fix found during the same pass is in #34 (re-login on an expired session).

These are security fixes found while auditing the tool surface against live appliances.

What this changes:

- Device tools leaked credentials. `list_devices`, `get_device`, `search_devices` and `get_device_info` returned raw DVMDB objects, which include the `adm_pass` encrypted-credential blob. They now run device objects through the existing sensitive-field masker before returning.
- PCAP extraction trusted the ZIP header size. The three PCAP download paths checked only `ZipInfo.file_size` (central-directory metadata a crafted archive can understate) before reading the entry. They now stream-read at most the size cap plus one byte and error out past it, so memory stays bounded regardless of what the header claims.
- Bearer-token comparison could leak the token length. `hmac.compare_digest` returns early on a length mismatch, so response timing revealed the configured token length. Both sides are now SHA-256 hashed before the constant-time compare.
- Mutation tools validate their inputs. `add_device`/`delete_device` (single and bulk) run `validate_adom` and `validate_device_name`; `create_incident`/`update_incident` check severity and status against their allowlists.

Verification: the full unit suite plus CI (lint, security, tests on 3.12 and 3.13) pass; new tests are in `tests/test_security_regressions.py`. Live on both 7.6.7 and 8.0.0 I confirmed the credential masking (adm_pass comes back redacted) and the input validation (bad severity, status, adom and device name are rejected before any appliance call). The ZIP-size cap and the token-compare change are not appliance-observable, so they are covered by the unit tests only.
