### PR TITLE
Re-login on "No permission" (-11) instead of retrying an expired session

### DIFF
--- a/src/fortianalyzer_mcp/api/client.py
+++ b/src/fortianalyzer_mcp/api/client.py
@@ -40,10 +40,13 @@ class FortiAnalyzerClient:
     # is handled separately by ensure_connected() (tools call it upfront).
     _TRANSIENT_RETRIES = 2
     _TRANSIENT_BACKOFF_BASE = 0.5  # seconds; doubled each retry
-    # FAZ error codes worth a retry: internal error, task timeout.
-    _TRANSIENT_ERROR_CODES = frozenset({-1, -11})
+    # FAZ error codes worth a retry on the same session: internal/general error.
+    _TRANSIENT_ERROR_CODES = frozenset({-1})
     # FAZ error codes that mean the server session is gone (revive once).
-    _RECONNECTABLE_ERROR_CODES = frozenset({-2, -20, -21})
+    # -11 "No permission for the resource" is what an expired or closed FAZ
+    # session returns on a per-request basis (not a clean no-session error), so a
+    # long-lived client must re-login on it instead of retrying the dead session.
+    _RECONNECTABLE_ERROR_CODES = frozenset({-2, -11, -20, -21})
 
     def __init__(
         self,

--- a/src/fortianalyzer_mcp/utils/errors.py
+++ b/src/fortianalyzer_mcp/utils/errors.py
@@ -75,7 +75,7 @@ ERROR_CODE_MAP: dict[int, type[FortiAnalyzerError]] = {
     -8: WorkspaceError,  # Workspace locked
     -9: WorkspaceError,  # Workspace uncommitted changes
     -10: APIError,  # Version mismatch
-    -11: TimeoutError,  # Task timeout
+    -11: PermissionError,  # No permission for the resource (session expired or rpc-permit denied)
     -20: AuthenticationError,  # Invalid credentials
     -21: AuthenticationError,  # Token expired
 }

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -313,6 +313,36 @@ class TestExecuteResilient:
 
         assert len(calls) == 1
 
+    async def test_no_permission_forces_reconnect_not_dead_session_retry(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Code -11 (No permission) is what an expired or closed FAZ session
+        returns per request, so it must force a single re-login and retry rather
+        than retrying the dead session as a transient error."""
+        from fortianalyzer_mcp.utils.errors import APIError
+
+        client = _bare_client()
+        reconnects: list[int] = []
+
+        async def fake_reconnect() -> None:
+            reconnects.append(1)
+
+        monkeypatch.setattr(client, "_force_reconnect", fake_reconnect)
+
+        calls: list[int] = []
+
+        async def factory() -> str:
+            calls.append(1)
+            if len(calls) == 1:
+                raise APIError("No permission for the resource", code=-11)
+            return "ok"
+
+        result = await client._execute_resilient(factory, sleep=_no_sleep)
+
+        assert result == "ok"
+        assert reconnects == [1]  # re-logged in once, did not retry the dead session
+        assert len(calls) == 2
+
     async def test_oserror_retried_then_succeeds(self) -> None:
         """A network OSError is transient and retried."""
         client = _bare_client()

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -113,7 +113,7 @@ class TestErrorCodeMapping:
             (-8, WorkspaceError),
             (-9, WorkspaceError),
             (-10, APIError),
-            (-11, TimeoutError),
+            (-11, PermissionError),
             (-20, AuthenticationError),
             (-21, AuthenticationError),
         ],
@@ -163,10 +163,10 @@ class TestParseFazError:
         error = parse_faz_error(-8, "Workspace locked")
         assert isinstance(error, WorkspaceError)
 
-    def test_timeout_error_code(self):
-        """Test timeout error code."""
-        error = parse_faz_error(-11, "Task timeout")
-        assert isinstance(error, TimeoutError)
+    def test_no_permission_error_code(self):
+        """Test no-permission / session-expired error code."""
+        error = parse_faz_error(-11, "No permission for the resource")
+        assert isinstance(error, PermissionError)
 
     def test_validation_error_code(self):
         """Test validation error code."""


### PR DESCRIPTION
Found while QA-ing against a live FAZ 8.0.0: a long-running MCP (the HTTP server can run for days) eventually has its FAZ session expire or get closed by the appliance, and the next request then comes back as code -11 "No permission for the resource" rather than a clean no-session error.

`-11` was in the transient-retry set, so the client retried the same dead session twice and then failed, and kept failing on every call until the process was restarted. I hit exactly this: a process idle for several hours returned -11 on every call (`list_devices`, logsearch, report layouts), and a fresh login fixed it immediately.

This moves `-11` from the transient set to the reconnectable set, so the resilient path forces a single re-login and retries, which is what actually recovers the session. A genuine permission error (rpc-permit not granted) still surfaces after the one re-login attempt, since reconnect is bounded to once.

Test: `tests/test_client.py::TestExecuteResilient::test_no_permission_forces_reconnect_not_dead_session_retry`. Full suite passes, ruff clean.

Independent of the three QA PRs (#31, #32, #33) - this touches only the client's error-code classification.
