### PR TITLE
fix(traffic): sum per-slice total-counts for policy total_hits (#30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to FortiAnalyzer MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+Real fix for the policy `total_hits` under-report ([#30](https://github.com/rstierli/fortianalyzer-mcp/issues/30), variant 2): sum the per-slice `total-count`s the breakdown already fetches instead of a separate `limit=1` whole-window logsearch. Removes the v2.4.1 clamp's reason to exist (kept as a guard) and decides exactness per slice. By [@inxbit](https://github.com/inxbit). 559 unit tests pass.
+
+### Fixed
+- **`get_policy_traffic_profile` / `get_policy_port_analysis` / `get_policy_protocol_summary` no longer report `total_hits` below `observed_hits`, and now report it correctly when the window is fully scanned.** The total came from `_query_policy_total_count`, a `limit=1` logsearch whose `total-count` short-circuits the instant the first match is found, so it returned a tiny scanned-block count rather than the real total (observed 44 vs 4,000 on heavy policies, and as low as 37 vs 1,151 in a real audit). That function is deleted. `_query_policy_logs_bounded` now sums the `total-count` each per-slice breakdown search already returns and discards. Slices are contiguous and non-overlapping and each slice's `total-count` is at least the rows it returned, so the summed `total_hits` is `>= observed_hits` by construction. This also drops one FAZ logsearch per policy (was `slice_count + 1`, now `slice_count`).
+- **`is_exact` ("complete") is decided per slice and can no longer mislabel an unproven result.** A result is exact only when every slice reported a `total-count` equal to the rows it returned and below the fetch limit, i.e. every slice was fully scanned. The previous rule was `truncated_slices == 0`, which would call a result "complete" even when a slice timed out or omitted its total (0 rows, not counted as truncated). Exactness is now computed from the raw per-slice proof, so an aggregate over/under-count cancellation cannot fabricate completeness.
+
+### Changed
+- The v2.4.1 defensive clamp (`max(authoritative, observed_hits)` at `_bounded_metadata`) is kept as a belt rather than removed: with variant 2 the summed total is `>= observed_hits` by construction so it is normally a no-op, but if a slice ever under-reports below its own rows the clamp still holds the schema contract and now logs a warning instead of silently flooring. The clamped display value is never used to decide `is_exact`.
+- Tool docstrings, `README.md`, and `docs/INTERNAL_ARCHITECTURE.md` now describe `total_hits` as the sum of per-slice `total-count`s (a floor that is at least `observed_hits`), not an "authoritative whole-window" count.
+
 ## [2.5.0] - 2026-06-16
 
 Type safety + internals refactor and a session-expired re-login signal. PRs [#33](https://github.com/rstierli/fortianalyzer-mcp/pull/33) and [#34](https://github.com/rstierli/fortianalyzer-mcp/pull/34) by [@inxbit](https://github.com/inxbit). 554 unit tests pass.

--- a/README.md
+++ b/README.md
@@ -542,12 +542,13 @@ number of log slices per request. A result is marked `is_exact=true` only when
 every queried slice returns below the per-slice log limit. If any slice reaches
 the limit, the tool returns observed results with `analysis_mode=bounded_sample`,
 truncation metadata, and a recommendation to narrow the time window for exact proof.
-For bounded samples, `total_hits` comes from a whole-window FortiAnalyzer
-log-search `total-count` for the same policy/action/device/time filter when
-available, but port, protocol, service, and application breakdowns still
-describe only the fetched rows. Use `observed_hits`, `total_hits_is_known`, and
-`total_hit_source` to distinguish observed row counts from authoritative
-matching-log totals.
+`total_hits` is the sum of the per-slice `total-count`s the breakdown searches
+already fetch for the same policy/action/device/time filter, so it is at least
+`observed_hits` by construction. On heavy policies it is a floor near
+`observed_hits`, not the true total; port, protocol, service, and application
+breakdowns describe only the fetched rows. Use `observed_hits`,
+`total_hits_is_known`, and `total_hit_source` to tell observed row counts from
+the summed per-slice total.
 
 ### PCAP Tools (5 tools)
 

--- a/docs/INTERNAL_ARCHITECTURE.md
+++ b/docs/INTERNAL_ARCHITECTURE.md
@@ -500,15 +500,16 @@ request retries `client._execute_resilient` performed (0 on non-retry paths).
 
 The bounded policy tools add top-level `adom`/`time_range`/`timezone` and a
 per-policy `filter`, plus per-policy `total_hits`, `total_hits_is_known`, and
-`total_hit_source` (`"logsearch_total-count"` when the count is authoritative,
-`"observed_rows"` when it fell back to fetched rows). The analysis window is
-resolved **once** at tool entry and threaded into the slice queries and the
-whole-window total-count query, so the reported window, the slices, and the
-total never drift. Like `query_logs`, each slice and the total-count re-run a
-fresh search per page because the appliance `tid` is single-use; the total-count
-is best-effort (its failure degrades to `"observed_rows"`, never failing the
-policy), and `is_exact` is true only when no slice truncated **and**
-`total_hits == observed_hits`.
+`total_hit_source` (`"logsearch_total-count"` when every slice reported a total,
+`"observed_rows"` when any slice did not). The analysis window is resolved
+**once** at tool entry and threaded into the slice queries, so the reported
+window and the slices never drift. Like `query_logs`, each slice re-runs a fresh
+search per page because the appliance `tid` is single-use. `total_hits` is the
+sum of the per-slice `total-count`s those searches already return (issue #30), so
+it is at least `observed_hits` by construction; a slice that times out or omits
+its total leaves `total_hits_is_known` false and the result bounded. `is_exact`
+is true only when every slice was fully scanned (each reported a total equal to
+its rows, none truncated), so `total_hits == observed_hits`.
 
 ### Glossary
 

--- a/src/fortianalyzer_mcp/tools/traffic_tools.py
+++ b/src/fortianalyzer_mcp/tools/traffic_tools.py
@@ -20,6 +20,7 @@ from typing import Any, cast
 
 from fortianalyzer_mcp.server import get_faz_client, mcp
 from fortianalyzer_mcp.tools.log_tools import (
+    _clamp_limit,
     _run_logsearch_page,
 )
 from fortianalyzer_mcp.utils.log_clock import resolve_time_window
@@ -278,32 +279,6 @@ async def _query_policy_log_slice(
     }
 
 
-async def _query_policy_total_count(
-    adom: str,
-    device_filter: list[dict[str, str]],
-    policy_id: int,
-    time_range: dict[str, str],
-    action: str | None,
-    timeout: int = DEFAULT_SEARCH_TIMEOUT,
-) -> dict[str, Any]:
-    """Query authoritative log-search total-count for one full policy window."""
-    result = await _query_policy_log_slice(
-        adom=adom,
-        device_filter=device_filter,
-        policy_id=policy_id,
-        time_range=time_range,
-        action=action,
-        limit=1,
-        timeout=timeout,
-    )
-    total_hits = result.get("total_hits")
-    total_hits_is_known = result.get("total_hits_is_known") is True
-    return {
-        "total_hits": total_hits if total_hits_is_known else None,
-        "total_hits_is_known": total_hits_is_known,
-    }
-
-
 async def _query_policy_logs(
     adom: str,
     device: str | None,
@@ -359,30 +334,29 @@ async def _query_policy_logs_bounded(
 
     ``time_range`` is the already-resolved ``{start, end}`` window (resolved once
     by the caller) so slices and reported metadata share one window.
+
+    The whole-window ``total_hits`` is the sum of the per-slice ``total-count``s
+    that the breakdown searches already return (issue #30). Slices are contiguous
+    and non-overlapping, so the sum is a valid whole-window count and is at least
+    the rows fetched. ``all_slices_exact`` is True only when every slice reported a
+    total equal to the rows it returned and below the fetch limit (every slice was
+    fully scanned); that is what makes a result "complete". A slice that timed out,
+    returned no TID, or omitted its total leaves the total unproven and forces a
+    bounded result.
     """
     async with _QUERY_SEMAPHORE:
         full_time_range = time_range
         device_filter = _build_device_filter(device)
+        # Clamp once with the runner's own helper so the truncation test below
+        # compares against the limit the runner actually applies.
+        effective_limit = _clamp_limit(limit)
         slice_count = _plan_policy_slice_count(full_time_range, policy_count)
         time_slices = _build_bounded_time_slices(full_time_range, slice_count)
         logs: list[dict[str, Any]] = []
         truncated_slices = 0
-        # The whole-window total-count is best-effort enrichment: its failure must
-        # never discard the per-slice observations (degrade to observed_rows).
-        try:
-            total_result = await _query_policy_total_count(
-                adom=adom,
-                device_filter=device_filter,
-                policy_id=policy_id,
-                time_range=full_time_range,
-                action=action,
-                timeout=timeout,
-            )
-        except Exception as exc:
-            logger.info(f"Total-count unavailable for policy {policy_id}: {exc}")
-            total_result = {"total_hits": None, "total_hits_is_known": False}
-        total_hits = total_result.get("total_hits")
-        total_hits_is_known = total_result.get("total_hits_is_known") is True
+        summed_total = 0
+        total_hits_is_known = True
+        all_slices_exact = True
 
         for time_slice in time_slices:
             slice_result = await _query_policy_log_slice(
@@ -391,22 +365,38 @@ async def _query_policy_logs_bounded(
                 policy_id=policy_id,
                 time_range=time_slice,
                 action=action,
-                limit=limit,
+                limit=effective_limit,
                 timeout=timeout,
             )
             slice_logs = slice_result.get("logs", [])
             if not isinstance(slice_logs, list):
                 slice_logs = []
             logs.extend(slice_logs)
-            if len(slice_logs) >= limit:
+            rows = len(slice_logs)
+            truncated = rows >= effective_limit
+            if truncated:
                 truncated_slices += 1
+
+            slice_total = slice_result.get("total_hits")
+            slice_known = slice_result.get("total_hits_is_known") is True and isinstance(
+                slice_total, int
+            )
+            if slice_known:
+                summed_total += cast(int, slice_total)
+            else:
+                total_hits_is_known = False
+            # A slice is exact only if it proved its total and was fully scanned.
+            all_slices_exact = (
+                all_slices_exact and slice_known and not truncated and slice_total == rows
+            )
 
         return {
             "logs": logs,
             "slices_scanned": len(time_slices),
             "truncated_slices": truncated_slices,
-            "total_hits": total_hits if total_hits_is_known else None,
+            "total_hits": summed_total if total_hits_is_known else None,
             "total_hits_is_known": total_hits_is_known,
+            "all_slices_exact": all_slices_exact,
         }
 
 
@@ -416,24 +406,36 @@ def _bounded_metadata(
     truncated_slices: int,
     total_hits: int | None = None,
     total_hits_is_known: bool = False,
+    all_slices_exact: bool = False,
+    policy_id: int | None = None,
 ) -> dict[str, Any]:
-    """Build common bounded-analysis response metadata."""
+    """Build common bounded-analysis response metadata.
+
+    ``total_hits`` is the sum of per-slice ``total-count``s (issue #30); it is at
+    least ``observed_hits`` by construction. A result is exact ("complete") only
+    when ``all_slices_exact`` -- every slice proved a total equal to its rows and
+    was fully scanned. Exactness is decided from that per-slice proof, not from an
+    aggregate ``observed == total`` comparison, so an over/under-count cancellation
+    across slices cannot fabricate completeness.
+    """
     authoritative = total_hits if (total_hits_is_known and total_hits is not None) else None
     if authoritative is not None:
-        # Defense against #30: the authoritative total comes from a limit=1
-        # logsearch whose `total-count` short-circuits unreliably on heavy
-        # traffic, sometimes reporting fewer hits than the breakdown actually
-        # observed. Clamp at the response boundary so the schema contract
-        # `total_hits >= observed_hits` always holds — otherwise a misleading
-        # tiny total breaks downstream audit decisions. Becomes a no-op once
-        # _query_policy_total_count is reworked to sum per-slice totals.
+        # Belt (the v2.4.1 defensive shim): the summed total is >= observed by
+        # construction, so this is normally a no-op. If it ever fires, the
+        # appliance under-reported a slice total; surface it, do not silently
+        # floor it.
         resolved_total_hits = max(authoritative, observed_hits)
-        # "complete" must mean the breakdown covers exactly the authoritative
-        # matching log count. Any mismatch keeps the result bounded.
-        is_exact = truncated_slices == 0 and observed_hits == authoritative
+        if authoritative < observed_hits:
+            logger.warning(
+                f"Policy {policy_id}: summed total-count {authoritative} below "
+                f"observed rows {observed_hits}; clamping to observed"
+            )
     else:
         resolved_total_hits = observed_hits
-        is_exact = truncated_slices == 0
+    # Exactness comes purely from per-slice proof. An unknown/unproven slice
+    # (timeout, no TID, omitted total) leaves all_slices_exact False, so a bounded
+    # result can never be mislabeled "complete".
+    is_exact = all_slices_exact
     metadata: dict[str, Any] = {
         "is_exact": is_exact,
         "analysis_mode": "complete" if is_exact else "bounded_sample",
@@ -672,6 +674,8 @@ async def _run_bounded_policy_analysis(
                         truncated_slices=policy_result["truncated_slices"],
                         total_hits=policy_result.get("total_hits"),
                         total_hits_is_known=policy_result.get("total_hits_is_known") is True,
+                        all_slices_exact=policy_result.get("all_slices_exact") is True,
+                        policy_id=pid,
                     )
                 )
                 entry["policy_id"] = pid
@@ -756,11 +760,13 @@ async def get_policy_traffic_profile(
             - adom, time_range, timezone: resolved query-window audit metadata
             - results: Per-policy traffic profiles with top ports, services, apps,
               plus per-policy total accounting:
-                - total_hits: authoritative whole-window match count when
-                  total_hits_is_known, else the observed row count
+                - total_hits: sum of per-slice total-counts when
+                  total_hits_is_known, else the observed row count. A floor that is
+                  always at least observed_hits, not the true total on heavy
+                  (bounded) policies
                 - total_hits_is_known / total_hit_source: True with
-                  "logsearch_total-count" when the total came from a FAZ
-                  whole-window total-count; False with "observed_rows" otherwise
+                  "logsearch_total-count" when every slice reported a total; False
+                  with "observed_rows" when any slice did not
                 - observed_hits: rows actually fetched and aggregated
                 Top ports/services/applications and their residuals describe the
                 observed rows only, not total_hits.
@@ -819,14 +825,17 @@ async def get_policy_port_analysis(
             - status: "success" or "error"
             - adom, time_range, timezone: resolved query-window audit metadata
             - results: Per-policy port analysis with:
-                - is_exact: True only when the breakdown covers every matching
-                  log (no truncated slice AND total_hits == observed_hits)
+                - is_exact: True only when every slice was fully scanned and
+                  proved its total (no truncated slice AND total_hits ==
+                  observed_hits)
                 - analysis_mode: "complete" or "bounded_sample"
-                - total_hits: authoritative whole-window match count when
-                  total_hits_is_known, else the observed row count
+                - total_hits: sum of per-slice total-counts when
+                  total_hits_is_known, else the observed row count. A floor that is
+                  always at least observed_hits, not the true total on heavy
+                  (bounded) policies
                 - total_hits_is_known / total_hit_source: True with
-                  "logsearch_total-count" when the total came from a FAZ
-                  whole-window total-count; False with "observed_rows" otherwise
+                  "logsearch_total-count" when every slice reported a total; False
+                  with "observed_rows" when any slice did not
                 - observed_hits: Number of log rows fetched and aggregated
                 - ports: List of port/protocol pairs with hit counts
                 - protocols: Protocol breakdown
@@ -887,7 +896,8 @@ async def get_policy_protocol_summary(
             - results: Per-policy protocol summaries with hit counts, plus
               total_hits / total_hits_is_known / total_hit_source and
               observed_hits (the protocol breakdown describes observed rows only;
-              total_hits is the authoritative whole-window count when known)
+              total_hits is the sum of per-slice total-counts, a floor at least
+              observed_hits, when known)
             - query_time_seconds: Total query duration
             - message: Error message if failed
 

--- a/tests/test_traffic_tools.py
+++ b/tests/test_traffic_tools.py
@@ -4,6 +4,8 @@ Tests validation functions, aggregation logic, and tool behavior
 without triggering server initialization.
 """
 
+import logging
+
 import pytest
 
 import fortianalyzer_mcp.tools.log_tools as log_tools
@@ -21,7 +23,6 @@ from fortianalyzer_mcp.tools.traffic_tools import (
     _build_policy_filter,
     _plan_policy_slice_count,
     _query_policy_log_slice,
-    _query_policy_total_count,
     sanitize_filter_value,
     validate_action,
     validate_policy_ids,
@@ -443,38 +444,6 @@ class TestPolicyPortAnalysisToolBounded:
         assert result["total_hits"] == 25
         assert result["total_hits_is_known"] is True
 
-    async def test_policy_total_count_uses_full_window_with_small_fetch(
-        self,
-        monkeypatch: pytest.MonkeyPatch,
-    ) -> None:
-        """Whole-window total queries should not depend on bounded slice totals."""
-        calls = []
-
-        async def fake_slice(*_args: object, **kwargs: object) -> dict[str, object]:
-            calls.append(kwargs)
-            return {
-                "logs": [{"dstport": 443, "proto": "6"}],
-                "total_hits": 12609,
-                "total_hits_is_known": True,
-            }
-
-        monkeypatch.setattr(traffic_tools, "_query_policy_log_slice", fake_slice)
-
-        result = await _query_policy_total_count(
-            adom="root",
-            device_filter=[{"devid": "All_FortiGate"}],
-            policy_id=29,
-            time_range={"start": "2024-01-01 00:00:00", "end": "2024-01-31 00:00:00"},
-            action="accept",
-        )
-
-        assert result == {"total_hits": 12609, "total_hits_is_known": True}
-        assert calls[0]["time_range"] == {
-            "start": "2024-01-01 00:00:00",
-            "end": "2024-01-31 00:00:00",
-        }
-        assert calls[0]["limit"] == 1
-
     async def test_large_request_returns_bounded_result(
         self,
         monkeypatch: pytest.MonkeyPatch,
@@ -498,11 +467,6 @@ class TestPolicyPortAnalysisToolBounded:
             }
 
         monkeypatch.setattr(traffic_tools, "_query_policy_log_slice", fake_slice)
-
-        async def fake_total(*_args: object, **_kwargs: object) -> dict[str, object]:
-            return {"total_hits": 2503, "total_hits_is_known": True}
-
-        monkeypatch.setattr(traffic_tools, "_query_policy_total_count", fake_total)
 
         result = await traffic_tools.get_policy_port_analysis(
             adom="root",
@@ -528,24 +492,24 @@ class TestPolicyPortAnalysisToolBounded:
         assert "estimate_available" not in analysis
         assert "recommendation" in analysis
 
-    async def test_bounded_result_uses_whole_window_total_count(
+    async def test_bounded_result_sums_per_slice_totals(
         self,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Bounded metadata should not sum inflated per-slice totals."""
+        """Whole-window total_hits is the sum of per-slice total-counts (issue #30)."""
+        call_count = 0
 
         async def fake_slice(*_args: object, **_kwargs: object) -> dict[str, object]:
+            nonlocal call_count
+            call_count += 1
+            rows = call_count  # slices return 1, 2, 3, 4 rows, each fully scanned
             return {
-                "logs": [{"dstport": 161, "proto": "17"}],
-                "total_hits": 14000,
+                "logs": [{"dstport": 161, "proto": "17"} for _ in range(rows)],
+                "total_hits": rows,
                 "total_hits_is_known": True,
             }
 
-        async def fake_total(*_args: object, **_kwargs: object) -> dict[str, object]:
-            return {"total_hits": 12609, "total_hits_is_known": True}
-
         monkeypatch.setattr(traffic_tools, "_query_policy_log_slice", fake_slice)
-        monkeypatch.setattr(traffic_tools, "_query_policy_total_count", fake_total, raising=False)
 
         result = await traffic_tools.get_policy_port_analysis(
             adom="root",
@@ -557,16 +521,16 @@ class TestPolicyPortAnalysisToolBounded:
 
         assert result["status"] == "success"
         analysis = result["results"][0]
-        assert analysis["total_hits"] == 12609
+        # 4 slices returned 1+2+3+4 rows, each with total-count == its rows.
+        assert analysis["observed_hits"] == 10
+        assert analysis["total_hits"] == 10
         assert analysis["total_hits_is_known"] is True
         assert analysis["total_hit_source"] == "logsearch_total-count"
-        assert analysis["observed_hits"] == 4
-        assert analysis["ports"] == [{"port": "17/161", "hits": 4}]
-        # An authoritative total that dwarfs the observed rows must NOT be
-        # labelled "complete": the port breakdown only covers observed rows.
-        assert analysis["is_exact"] is False
-        assert analysis["analysis_mode"] == "bounded_sample"
-        assert "recommendation" in analysis
+        assert analysis["ports"] == [{"port": "17/161", "hits": 10}]
+        # Every slice fully scanned (total == rows, none truncated) -> complete.
+        assert analysis["is_exact"] is True
+        assert analysis["analysis_mode"] == "complete"
+        assert "recommendation" not in analysis
 
     async def test_missing_slice_total_falls_back_to_observed_rows(
         self,
@@ -595,10 +559,13 @@ class TestPolicyPortAnalysisToolBounded:
 
         assert result["status"] == "success"
         analysis = result["results"][0]
-        assert analysis["is_exact"] is True
+        # An unproven slice total (omitted total-count) cannot be "complete".
+        assert analysis["is_exact"] is False
+        assert analysis["analysis_mode"] == "bounded_sample"
         assert analysis["total_hits"] == 1
         assert analysis["total_hits_is_known"] is False
         assert analysis["total_hit_source"] == "observed_rows"
+        assert "recommendation" in analysis
         assert "estimated_total_hits" not in analysis
 
     async def test_per_policy_exceptions_are_isolated(
@@ -755,11 +722,6 @@ class TestPolicyTrafficProfileToolBounded:
 
         monkeypatch.setattr(traffic_tools, "_query_policy_log_slice", fake_slice)
 
-        async def fake_total(*_args: object, **_kwargs: object) -> dict[str, object]:
-            return {"total_hits": 4, "total_hits_is_known": True}
-
-        monkeypatch.setattr(traffic_tools, "_query_policy_total_count", fake_total)
-
         result = await traffic_tools.get_policy_traffic_profile(
             adom="root",
             device="FGT70FTK22019321",
@@ -811,11 +773,6 @@ class TestPolicyProtocolSummaryToolBounded:
             }
 
         monkeypatch.setattr(traffic_tools, "_query_policy_log_slice", fake_slice)
-
-        async def fake_total(*_args: object, **_kwargs: object) -> dict[str, object]:
-            return {"total_hits": 1203, "total_hits_is_known": True}
-
-        monkeypatch.setattr(traffic_tools, "_query_policy_total_count", fake_total)
 
         result = await traffic_tools.get_policy_protocol_summary(
             adom="root",
@@ -1034,47 +991,6 @@ class TestQueryPolicySliceReliability:
 
 
 # =============================================================================
-# Whole-window total-count: best-effort enrichment
-# =============================================================================
-
-
-class TestTotalCountBestEffort:
-    """The whole-window total-count is enrichment; its failure must not discard
-    the per-policy observed breakdown."""
-
-    async def test_total_count_failure_keeps_observed_result(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        async def good_slice(*_args: object, **_kwargs: object) -> dict[str, object]:
-            return {
-                "logs": [{"dstport": 443, "proto": "6"}],
-                "total_hits": None,
-                "total_hits_is_known": False,
-            }
-
-        async def boom_total(*_args: object, **_kwargs: object) -> dict[str, object]:
-            raise RuntimeError("total-count search failed")
-
-        monkeypatch.setattr(traffic_tools, "_query_policy_log_slice", good_slice)
-        monkeypatch.setattr(traffic_tools, "_query_policy_total_count", boom_total)
-
-        result = await traffic_tools.get_policy_port_analysis(
-            adom="root",
-            device="FGT70FTK22019321",
-            policy_ids=[2],
-            time_range="2024-01-01 00:00:00|2024-01-02 00:00:00",
-        )
-
-        assert result["status"] == "success"
-        analysis = result["results"][0]
-        assert "error" not in analysis
-        assert analysis["observed_hits"] == 1
-        assert analysis["total_hits_is_known"] is False
-        assert analysis["total_hit_source"] == "observed_rows"
-        assert analysis["total_hits"] == 1
-
-
-# =============================================================================
 # Bounded metadata: honesty gate + observed floor
 # =============================================================================
 
@@ -1089,6 +1005,7 @@ class TestBoundedMetadata:
             truncated_slices=0,
             total_hits=100,
             total_hits_is_known=True,
+            all_slices_exact=False,
         )
         assert md["total_hits"] == 100
         assert md["total_hit_source"] == "logsearch_total-count"
@@ -1096,17 +1013,21 @@ class TestBoundedMetadata:
         assert md["analysis_mode"] == "bounded_sample"
         assert "recommendation" in md
 
-    def test_unknown_total_cannot_flip_exactness(self) -> None:
+    def test_unknown_total_is_never_complete(self) -> None:
+        """An unproven total (slice timed out / omitted total) is never complete."""
         md = _bounded_metadata(
             observed_hits=4,
             slices_scanned=1,
             truncated_slices=0,
             total_hits=None,
             total_hits_is_known=False,
+            all_slices_exact=False,
         )
         assert md["total_hits"] == 4
         assert md["total_hit_source"] == "observed_rows"
-        assert md["is_exact"] is True
+        assert md["is_exact"] is False
+        assert md["analysis_mode"] == "bounded_sample"
+        assert "recommendation" in md
 
     def test_total_equal_to_observed_is_complete(self) -> None:
         md = _bounded_metadata(
@@ -1115,6 +1036,7 @@ class TestBoundedMetadata:
             truncated_slices=0,
             total_hits=4,
             total_hits_is_known=True,
+            all_slices_exact=True,
         )
         assert md["is_exact"] is True
         assert md["analysis_mode"] == "complete"
@@ -1137,6 +1059,7 @@ class TestBoundedMetadata:
             truncated_slices=0,
             total_hits=2,
             total_hits_is_known=True,
+            all_slices_exact=False,
         )
         # Clamped up to observed (was the broken authoritative value of 2).
         assert md["total_hits"] == 5
@@ -1148,6 +1071,169 @@ class TestBoundedMetadata:
         assert md["is_exact"] is False
         assert md["analysis_mode"] == "bounded_sample"
         assert "recommendation" in md
+
+    def test_belt_clamp_below_observed_logs_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        """If the summed total ever lands below observed, clamp AND log it."""
+        with caplog.at_level(logging.WARNING, logger="fortianalyzer_mcp.tools.traffic_tools"):
+            md = _bounded_metadata(
+                observed_hits=5,
+                slices_scanned=1,
+                truncated_slices=0,
+                total_hits=2,
+                total_hits_is_known=True,
+                all_slices_exact=False,
+                policy_id=7,
+            )
+        assert md["total_hits"] == 5
+        assert any(
+            "Policy 7" in record.message and "below" in record.message for record in caplog.records
+        )
+
+
+# =============================================================================
+# issue #30: total_hits summed from per-slice totals; per-slice exactness
+# =============================================================================
+
+
+class TestPerSliceTotalSum:
+    """`_query_policy_logs_bounded` sums per-slice total-counts and proves
+    exactness per slice (issue #30)."""
+
+    @staticmethod
+    def _window_30d() -> dict[str, str]:
+        return {"start": "2024-01-01 00:00:00", "end": "2024-01-31 00:00:00"}
+
+    async def test_sums_known_slice_totals(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        totals = [10, 20, 30]
+        idx = 0
+
+        async def fake_slice(*_args: object, **_kwargs: object) -> dict[str, object]:
+            nonlocal idx
+            count = totals[idx]
+            idx += 1
+            return {
+                "logs": [{"dstport": 443, "proto": "6"} for _ in range(count)],
+                "total_hits": count,
+                "total_hits_is_known": True,
+            }
+
+        monkeypatch.setattr(traffic_tools, "_query_policy_log_slice", fake_slice)
+        result = await traffic_tools._query_policy_logs_bounded(
+            "root", "FGT70FTK22019321", 2, self._window_30d(), None, policy_count=8
+        )
+        assert result["slices_scanned"] == 3
+        assert result["total_hits"] == 60
+        assert result["total_hits_is_known"] is True
+        assert result["all_slices_exact"] is True
+        assert len(result["logs"]) == 60
+
+    async def test_one_unknown_slice_makes_total_unknown(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        idx = 0
+
+        async def fake_slice(*_args: object, **_kwargs: object) -> dict[str, object]:
+            nonlocal idx
+            idx += 1
+            if idx == 2:
+                return {
+                    "logs": [{"dstport": 80, "proto": "6"}],
+                    "total_hits": None,
+                    "total_hits_is_known": False,
+                }
+            return {
+                "logs": [{"dstport": 443, "proto": "6"}],
+                "total_hits": 1,
+                "total_hits_is_known": True,
+            }
+
+        monkeypatch.setattr(traffic_tools, "_query_policy_log_slice", fake_slice)
+        result = await traffic_tools._query_policy_logs_bounded(
+            "root", "FGT70FTK22019321", 2, self._window_30d(), None, policy_count=8
+        )
+        assert result["total_hits"] is None
+        assert result["total_hits_is_known"] is False
+        assert result["all_slices_exact"] is False
+        assert len(result["logs"]) == 3  # rows still accumulate
+
+    async def test_nontruncated_total_above_rows_is_not_exact(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        async def fake_slice(*_args: object, **_kwargs: object) -> dict[str, object]:
+            return {
+                "logs": [{"dstport": 443, "proto": "6"}],
+                "total_hits": 5,
+                "total_hits_is_known": True,
+            }
+
+        monkeypatch.setattr(traffic_tools, "_query_policy_log_slice", fake_slice)
+        result = await traffic_tools._query_policy_logs_bounded(
+            "root", "FGT70FTK22019321", 2, self._window_30d(), None, policy_count=8
+        )
+        assert result["truncated_slices"] == 0
+        assert result["total_hits"] == 15
+        assert result["all_slices_exact"] is False
+
+    async def test_undercounting_slice_is_not_exact(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def fake_slice(*_args: object, **_kwargs: object) -> dict[str, object]:
+            return {
+                "logs": [{"dstport": 443, "proto": "6"} for _ in range(3)],
+                "total_hits": 2,
+                "total_hits_is_known": True,
+            }
+
+        monkeypatch.setattr(traffic_tools, "_query_policy_log_slice", fake_slice)
+        result = await traffic_tools._query_policy_logs_bounded(
+            "root", "FGT70FTK22019321", 2, self._window_30d(), None, policy_count=8
+        )
+        assert result["all_slices_exact"] is False
+
+    async def test_clamps_limit_with_runner_helper(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        seen_limits: list[int] = []
+
+        async def fake_slice(*_args: object, limit: int, **_kwargs: object) -> dict[str, object]:
+            seen_limits.append(limit)
+            return {
+                "logs": [{"dstport": 443, "proto": "6"}],
+                "total_hits": 1,
+                "total_hits_is_known": True,
+            }
+
+        monkeypatch.setattr(traffic_tools, "_query_policy_log_slice", fake_slice)
+        await traffic_tools._query_policy_logs_bounded(
+            "root", "FGT70FTK22019321", 2, self._window_30d(), None, policy_count=8, limit=99999
+        )
+        # _clamp_limit caps at LOG_FETCH_LIMIT (1000); the slice never sees 99999.
+        assert seen_limits and all(seen == LOG_FETCH_LIMIT for seen in seen_limits)
+
+    async def test_timed_out_slice_makes_tool_bounded(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        idx = 0
+
+        async def fake_slice(*_args: object, **_kwargs: object) -> dict[str, object]:
+            nonlocal idx
+            idx += 1
+            if idx == 1:
+                return {"logs": [], "total_hits": None, "total_hits_is_known": False}
+            return {
+                "logs": [{"dstport": 443, "proto": "6"}],
+                "total_hits": 1,
+                "total_hits_is_known": True,
+            }
+
+        monkeypatch.setattr(traffic_tools, "_query_policy_log_slice", fake_slice)
+        result = await traffic_tools.get_policy_port_analysis(
+            adom="root",
+            device="FGT70FTK22019321",
+            policy_ids=[2],
+            time_range="2024-01-01 00:00:00|2024-01-31 00:00:00",
+        )
+        analysis = result["results"][0]
+        assert analysis["is_exact"] is False
+        assert analysis["analysis_mode"] == "bounded_sample"
+        assert analysis["total_hits_is_known"] is False
+        assert analysis["total_hit_source"] == "observed_rows"
 
 
 # =============================================================================


### PR DESCRIPTION
Fixes #30. @rstierli this is variant 2 from the issue body, so the v2.4.1 clamp becomes a no-op as you predicted.

## What was wrong

`_query_policy_total_count` computed the whole-window total with a `limit=1` logsearch. Per the FAZ spec a search reaches `percentage:100` as soon as either the requested limit of rows is found or all matches are scanned, so at `limit=1` it stops at the first match and `total-count` reflects only the rows scanned to get there, not the real total. On heavy policies that under-reported by one to two orders of magnitude (your runs showed 37 vs 1,151 observed, and 44 vs 4,000).

## The fix (variant 2)

- Delete `_query_policy_total_count`. `_query_policy_logs_bounded` now sums the `total-count` each per-slice breakdown search already returns and previously discarded. The slices are contiguous and non-overlapping and each slice's `total-count` is at least the rows it returned, so the summed `total_hits` is `>= observed_hits` by construction. This also drops one logsearch per policy (`slice_count + 1` becomes `slice_count`).
- `is_exact` is now decided per slice. A result is "complete" only when every slice reported a `total-count` equal to the rows it returned and below the fetch limit (every slice fully scanned). The old rule was `truncated_slices == 0`, which would label a result complete even when a slice timed out or omitted its total (0 rows, so not counted as truncated). Under per-slice summing that case is now correctly bounded, and an over/under-count cancellation that an aggregate `observed == total` check could miss is ruled out too.

## On your v2.4.1 clamp

I kept `max(authoritative, observed_hits)` as a boundary guard rather than removing it. With variant 2 it is a no-op in the happy path (verified below), but if a slice ever reports a total below its own rows it still holds the schema contract, and it now logs a warning so a future appliance regression surfaces instead of silently flooring. `is_exact` is computed from the raw per-slice proof, never the clamped value, so the clamp can never fabricate a "complete". Happy to drop it entirely if you would rather rely purely on the construction; that is a one-line change.

## Docs

Tool docstrings, `README.md`, and `docs/INTERNAL_ARCHITECTURE.md` now describe `total_hits` as the sum of per-slice `total-count`s (a floor that is at least `observed_hits`), not an "authoritative whole-window" count.

## Verification

- 559 unit tests pass; `ruff check`, `ruff format --check`, and `mypy src/` clean.
- Live read-only verification on FAZ 7.6.7 and 8.0.0 (build 0105 GA), all three bounded policy tools, across heavy / quiet / multi-policy / action-filter cases. 137 invariant checks green on each version:
  - heavy policy, 30-day: `total_hits` well above `observed_hits` (for example 8,557 vs 1,000), `is_exact:false`, recommendation present.
  - quiet policy, 1-hour: `total_hits == observed_hits` (912 on 8.0.0, 911 on 7.6.7), `is_exact:true`, "complete", no recommendation. This confirms the load-bearing assumption live: a fully scanned slice reports `total-count == rows`.
  - the three tools agree on stable metadata for the same input; bounded `total_hits` can drift a few percent run-to-run because each tool re-runs its slice searches over a window that keeps ingesting (consistent with ADR-0002), while complete totals match exactly.
