### PR TITLE
Type safety and internals: event-loop offload, single ValidationError, client typing

### DIFF
--- a/src/fortianalyzer_mcp/api/client.py
+++ b/src/fortianalyzer_mcp/api/client.py
@@ -7,7 +7,7 @@ import asyncio
 import json
 import logging
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import Any, cast
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from pyFMG.fortimgr import FortiManager
@@ -78,6 +78,11 @@ class FortiAnalyzerClient:
         # lets a waiter detect that a peer already reconnected while it blocked.
         self._reconnect_lock = asyncio.Lock()
         self._reconnect_generation = 0
+        # Serialize all blocking pyfmg I/O. pyfmg shares one requests.Session
+        # and req_id counter, neither safe under concurrent use from worker
+        # threads. One in-flight FAZ request at a time matches the previous
+        # (loop-blocking) behavior while keeping the event loop responsive.
+        self._io_lock = asyncio.Lock()
 
         logger.info(f"Initialized FortiAnalyzer client for {self.host}")
 
@@ -108,47 +113,53 @@ class FortiAnalyzerClient:
                 "Prefer trusting the FAZ CA (set the CA bundle) over disabling verification."
             )
 
-        try:
-            if self.api_token:
-                self._fmg = FortiManager(
-                    self.host,
-                    apikey=self.api_token,
-                    debug=False,
-                    use_ssl=True,
-                    verify_ssl=self.verify_ssl,
-                    timeout=self.timeout,
-                    check_adom_workspace=False,
-                )
-            elif self.username and self.password:
-                self._fmg = FortiManager(
-                    self.host,
-                    self.username,
-                    self.password,
-                    debug=False,
-                    use_ssl=True,
-                    verify_ssl=self.verify_ssl,
-                    timeout=self.timeout,
-                )
-            else:
-                raise AuthenticationError(
-                    "No authentication provided. Set API token or username/password."
-                )
+        # Hold the I/O lock across the connected-check and login so two
+        # concurrent connect() calls (now possible since login runs off-loop)
+        # cannot both log in and leak a session.
+        async with self._io_lock:
+            if self._connected:
+                return
+            try:
+                if self.api_token:
+                    self._fmg = FortiManager(
+                        self.host,
+                        apikey=self.api_token,
+                        debug=False,
+                        use_ssl=True,
+                        verify_ssl=self.verify_ssl,
+                        timeout=self.timeout,
+                        check_adom_workspace=False,
+                    )
+                elif self.username and self.password:
+                    self._fmg = FortiManager(
+                        self.host,
+                        self.username,
+                        self.password,
+                        debug=False,
+                        use_ssl=True,
+                        verify_ssl=self.verify_ssl,
+                        timeout=self.timeout,
+                    )
+                else:
+                    raise AuthenticationError(
+                        "No authentication provided. Set API token or username/password."
+                    )
 
-            code, response = self._fmg.login()
+                code, response = await asyncio.to_thread(self._fmg.login)
 
-            if code != 0:
-                error_msg = response.get("status", {}).get("message", "Login failed")
-                raise AuthenticationError(f"FortiAnalyzer login failed: {error_msg}")
+                if code != 0:
+                    error_msg = response.get("status", {}).get("message", "Login failed")
+                    raise AuthenticationError(f"FortiAnalyzer login failed: {error_msg}")
 
-            self._connected = True
-            self._ever_connected = True
-            logger.info("Successfully connected to FortiAnalyzer")
+                self._connected = True
+                self._ever_connected = True
+                logger.info("Successfully connected to FortiAnalyzer")
 
-        except AuthenticationError:
-            raise
-        except Exception as e:
-            logger.error(f"Connection failed: {e}")
-            raise ConnectionError(f"Failed to connect to FortiAnalyzer: {e}") from e
+            except AuthenticationError:
+                raise
+            except Exception as e:
+                logger.error(f"Connection failed: {e}")
+                raise ConnectionError(f"Failed to connect to FortiAnalyzer: {e}") from e
 
     async def disconnect(self) -> None:
         """Disconnect and cleanup resources."""
@@ -158,7 +169,8 @@ class FortiAnalyzerClient:
         logger.info("Disconnecting from FortiAnalyzer")
 
         try:
-            self._fmg.logout()
+            async with self._io_lock:
+                await asyncio.to_thread(self._fmg.logout)
         except Exception as e:
             logger.warning(f"Logout failed: {e}")
         finally:
@@ -438,14 +450,17 @@ class FortiAnalyzerClient:
         else:
             headers = {"content-type": "application/json"}
 
-        # Make request
-        response = fmg.sess.post(
-            fmg._url,
-            data=json.dumps(json_request),
-            verify=fmg.verify_ssl,
-            timeout=fmg.timeout,
-            headers=headers,
-        )
+        # Make request off the event loop; serialized via the I/O lock so the
+        # shared requests.Session is never used from two threads at once.
+        async with self._io_lock:
+            response = await asyncio.to_thread(
+                fmg.sess.post,
+                fmg._url,
+                data=json.dumps(json_request),
+                verify=fmg.verify_ssl,
+                timeout=fmg.timeout,
+                headers=headers,
+            )
 
         try:
             result = response.json()
@@ -511,7 +526,10 @@ class FortiAnalyzerClient:
         async def _factory() -> Any:
             fmg = self._ensure_connected()
             method = getattr(fmg, verb)
-            code, response = method(url, **kwargs)
+            # Run the blocking pyfmg verb off the event loop; serialized via
+            # the I/O lock (shared requests.Session is not thread-safe).
+            async with self._io_lock:
+                code, response = await asyncio.to_thread(lambda: method(url, **kwargs))
             return self._handle_response(code, response, f"{verb.upper()} {url}")
 
         return await self._execute_resilient(_factory)
@@ -540,6 +558,18 @@ class FortiAnalyzerClient:
         """Execute EXEC request."""
         return await self._generic_request("execute", url, **kwargs)
 
+    async def _request_dict(self, verb: str, url: str, **kwargs: Any) -> dict[str, Any]:
+        """Typed _generic_request for endpoints whose payload is a JSON object.
+
+        The JSON-RPC layer is untyped (payload shape varies by endpoint);
+        this is the single cast point for object-shaped responses.
+        """
+        return cast(dict[str, Any], await self._generic_request(verb, url, **kwargs))
+
+    async def _raw_request_dict(self, method: str, url: str, **kwargs: Any) -> dict[str, Any]:
+        """Typed _raw_request counterpart for object-shaped LogView responses."""
+        return cast(dict[str, Any], await self._raw_request(method, url, **kwargs))
+
     # =========================================================================
     # DVMDB - Device Manager Database (from dvmdb.json)
     # =========================================================================
@@ -547,7 +577,7 @@ class FortiAnalyzerClient:
     async def list_adoms(
         self,
         fields: list[str] | None = None,
-        filter: list[str] | None = None,
+        filter: list[Any] | None = None,
         loadsub: int = 0,
     ) -> list[dict[str, Any]]:
         """List all ADOMs.
@@ -568,13 +598,13 @@ class FortiAnalyzerClient:
 
         FNDN: GET /dvmdb/adom/{adom}
         """
-        return await self.get(f"/dvmdb/adom/{name}", loadsub=loadsub)
+        return await self._request_dict("get", f"/dvmdb/adom/{name}", loadsub=loadsub)
 
     async def list_devices(
         self,
         adom: str = "root",
         fields: list[str] | None = None,
-        filter: list[str] | None = None,
+        filter: list[Any] | None = None,
         loadsub: int = 0,
     ) -> list[dict[str, Any]]:
         """List devices in ADOM.
@@ -595,7 +625,9 @@ class FortiAnalyzerClient:
 
         FNDN: GET /dvmdb/adom/{adom}/device/{device}
         """
-        return await self.get(f"/dvmdb/adom/{adom}/device/{device}", loadsub=loadsub)
+        return await self._request_dict(
+            "get", f"/dvmdb/adom/{adom}/device/{device}", loadsub=loadsub
+        )
 
     async def list_device_vdoms(self, device: str, adom: str = "root") -> list[dict[str, Any]]:
         """List VDOMs for a device.
@@ -641,7 +673,7 @@ class FortiAnalyzerClient:
         if flags:
             data["flags"] = flags
 
-        return await self.execute("/dvm/cmd/add/device", **data)
+        return await self._request_dict("execute", "/dvm/cmd/add/device", **data)
 
     async def delete_device(
         self,
@@ -657,7 +689,7 @@ class FortiAnalyzerClient:
         if flags:
             data["flags"] = flags
 
-        return await self.execute("/dvm/cmd/del/device", **data)
+        return await self._request_dict("execute", "/dvm/cmd/del/device", **data)
 
     async def add_device_list(
         self,
@@ -673,7 +705,7 @@ class FortiAnalyzerClient:
         if flags:
             data["flags"] = flags
 
-        return await self.execute("/dvm/cmd/add/dev-list", **data)
+        return await self._request_dict("execute", "/dvm/cmd/add/dev-list", **data)
 
     async def delete_device_list(
         self,
@@ -689,7 +721,7 @@ class FortiAnalyzerClient:
         if flags:
             data["flags"] = flags
 
-        return await self.execute("/dvm/cmd/del/dev-list", **data)
+        return await self._request_dict("execute", "/dvm/cmd/del/dev-list", **data)
 
     # =========================================================================
     # LogView - Log Search Operations (from logview.json)
@@ -742,7 +774,7 @@ class FortiAnalyzerClient:
         if filter:
             data["filter"] = filter
 
-        return await self._raw_request("add", f"/logview/adom/{adom}/logsearch", **data)
+        return await self._raw_request_dict("add", f"/logview/adom/{adom}/logsearch", **data)
 
     async def logsearch_fetch(
         self,
@@ -769,7 +801,7 @@ class FortiAnalyzerClient:
                 "status": {"code": 0, "message": "..."}
             }
         """
-        return await self._raw_request(
+        return await self._raw_request_dict(
             "get",
             f"/logview/adom/{adom}/logsearch/{tid}",
             apiver=API_VERSION,
@@ -782,7 +814,7 @@ class FortiAnalyzerClient:
 
         FNDN: DELETE /logview/adom/{adom}/logsearch/{tid}
         """
-        return await self._raw_request(
+        return await self._raw_request_dict(
             "delete",
             f"/logview/adom/{adom}/logsearch/{tid}",
             apiver=API_VERSION,
@@ -798,7 +830,7 @@ class FortiAnalyzerClient:
 
         FNDN: GET /logview/adom/{adom}/logfields
         """
-        return await self._raw_request(
+        return await self._raw_request_dict(
             "get",
             f"/logview/adom/{adom}/logfields",
             apiver=API_VERSION,
@@ -824,7 +856,7 @@ class FortiAnalyzerClient:
         if device:
             params["device"] = device
 
-        return await self._raw_request("get", f"/logview/adom/{adom}/logstats", **params)
+        return await self._raw_request_dict("get", f"/logview/adom/{adom}/logstats", **params)
 
     async def get_logfiles_state(
         self,
@@ -845,7 +877,7 @@ class FortiAnalyzerClient:
         if time_range:
             params["time-range"] = time_range
 
-        return await self._raw_request("get", f"/logview/adom/{adom}/logfiles/state", **params)
+        return await self._raw_request_dict("get", f"/logview/adom/{adom}/logfiles/state", **params)
 
     async def get_logfiles_data(
         self,
@@ -865,7 +897,7 @@ class FortiAnalyzerClient:
             data_type: "base64", "csv/gzip/base64", "text/gzip/base64"
             length: Max 50MB (52428800)
         """
-        return await self._raw_request(
+        return await self._raw_request_dict(
             "get",
             f"/logview/adom/{adom}/logfiles/data",
             apiver=API_VERSION,
@@ -906,7 +938,9 @@ class FortiAnalyzerClient:
         if filter:
             params["filter"] = filter
 
-        return await self._raw_request("get", f"/logview/adom/{adom}/logfiles/search", **params)
+        return await self._raw_request_dict(
+            "get", f"/logview/adom/{adom}/logfiles/search", **params
+        )
 
     async def get_pcapfile(
         self,
@@ -921,7 +955,7 @@ class FortiAnalyzerClient:
             key_data: Log data (JSON or pcapurl)
             key_type: "log-data" or "pcapurl"
         """
-        return await self._raw_request(
+        return await self._raw_request_dict(
             "get",
             "/logview/pcapfile",
             apiver=API_VERSION,
@@ -934,7 +968,7 @@ class FortiAnalyzerClient:
 
     async def list_tasks(
         self,
-        filter: list[str] | None = None,
+        filter: list[Any] | None = None,
     ) -> list[dict[str, Any]]:
         """List all tasks.
 
@@ -952,7 +986,7 @@ class FortiAnalyzerClient:
 
         FNDN: GET /task/task/{task_id}
         """
-        return await self.get(f"/task/task/{task_id}")
+        return await self._request_dict("get", f"/task/task/{task_id}")
 
     async def get_task_line(self, task_id: int) -> list[dict[str, Any]]:
         """Get task line details.
@@ -971,14 +1005,14 @@ class FortiAnalyzerClient:
 
         FNDN: GET /sys/status
         """
-        return await self.get("/sys/status")
+        return await self._request_dict("get", "/sys/status")
 
     async def get_ha_status(self) -> dict[str, Any]:
         """Get HA status.
 
         FNDN: GET /sys/ha/status
         """
-        return await self.get("/sys/ha/status")
+        return await self._request_dict("get", "/sys/ha/status")
 
     # =========================================================================
     # Event Management (from eventmgmt.json)
@@ -1016,7 +1050,7 @@ class FortiAnalyzerClient:
         if filter:
             params["filter"] = filter
 
-        return await self._raw_request("get", f"/eventmgmt/adom/{adom}/alerts", **params)
+        return await self._raw_request_dict("get", f"/eventmgmt/adom/{adom}/alerts", **params)
 
     async def get_alerts_count(
         self,
@@ -1034,7 +1068,7 @@ class FortiAnalyzerClient:
         if filter:
             params["filter"] = filter
 
-        return await self._raw_request("get", f"/eventmgmt/adom/{adom}/alerts/count", **params)
+        return await self._raw_request_dict("get", f"/eventmgmt/adom/{adom}/alerts/count", **params)
 
     async def acknowledge_alerts(
         self,
@@ -1046,7 +1080,7 @@ class FortiAnalyzerClient:
 
         FNDN: UPDATE /eventmgmt/adom/{adom}/alerts/ack
         """
-        return await self._raw_request(
+        return await self._raw_request_dict(
             "update",
             f"/eventmgmt/adom/{adom}/alerts/ack",
             apiver=API_VERSION,
@@ -1064,7 +1098,7 @@ class FortiAnalyzerClient:
 
         FNDN: UPDATE /eventmgmt/adom/{adom}/alerts/unack
         """
-        return await self._raw_request(
+        return await self._raw_request_dict(
             "update",
             f"/eventmgmt/adom/{adom}/alerts/unack",
             apiver=API_VERSION,
@@ -1084,7 +1118,7 @@ class FortiAnalyzerClient:
 
         FNDN: GET /eventmgmt/adom/{adom}/alertlogs
         """
-        return await self._raw_request(
+        return await self._raw_request_dict(
             "get",
             f"/eventmgmt/adom/{adom}/alertlogs",
             apiver=API_VERSION,
@@ -1103,7 +1137,7 @@ class FortiAnalyzerClient:
 
         FNDN: GET /eventmgmt/adom/{adom}/alerts/extra-details
         """
-        return await self._raw_request(
+        return await self._raw_request_dict(
             "get",
             f"/eventmgmt/adom/{adom}/alerts/extra-details",
             apiver=API_VERSION,
@@ -1121,7 +1155,7 @@ class FortiAnalyzerClient:
 
         FNDN: ADD /eventmgmt/adom/{adom}/alerts/comment
         """
-        return await self._raw_request(
+        return await self._raw_request_dict(
             "add",
             f"/eventmgmt/adom/{adom}/alerts/comment",
             apiver=API_VERSION,
@@ -1143,7 +1177,7 @@ class FortiAnalyzerClient:
         Args:
             stat_type: "severity", "severity-timescale", "status", etc.
         """
-        return await self._raw_request(
+        return await self._raw_request_dict(
             "get",
             f"/eventmgmt/adom/{adom}/alert-incident/stats",
             apiver=API_VERSION,
@@ -1207,7 +1241,9 @@ class FortiAnalyzerClient:
         if sort_by:
             params["sort-by"] = sort_by
 
-        return await self._raw_request("add", f"/fortiview/adom/{adom}/{view_name}/run", **params)
+        return await self._raw_request_dict(
+            "add", f"/fortiview/adom/{adom}/{view_name}/run", **params
+        )
 
     async def fortiview_fetch(
         self,
@@ -1219,7 +1255,7 @@ class FortiAnalyzerClient:
 
         FNDN: GET /fortiview/adom/{adom}/{view-name}/run/{tid}
         """
-        return await self._raw_request(
+        return await self._raw_request_dict(
             "get",
             f"/fortiview/adom/{adom}/{view_name}/run/{tid}",
             apiver=API_VERSION,
@@ -1256,7 +1292,9 @@ class FortiAnalyzerClient:
         if filter:
             params["filter"] = filter
 
-        return await self._raw_request("get", f"/config/adom/{adom}/sql-report/layout", **params)
+        return await self._raw_request_dict(
+            "get", f"/config/adom/{adom}/sql-report/layout", **params
+        )
 
     async def report_run(
         self,
@@ -1293,7 +1331,7 @@ class FortiAnalyzerClient:
         if device:
             params["device"] = device
 
-        return await self._raw_request("add", f"/report/adom/{adom}/run", **params)
+        return await self._raw_request_dict("add", f"/report/adom/{adom}/run", **params)
 
     async def report_fetch(
         self,
@@ -1308,7 +1346,9 @@ class FortiAnalyzerClient:
             adom: ADOM name
             tid: Task ID (UUID string from report_run)
         """
-        return await self._raw_request("get", f"/report/adom/{adom}/run/{tid}", apiver=API_VERSION)
+        return await self._raw_request_dict(
+            "get", f"/report/adom/{adom}/run/{tid}", apiver=API_VERSION
+        )
 
     async def report_get_data(
         self,
@@ -1327,7 +1367,7 @@ class FortiAnalyzerClient:
             output_format: Output format - "PDF", "HTML", "CSV", "XML"
             data_type: Data encoding type - "string" (base64)
         """
-        return await self._raw_request(
+        return await self._raw_request_dict(
             "get",
             f"/report/adom/{adom}/reports/data/{tid}",
             apiver=API_VERSION,
@@ -1343,7 +1383,7 @@ class FortiAnalyzerClient:
 
         FNDN: GET /report/adom/{adom}/template/list
         """
-        return await self._raw_request(
+        return await self._raw_request_dict(
             "get", f"/report/adom/{adom}/template/list", apiver=API_VERSION
         )
 
@@ -1372,7 +1412,7 @@ class FortiAnalyzerClient:
         if title:
             params["title"] = title
 
-        return await self._raw_request("get", f"/report/adom/{adom}/reports/state", **params)
+        return await self._raw_request_dict("get", f"/report/adom/{adom}/reports/state", **params)
 
     async def get_report_schedules(
         self,
@@ -1397,7 +1437,9 @@ class FortiAnalyzerClient:
         if layout_id is not None:
             params["filter"] = ["name", "==", str(layout_id)]
 
-        return await self._raw_request("get", f"/config/adom/{adom}/sql-report/schedule", **params)
+        return await self._raw_request_dict(
+            "get", f"/config/adom/{adom}/sql-report/schedule", **params
+        )
 
     async def create_report_schedule(
         self,
@@ -1423,7 +1465,7 @@ class FortiAnalyzerClient:
         if device_filter:
             data["device"] = device_filter
 
-        return await self._raw_request(
+        return await self._raw_request_dict(
             "set",
             f"/report/adom/{adom}/config/schedule/{layout_id}",
             apiver=API_VERSION,
@@ -1440,7 +1482,7 @@ class FortiAnalyzerClient:
 
         Returns list of reports currently being generated.
         """
-        return await self._raw_request("get", f"/report/adom/{adom}/run", apiver=API_VERSION)
+        return await self._raw_request_dict("get", f"/report/adom/{adom}/run", apiver=API_VERSION)
 
     # =========================================================================
     # Incident Management (from incidentmgmt.json)
@@ -1468,7 +1510,7 @@ class FortiAnalyzerClient:
         if filter:
             params["filter"] = filter
 
-        return await self._raw_request("get", f"/incidentmgmt/adom/{adom}/incidents", **params)
+        return await self._raw_request_dict("get", f"/incidentmgmt/adom/{adom}/incidents", **params)
 
     async def get_incident(
         self,
@@ -1479,7 +1521,7 @@ class FortiAnalyzerClient:
 
         FNDN: GET /incidentmgmt/adom/{adom}/incident/{incid}
         """
-        return await self._raw_request(
+        return await self._raw_request_dict(
             "get", f"/incidentmgmt/adom/{adom}/incident/{incident_id}", apiver=API_VERSION
         )
 
@@ -1499,7 +1541,7 @@ class FortiAnalyzerClient:
         if filter:
             params["filter"] = filter
 
-        return await self._raw_request(
+        return await self._raw_request_dict(
             "get", f"/incidentmgmt/adom/{adom}/incidents/count", **params
         )
 
@@ -1525,7 +1567,7 @@ class FortiAnalyzerClient:
         if description:
             params["description"] = description
 
-        return await self._raw_request("add", f"/incidentmgmt/adom/{adom}/incident", **params)
+        return await self._raw_request_dict("add", f"/incidentmgmt/adom/{adom}/incident", **params)
 
     async def update_incident(
         self,
@@ -1547,7 +1589,7 @@ class FortiAnalyzerClient:
         if assignee:
             params["assignee"] = assignee
 
-        return await self._raw_request(
+        return await self._raw_request_dict(
             "update", f"/incidentmgmt/adom/{adom}/incident/{incident_id}", **params
         )
 
@@ -1575,7 +1617,7 @@ class FortiAnalyzerClient:
         if stats_items is None:
             stats_items = ["total", "severity", "status"]
 
-        return await self._raw_request(
+        return await self._raw_request_dict(
             "get",
             f"/incidentmgmt/adom/{adom}/incident/stats",
             apiver=API_VERSION,
@@ -1591,7 +1633,7 @@ class FortiAnalyzerClient:
 
         FNDN: GET /ioc/license/state
         """
-        return await self._raw_request("get", "/ioc/license/state", apiver=API_VERSION)
+        return await self._raw_request_dict("get", "/ioc/license/state", apiver=API_VERSION)
 
     async def acknowledge_ioc_events(
         self,
@@ -1603,7 +1645,7 @@ class FortiAnalyzerClient:
 
         FNDN: UPDATE /ioc/adom/{adom}/events/ack
         """
-        return await self._raw_request(
+        return await self._raw_request_dict(
             "update",
             f"/ioc/adom/{adom}/events/ack",
             apiver=API_VERSION,
@@ -1623,7 +1665,7 @@ class FortiAnalyzerClient:
 
         Returns TID for tracking.
         """
-        return await self._raw_request(
+        return await self._raw_request_dict(
             "add",
             f"/ioc/adom/{adom}/rescan/run",
             apiver=API_VERSION,
@@ -1640,7 +1682,7 @@ class FortiAnalyzerClient:
 
         FNDN: GET /ioc/adom/{adom}/rescan/run/{tid}
         """
-        return await self._raw_request(
+        return await self._raw_request_dict(
             "get", f"/ioc/adom/{adom}/rescan/run/{tid}", apiver=API_VERSION
         )
 
@@ -1652,6 +1694,6 @@ class FortiAnalyzerClient:
 
         FNDN: GET /ioc/adom/{adom}/rescan/history
         """
-        return await self._raw_request(
+        return await self._raw_request_dict(
             "get", f"/ioc/adom/{adom}/rescan/history", apiver=API_VERSION
         )

--- a/src/fortianalyzer_mcp/tools/event_tools.py
+++ b/src/fortianalyzer_mcp/tools/event_tools.py
@@ -7,6 +7,7 @@ Provides alert management, event handling, and SOC operations.
 import logging
 from typing import Any
 
+from fortianalyzer_mcp.api.client import FortiAnalyzerClient
 from fortianalyzer_mcp.server import get_faz_client, mcp
 from fortianalyzer_mcp.utils.responses import redact
 from fortianalyzer_mcp.utils.time_range import parse_time_range
@@ -15,7 +16,7 @@ from fortianalyzer_mcp.utils.validation import get_default_adom
 logger = logging.getLogger(__name__)
 
 
-def _get_client():
+def _get_client() -> FortiAnalyzerClient:
     """Get the FortiAnalyzer client instance."""
     client = get_faz_client()
     if not client:

--- a/src/fortianalyzer_mcp/tools/log_tools.py
+++ b/src/fortianalyzer_mcp/tools/log_tools.py
@@ -9,6 +9,7 @@ import logging
 import math
 from typing import Any
 
+from fortianalyzer_mcp.api.client import FortiAnalyzerClient
 from fortianalyzer_mcp.server import get_faz_client, mcp
 from fortianalyzer_mcp.utils.log_clock import resolve_time_window
 from fortianalyzer_mcp.utils.responses import build_warnings, error_response, redact
@@ -297,7 +298,7 @@ async def _run_logsearch_page_unlocked(
     Returns ``{"timed_out": bool, "tid": int|None, "logs": list, "total": int|None}``.
     """
     await client.ensure_connected()
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     timeout = _clamp_timeout(timeout)
     limit = _clamp_limit(limit)
     deadline = loop.time() + timeout
@@ -392,7 +393,7 @@ async def _run_logsearch_page_unlocked(
                     pass
 
 
-def _get_client():
+def _get_client() -> FortiAnalyzerClient:
     """Get the FortiAnalyzer client instance."""
     client = get_faz_client()
     if not client:
@@ -1198,7 +1199,7 @@ async def search_traffic_logs(
 
         filter_str = " and ".join(filters) if filters else None
 
-        result = await query_logs(
+        result: dict[str, Any] = await query_logs(
             adom=adom,
             logtype="traffic",
             device=device,
@@ -1291,7 +1292,7 @@ async def search_security_logs(
 
         filter_str = " and ".join(filters) if filters else None
 
-        result = await query_logs(
+        result: dict[str, Any] = await query_logs(
             adom=adom,
             logtype="attack",
             device=device,
@@ -1382,7 +1383,7 @@ async def search_event_logs(
 
         filter_str = " and ".join(filters) if filters else None
 
-        result = await query_logs(
+        result: dict[str, Any] = await query_logs(
             adom=adom,
             logtype="event",
             device=device,

--- a/src/fortianalyzer_mcp/utils/config.py
+++ b/src/fortianalyzer_mcp/utils/config.py
@@ -261,4 +261,6 @@ def get_settings() -> Settings:
         ValidationError: If required settings are missing or invalid
     """
     _check_env_file_permissions()
-    return Settings()
+    # Required fields (FORTIANALYZER_HOST) come from the environment at
+    # runtime; pydantic-settings raises if they are missing.
+    return Settings()  # type: ignore[call-arg]

--- a/src/fortianalyzer_mcp/utils/errors.py
+++ b/src/fortianalyzer_mcp/utils/errors.py
@@ -51,8 +51,14 @@ class TimeoutError(FortiAnalyzerError):
     pass
 
 
-class ValidationError(FortiAnalyzerError):
-    """Input validation failed."""
+class ValidationError(FortiAnalyzerError, ValueError):
+    """Input validation failed.
+
+    Single canonical class: raised by the input validators in
+    utils.validation (which re-exports it) and mapped from FAZ error
+    code -5. Subclasses ValueError so validator callers can treat it
+    as a plain bad-value error.
+    """
 
     pass
 

--- a/src/fortianalyzer_mcp/utils/validation.py
+++ b/src/fortianalyzer_mcp/utils/validation.py
@@ -13,6 +13,11 @@ import re
 from pathlib import Path
 from typing import Any
 
+# Canonical ValidationError lives in utils.errors (also mapped from FAZ
+# error code -5); re-exported here so validator callers keep importing it
+# from this module.
+from fortianalyzer_mcp.utils.errors import ValidationError
+
 # Sensitive fields that should be masked in logs
 SENSITIVE_FIELDS = {
     "password",
@@ -211,12 +216,6 @@ _PCAPURL_RE = re.compile(r"^[A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=%\-]+$")
 _PCAPURL_MAX_LEN = 4096
 
 
-class ValidationError(ValueError):
-    """Raised when input validation fails."""
-
-    pass
-
-
 def validate_adom(adom: str) -> str:
     """Validate ADOM name format.
 
@@ -309,7 +308,7 @@ def validate_device_serial(serial: str) -> str:
 # Serial-number prefixes used to decide whether a device string is a serial
 # (devid) or a device name (devname). Kept here as the single source of truth so
 # every tool builds the FAZ device filter identically.
-_DEVICE_SERIAL_PREFIXES = ("FG", "FM", "FW", "FA", "FS", "FD", "FP", "FC")
+_DEVICE_SERIAL_PREFIXES = ("FG", "FM", "FW", "FA", "FS", "FD", "FP", "FC", "FV")
 
 
 def build_device_filter(device: str | None) -> list[dict[str, str]]:

--- a/tests/test_device_filter.py
+++ b/tests/test_device_filter.py
@@ -23,6 +23,10 @@ class TestBuildDeviceFilter:
     def test_all_group_uses_devid(self) -> None:
         assert build_device_filter("All_FortiMail") == [{"devid": "All_FortiMail"}]
 
+    def test_fortivoice_serial_uses_devid(self) -> None:
+        """Regression: FV serials are valid (DEVICE_SERIAL_PATTERN) and must map to devid."""
+        assert build_device_filter("FVVM0000000001") == [{"devid": "FVVM0000000001"}]
+
     def test_plain_name_uses_devname(self) -> None:
         assert build_device_filter("myfw01") == [{"devname": "myfw01"}]
 


### PR DESCRIPTION
Part of a QA pass against live FortiAnalyzer 7.6.7 and 8.0.0, split into focused PRs that are independent and mergeable in any order: #31 (security hardening), #32 (tool correctness fixes), #33 (this one, type safety and internals). A separate reliability fix found during the same pass is in #34 (re-login on an expired session).

Internal cleanup found while making mypy pass on the source tree.

What this changes:

- Blocking pyfmg I/O moved off the event loop. Every pyfmg call (login, logout, the raw LogView POST, and the generic verb methods) ran synchronous `requests` I/O directly on the asyncio event loop, which starves every other coroutine (health checks, keepalives, concurrent tool calls) for up to `FORTIANALYZER_TIMEOUT` per request. These now run through `asyncio.to_thread`, serialized by a per-client lock because pyfmg shares one non-thread-safe `requests.Session` and `req_id` counter. `connect()` holds that lock across its connected-check and login so two concurrent connects cannot double-login.
- `asyncio.get_event_loop()` replaced with `get_running_loop()` in the polling loops. Inside a coroutine the former is a deprecated alias on 3.12.
- One `ValidationError`. `utils.validation.ValidationError(ValueError)` and `utils.errors.ValidationError(FortiAnalyzerError)` were two unrelated classes with the same name, so an `except` in one module could miss a `raise` from the other. The canonical class now lives in `utils.errors`, subclasses both `FortiAnalyzerError` and `ValueError`, and is re-exported from `utils.validation` so existing imports keep working.
- Client typing. The JSON-RPC helpers now have a single typed cast point (`_request_dict` / `_raw_request_dict`) instead of an `Any` return at every call site, and filter parameters accept the nested `[field, op, value]` triples FAZ takes.
- FortiVoice serials: `FV` was accepted by `DEVICE_SERIAL_PATTERN` but missing from the serial-prefix set, so an FV serial built a devname filter that matched nothing. It lives here because it shares `validation.py` with the ValidationError change.

This branch types the client and the shared utils. The per-tool `_get_client()` annotations are in the security and correctness PRs, which share those files; with all three applied, `mypy src/` is clean.

Verification: the full unit suite plus CI (lint, security, tests on 3.12 and 3.13) pass. These are internal changes; the code ran live on both 7.6.7 and 8.0.0 as part of the QA pass (the server handled real traffic, report and device calls on both), so they are exercised broadly, but the individual items here are verified by the unit tests rather than by a dedicated live check.
