### PR TITLE
Fix broken/incorrect tool behavior: IOC ack, FortiView completeness, report verification, IOC rescan filter

### DIFF
--- a/src/fortianalyzer_mcp/tools/fortiview_tools.py
+++ b/src/fortianalyzer_mcp/tools/fortiview_tools.py
@@ -8,6 +8,7 @@ import asyncio
 import logging
 from typing import Any
 
+from fortianalyzer_mcp.api.client import FortiAnalyzerClient
 from fortianalyzer_mcp.server import get_faz_client, mcp
 from fortianalyzer_mcp.utils.responses import redact
 from fortianalyzer_mcp.utils.time_range import parse_time_range
@@ -21,7 +22,7 @@ from fortianalyzer_mcp.utils.validation import (
 logger = logging.getLogger(__name__)
 
 
-def _get_client():
+def _get_client() -> FortiAnalyzerClient:
     """Get the FortiAnalyzer client instance."""
     client = get_faz_client()
     if not client:
@@ -279,11 +280,11 @@ async def get_fortiview_data(
             }
 
         # Poll for results
-        start_time = asyncio.get_event_loop().time()
+        start_time = asyncio.get_running_loop().time()
         poll_interval = 0.5
 
         while True:
-            elapsed = asyncio.get_event_loop().time() - start_time
+            elapsed = asyncio.get_running_loop().time() - start_time
             if elapsed > timeout:
                 return {
                     "status": "timeout",
@@ -297,12 +298,15 @@ async def get_fortiview_data(
                 tid=tid,
             )
 
-            # Check if we have data
+            # Only return once the query is complete; returning on first
+            # non-empty data hands back partial aggregates (wrong top-N).
+            # A missing percentage defaults to 100 so builds that omit it
+            # still return immediately.
             if isinstance(fetch_result, dict):
                 data = fetch_result.get("data", [])
                 percentage = fetch_result.get("percentage", 100)
 
-                if percentage >= 100 or data:
+                if percentage >= 100:
                     if not isinstance(data, list):
                         data = [data] if data else []
 
@@ -353,7 +357,7 @@ async def get_top_sources(
         >>> for source in result["data"]:
         ...     print(f"{source['srcip']}: {source['bandwidth']} bytes")
     """
-    return await get_fortiview_data(
+    result: dict[str, Any] = await get_fortiview_data(
         view_name="top-sources",
         adom=adom,
         device=device,
@@ -361,6 +365,7 @@ async def get_top_sources(
         limit=limit,
         sort_by=sort_by,
     )
+    return result
 
 
 @mcp.tool()
@@ -385,7 +390,7 @@ async def get_top_destinations(
     Returns:
         dict with top destinations data
     """
-    return await get_fortiview_data(
+    result: dict[str, Any] = await get_fortiview_data(
         view_name="top-destinations",
         adom=adom,
         device=device,
@@ -393,6 +398,7 @@ async def get_top_destinations(
         limit=limit,
         sort_by=sort_by,
     )
+    return result
 
 
 @mcp.tool()
@@ -422,7 +428,7 @@ async def get_top_applications(
         >>> for app in result["data"]:
         ...     print(f"{app['app']}: {app['bandwidth']} bytes")
     """
-    return await get_fortiview_data(
+    result: dict[str, Any] = await get_fortiview_data(
         view_name="top-applications",
         adom=adom,
         device=device,
@@ -430,6 +436,7 @@ async def get_top_applications(
         limit=limit,
         sort_by=sort_by,
     )
+    return result
 
 
 @mcp.tool()
@@ -462,7 +469,7 @@ async def get_top_threats(
         >>> for threat in result["data"]:
         ...     print(f"{threat['threat']}: {threat['threatweight']} score")
     """
-    return await get_fortiview_data(
+    result: dict[str, Any] = await get_fortiview_data(
         view_name="top-threats",
         adom=adom,
         device=device,
@@ -470,6 +477,7 @@ async def get_top_threats(
         limit=limit,
         sort_by=sort_by,
     )
+    return result
 
 
 @mcp.tool()
@@ -494,7 +502,7 @@ async def get_top_websites(
     Returns:
         dict with top websites data
     """
-    return await get_fortiview_data(
+    result: dict[str, Any] = await get_fortiview_data(
         view_name="top-websites",
         adom=adom,
         device=device,
@@ -502,6 +510,7 @@ async def get_top_websites(
         limit=limit,
         sort_by=sort_by,
     )
+    return result
 
 
 @mcp.tool()
@@ -526,7 +535,7 @@ async def get_top_cloud_applications(
     Returns:
         dict with top cloud applications data
     """
-    return await get_fortiview_data(
+    result: dict[str, Any] = await get_fortiview_data(
         view_name="top-cloud-applications",
         adom=adom,
         device=device,
@@ -534,6 +543,7 @@ async def get_top_cloud_applications(
         limit=limit,
         sort_by=sort_by,
     )
+    return result
 
 
 @mcp.tool()
@@ -560,7 +570,7 @@ async def get_policy_hits(
     Returns:
         dict with policy hit statistics including policyid
     """
-    return await get_fortiview_data(
+    result: dict[str, Any] = await get_fortiview_data(
         view_name="policy-hits",
         adom=adom,
         device=device,
@@ -568,3 +578,4 @@ async def get_policy_hits(
         limit=limit,
         sort_by=sort_by,
     )
+    return result

--- a/src/fortianalyzer_mcp/tools/ioc_tools.py
+++ b/src/fortianalyzer_mcp/tools/ioc_tools.py
@@ -8,15 +8,16 @@ import asyncio
 import logging
 from typing import Any
 
+from fortianalyzer_mcp.api.client import FortiAnalyzerClient
 from fortianalyzer_mcp.server import get_faz_client, mcp
 from fortianalyzer_mcp.utils.responses import redact
 from fortianalyzer_mcp.utils.time_range import parse_time_range
-from fortianalyzer_mcp.utils.validation import get_default_adom
+from fortianalyzer_mcp.utils.validation import build_device_filter, get_default_adom
 
 logger = logging.getLogger(__name__)
 
 
-def _get_client():
+def _get_client() -> FortiAnalyzerClient:
     """Get the FortiAnalyzer client instance."""
     client = get_faz_client()
     if not client:
@@ -102,7 +103,7 @@ async def acknowledge_ioc_events(
 
         result = await client.acknowledge_ioc_events(
             adom=adom,
-            ioc_ids=ioc_ids,
+            event_ids=ioc_ids,
             user=user,
         )
 
@@ -153,7 +154,7 @@ async def run_ioc_rescan(
 
         result = await client.ioc_rescan_run(
             adom=adom,
-            device=device,
+            device=build_device_filter(device),
             time_range=tr,
         )
 
@@ -300,7 +301,7 @@ async def run_and_wait_ioc_rescan(
         # Start the rescan
         run_result = await client.ioc_rescan_run(
             adom=adom,
-            device=device,
+            device=build_device_filter(device),
             time_range=tr,
         )
 
@@ -312,11 +313,11 @@ async def run_and_wait_ioc_rescan(
             }
 
         # Poll for completion
-        start_time = asyncio.get_event_loop().time()
+        start_time = asyncio.get_running_loop().time()
         poll_interval = 2.0
 
         while True:
-            elapsed = asyncio.get_event_loop().time() - start_time
+            elapsed = asyncio.get_running_loop().time() - start_time
             if elapsed > timeout:
                 return {
                     "status": "timeout",
@@ -328,7 +329,9 @@ async def run_and_wait_ioc_rescan(
 
             if isinstance(status_result, dict):
                 state = status_result.get("state", status_result.get("status", ""))
-                percentage = status_result.get("percentage", status_result.get("percent", 0))
+                raw_pct = status_result.get("percentage", status_result.get("percent", 0))
+                # FAZ can send a null percentage; treat anything non-numeric as 0.
+                percentage = raw_pct if isinstance(raw_pct, (int, float)) else 0
 
                 if state in ("done", "completed") or percentage >= 100:
                     return {

--- a/src/fortianalyzer_mcp/tools/report_tools.py
+++ b/src/fortianalyzer_mcp/tools/report_tools.py
@@ -12,6 +12,7 @@ import os
 import zipfile
 from typing import Any
 
+from fortianalyzer_mcp.api.client import FortiAnalyzerClient
 from fortianalyzer_mcp.server import get_faz_client, mcp
 from fortianalyzer_mcp.utils.responses import redact
 from fortianalyzer_mcp.utils.time_range import parse_time_range
@@ -26,7 +27,7 @@ from fortianalyzer_mcp.utils.validation import (
 logger = logging.getLogger(__name__)
 
 
-def _get_client():
+def _get_client() -> FortiAnalyzerClient:
     """Get the FortiAnalyzer client instance."""
     client = get_faz_client()
     if not client:
@@ -120,13 +121,15 @@ async def _get_layout_id_by_title(client: Any, adom: str, title: str) -> int | N
         for layout in layouts:
             layout_title = layout.get("title", "")
             if layout_title.lower() == title_lower:
-                return layout.get("layout-id")
+                layout_id = layout.get("layout-id")
+                return layout_id if isinstance(layout_id, int) else None
 
         # Try partial match if exact match fails
         for layout in layouts:
             layout_title = layout.get("title", "")
             if title_lower in layout_title.lower():
-                return layout.get("layout-id")
+                layout_id = layout.get("layout-id")
+                return layout_id if isinstance(layout_id, int) else None
 
         return None
     except Exception as e:
@@ -688,11 +691,11 @@ async def run_and_wait_report(
             }
 
         # Step 5: Poll for completion using get_running_reports
-        start_time = asyncio.get_event_loop().time()
+        start_time = asyncio.get_running_loop().time()
         poll_interval = 3.0
 
         while True:
-            elapsed = asyncio.get_event_loop().time() - start_time
+            elapsed = asyncio.get_running_loop().time() - start_time
             if elapsed > timeout:
                 return {
                     "status": "timeout",
@@ -733,18 +736,34 @@ async def run_and_wait_report(
                         "message": "Report completed. Use get_report_data() to download.",
                     }
             else:
-                # Report not in running list - either completed or failed
-                # Try to get report data to confirm completion
-                logger.info(f"Report {tid} no longer in running list, checking if completed")
-                return {
-                    "status": "success",
-                    "tid": tid,
-                    "layout": layout,
-                    "layout_id": layout_id,
-                    "adom": adom,
-                    "time_period": time_period,
-                    "message": "Report completed. Use get_report_data() to download.",
-                }
+                # Report not in running list - either completed or failed.
+                # Verify via report_fetch instead of assuming success
+                # (state is "generated" on completion; a vanished tid raises).
+                logger.info(f"Report {tid} not in running list, verifying completion")
+                fetch_result = await client.report_fetch(adom=adom, tid=tid)
+                state = fetch_result.get("state") if isinstance(fetch_result, dict) else None
+                if state == "generated":
+                    return {
+                        "status": "success",
+                        "tid": tid,
+                        "layout": layout,
+                        "layout_id": layout_id,
+                        "adom": adom,
+                        "time_period": time_period,
+                        "message": "Report completed. Use get_report_data() to download.",
+                    }
+                if state not in ("pending", "running"):
+                    return {
+                        "status": "error",
+                        "tid": tid,
+                        "layout": layout,
+                        "layout_id": layout_id,
+                        "adom": adom,
+                        "time_period": time_period,
+                        "message": f"Report ended in state '{state}' without completing.",
+                    }
+                # pending/running: not yet visible in the running list
+                # (startup race); fall through and keep polling.
 
             await asyncio.sleep(poll_interval)
 
@@ -845,9 +864,21 @@ async def save_report(
                             "message": f"Total extraction size exceeds limit ({MAX_TOTAL_SIZE} bytes)",
                         }
 
-                    # Read file content
-                    content = zf.read(filename)
+                    # Read file content. The central-directory file_size above is
+                    # untrusted metadata; cap the actual decompressed bytes too.
+                    with zf.open(filename) as src:
+                        content = src.read(MAX_EXTRACT_SIZE + 1)
+                    if len(content) > MAX_EXTRACT_SIZE:
+                        return {
+                            "status": "error",
+                            "message": f"File too large: {filename} (exceeds {MAX_EXTRACT_SIZE} bytes)",
+                        }
                     total_extracted += len(content)
+                    if total_extracted > MAX_TOTAL_SIZE:
+                        return {
+                            "status": "error",
+                            "message": f"Total extraction size exceeds limit ({MAX_TOTAL_SIZE} bytes)",
+                        }
 
                     # Determine output filename
                     # Use original filename or create based on report name

--- a/tests/test_correctness_regressions.py
+++ b/tests/test_correctness_regressions.py
@@ -1,0 +1,190 @@
+"""Regression tests for the tool correctness fixes.
+
+Covers the acknowledge_ioc_events keyword-argument bug, get_fortiview_data
+returning partial data before the scan finished, and run_and_wait_report
+reporting success without confirming the report generated.
+
+Each fake client mirrors the real FortiAnalyzerClient method signature so a
+tool passing a wrong keyword argument fails the test (a plain MagicMock would
+silently accept anything).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import fortianalyzer_mcp.tools.fortiview_tools as fortiview_tools
+import fortianalyzer_mcp.tools.ioc_tools as ioc_tools
+import fortianalyzer_mcp.tools.report_tools as report_tools
+
+CUSTOM_RANGE = "2024-01-01 00:00:00|2024-01-02 00:00:00"
+
+
+class TestAcknowledgeIocEventsKwarg:
+    """Regression: tool passed ``ioc_ids=`` but the client expects ``event_ids=``."""
+
+    async def test_tool_calls_client_with_event_ids(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list[tuple[str, list[str], str]] = []
+
+        class FakeClient:
+            async def acknowledge_ioc_events(
+                self, adom: str, event_ids: list[str], user: str
+            ) -> dict[str, Any]:
+                calls.append((adom, event_ids, user))
+                return {"status": "ok"}
+
+        monkeypatch.setattr(ioc_tools, "get_faz_client", lambda: FakeClient())
+
+        result = await ioc_tools.acknowledge_ioc_events(
+            ioc_ids=["IOC-001", "IOC-002"], user="analyst1", adom="root"
+        )
+
+        assert result["status"] == "success"
+        assert result["acknowledged_count"] == 2
+        assert calls == [("root", ["IOC-001", "IOC-002"], "analyst1")]
+
+
+class TestFortiviewPollsToCompletion:
+    """Regression: get_fortiview_data returned partial data when percentage < 100."""
+
+    async def test_partial_data_is_not_returned_early(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class FakeClient:
+            def __init__(self) -> None:
+                self.fetches = 0
+
+            async def fortiview_run(self, **kwargs: Any) -> dict[str, Any]:
+                return {"tid": 99}
+
+            async def fortiview_fetch(self, **kwargs: Any) -> dict[str, Any]:
+                self.fetches += 1
+                if self.fetches == 1:
+                    # Partial result: non-empty data but the scan is incomplete.
+                    return {"percentage": 50, "data": [{"srcip": "10.0.0.1"}]}
+                return {
+                    "percentage": 100,
+                    "data": [{"srcip": "10.0.0.1"}, {"srcip": "10.0.0.2"}],
+                }
+
+        fake = FakeClient()
+        monkeypatch.setattr(fortiview_tools, "get_faz_client", lambda: fake)
+
+        result = await fortiview_tools.get_fortiview_data(
+            view_name="top-sources", adom="root", time_range=CUSTOM_RANGE
+        )
+
+        assert result["status"] == "success"
+        assert fake.fetches == 2, "must keep polling past a partial (<100%) fetch"
+        assert result["count"] == 2
+
+    async def test_missing_percentage_defaults_to_complete(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class FakeClient:
+            async def fortiview_run(self, **kwargs: Any) -> dict[str, Any]:
+                return {"tid": 7}
+
+            async def fortiview_fetch(self, **kwargs: Any) -> dict[str, Any]:
+                return {"data": [{"srcip": "10.0.0.1"}]}
+
+        monkeypatch.setattr(fortiview_tools, "get_faz_client", lambda: FakeClient())
+
+        result = await fortiview_tools.get_fortiview_data(
+            view_name="top-sources", adom="root", time_range=CUSTOM_RANGE
+        )
+
+        assert result["status"] == "success"
+        assert result["count"] == 1
+
+
+class TestRunAndWaitReportVerifiesCompletion:
+    """Regression: tid vanishing from the running list was reported as success
+    without checking whether the report actually generated."""
+
+    @staticmethod
+    def _fake_client(fetch_result: dict[str, Any] | Exception) -> Any:
+        class FakeClient:
+            async def get_report_schedules(
+                self, adom: str, layout_id: int | None = None
+            ) -> dict[str, Any]:
+                return {"data": [{"schedule": str(layout_id)}]}
+
+            async def report_run(
+                self,
+                adom: str,
+                layout_id: int,
+                time_period: str = "last-7-days",
+                device: list[dict[str, str]] | None = None,
+            ) -> dict[str, Any]:
+                return {"tid": "TID-1"}
+
+            async def get_running_reports(self, adom: str) -> dict[str, Any]:
+                return {"data": []}  # tid never appears -> vanish branch
+
+            async def report_fetch(self, adom: str, tid: str) -> dict[str, Any]:
+                if isinstance(fetch_result, Exception):
+                    raise fetch_result
+                return fetch_result
+
+        return FakeClient()
+
+    async def test_generated_state_is_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = self._fake_client({"state": "generated", "progress-percent": 100})
+        monkeypatch.setattr(report_tools, "get_faz_client", lambda: client)
+
+        result = await report_tools.run_and_wait_report(layout="4", adom="root")
+        assert result["status"] == "success"
+        assert result["tid"] == "TID-1"
+
+    async def test_non_generated_state_is_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = self._fake_client({"state": "aborted", "progress-percent": 40})
+        monkeypatch.setattr(report_tools, "get_faz_client", lambda: client)
+
+        result = await report_tools.run_and_wait_report(layout="4", adom="root")
+        assert result["status"] == "error"
+        assert "aborted" in result["message"]
+
+    async def test_unknown_tid_is_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = self._fake_client(RuntimeError("Cannot find a report uuid=TID-1"))
+        monkeypatch.setattr(report_tools, "get_faz_client", lambda: client)
+
+        result = await report_tools.run_and_wait_report(layout="4", adom="root")
+        assert result["status"] == "error"
+
+    async def test_startup_race_keeps_polling(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Fetch says running while the tid is absent from the running list
+        (startup race): keep polling rather than declaring failure."""
+        states = iter([{"state": "running"}, {"state": "generated"}])
+
+        class FakeClient:
+            async def get_report_schedules(
+                self, adom: str, layout_id: int | None = None
+            ) -> dict[str, Any]:
+                return {"data": [{"schedule": str(layout_id)}]}
+
+            async def report_run(
+                self,
+                adom: str,
+                layout_id: int,
+                time_period: str = "last-7-days",
+                device: list[dict[str, str]] | None = None,
+            ) -> dict[str, Any]:
+                return {"tid": "TID-1"}
+
+            async def get_running_reports(self, adom: str) -> dict[str, Any]:
+                return {"data": []}
+
+            async def report_fetch(self, adom: str, tid: str) -> dict[str, Any]:
+                return next(states)
+
+        async def no_sleep(_seconds: float) -> None:
+            return None
+
+        monkeypatch.setattr(report_tools, "get_faz_client", lambda: FakeClient())
+        monkeypatch.setattr(report_tools.asyncio, "sleep", no_sleep)
+
+        result = await report_tools.run_and_wait_report(layout="4", adom="root")
+        assert result["status"] == "success"


### PR DESCRIPTION
Part of a QA pass against live FortiAnalyzer 7.6.7 and 8.0.0, split into focused PRs that are independent and mergeable in any order: #31 (security hardening), #32 (this one, tool correctness fixes), #33 (type safety and internals). A separate reliability fix found during the same pass is in #34 (re-login on an expired session).

These are behavioral bugs found while auditing the tool surface against live appliances.

What this changes:

- `acknowledge_ioc_events` never worked. It called the client with `ioc_ids=` but `FortiAnalyzerClient.acknowledge_ioc_events` takes `event_ids=`, so every call raised `TypeError` and returned an error. The regression test uses a signature-accurate fake client so a plain `MagicMock` cannot hide it again.
- `get_fortiview_data` returned partial results. The poll loop exited on the first non-empty `data` even when `percentage` was below 100, so top-N rankings could be incomplete. It now polls until `percentage` reaches 100; a missing `percentage` still defaults to complete so older builds return immediately.
- `run_and_wait_report` assumed success. When the tid dropped out of the running list the tool returned success without checking whether the report generated. It now confirms with `report_fetch`: state `generated` is success, `pending`/`running` keeps polling (covers the startup race where the tid is not yet in the running list), anything else is an error.
- `run_ioc_rescan` / `run_and_wait_ioc_rescan` sent the wrong device argument. Both passed the raw device string (or `None`) where the API expects a filter list like `[{"devid": ...}]`; they now go through the shared `build_device_filter` helper, and the status poll tolerates a null `percentage`.

One note: `report_tools.py` here also carries a ZIP decompression-size cap for the report-download path (matching the PCAP paths in the security PR). It sits in this branch only because it shares the file with the `run_and_wait_report` fix.

Verification: the full unit suite plus CI (lint, security, tests on 3.12 and 3.13) pass; new tests are in `tests/test_correctness_regressions.py`. Live on both 7.6.7 and 8.0.0 I confirmed FortiView completeness (`get_top_sources`) and ran `run_and_wait_report` end to end: on 8.0.0 the report completed and was confirmed generated; on 7.6.7 a heavy report correctly returned a timeout carrying the tid rather than a false success, which is the property this fix guarantees. The IOC ack and rescan fixes are covered by unit tests; the lab appliances have no IOC license to exercise them live.
