### PR TITLE
fix(traffic): count empty-service ICMP rows as type=unknown in port analysis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to FortiAnalyzer MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **ICMP rows with an empty `service` field are no longer omitted from the `get_policy_port_analysis` ICMP breakdown.** Follow-up to #37: proto=1 logs whose `service` field is empty or absent matched no parsing branch and were silently dropped from the `icmp` section (while still counted in `total_hits` and `protocols`), so the ICMP hit sum could undercount the proto=1 total. They are now recorded as `type=unknown`, keeping the `icmp` sum equal to the proto=1 count in `protocols`.
+
 ## [2.7.0] - 2026-07-03
 
 Full-codebase correctness and security-hardening review: uniform identifier validation, config/env parsing fix, task-state handling, device-filter classification, report custom time windows, and deployment hardening.

--- a/src/fortianalyzer_mcp/tools/traffic_tools.py
+++ b/src/fortianalyzer_mcp/tools/traffic_tools.py
@@ -547,9 +547,11 @@ def _aggregate_port_analysis(logs: list[dict[str, Any]]) -> dict[str, Any]:
                 else:
                     # Malformed "icmp/..." value: don't leak the raw string.
                     icmp_types["type=unknown"] += 1
-            elif service:
-                # Service field holds an application name (e.g. "DNS"), not an
-                # ICMP type/code — record as unknown instead of service=<name>.
+            else:
+                # Service field holds an application name (e.g. "DNS") or is
+                # empty; neither encodes ICMP type/code, so record as unknown.
+                # This keeps the icmp hit sum equal to the proto=1 count in
+                # the protocols breakdown.
                 icmp_types["type=unknown"] += 1
 
     uncovered = total - port_hits

--- a/tests/test_traffic_tools.py
+++ b/tests/test_traffic_tools.py
@@ -400,6 +400,21 @@ class TestAggregatePortAnalysis:
         # The raw service name is never leaked into type_code.
         assert all("service=" not in e["type_code"] for e in result["icmp"])
 
+    def test_icmp_empty_service_counted_as_unknown(self) -> None:
+        """ICMP rows with an empty or missing service field must still appear
+        in the icmp breakdown (as type=unknown), so the icmp hit sum always
+        matches the proto=1 count in the protocols breakdown."""
+        logs = [
+            {"proto": "1", "dstport": 0, "service": ""},
+            {"proto": "1", "dstport": 0},  # service key absent entirely
+            {"proto": "1", "dstport": 0, "service": "PING"},
+        ]
+        result = _aggregate_port_analysis(logs)
+        icmp_total = sum(e["hits"] for e in result["icmp"])
+        proto1_hits = next(p["hits"] for p in result["protocols"] if p["protocol"] == "1")
+        assert icmp_total == proto1_hits == 3
+        assert {"type_code": "type=unknown", "hits": 2} in result["icmp"]
+
     def test_portless_protocols(self) -> None:
         """Protocols without ports (GRE, ESP) should be tracked."""
         logs = [


### PR DESCRIPTION
## Summary

Small consistency follow-up to #37 / #38, spotted while reviewing the merged fix.

`_aggregate_port_analysis` handles proto=1 rows in three branches (`PING`, `icmp/T/C`, non-empty application name), but a row whose `service` field is **empty or absent** matches none of them and is silently omitted from the `icmp` breakdown. The row is still counted in `total_hits` and `protocols`, so the sum of `icmp` bucket hits can undercount the proto=1 total in `protocols` and a consumer cross-checking the two sections sees an unexplained gap.

## Change

- The final branch is now `else:` instead of `elif service:`, so empty/missing `service` lands in `type=unknown` alongside unrecognized application names. Invariant after this change: `sum(icmp hits) == protocols[proto=1] count`.
- Regression test `test_icmp_empty_service_counted_as_unknown` covers empty string and absent key, and asserts the sum invariant.
- CHANGELOG entry under `[Unreleased]`.

Empty `service` on traffic logs is rare in practice, so impact is low; this just closes the last gap in the proto=1 accounting.

## Validation

- `pytest tests/ --ignore=tests/integration`: 614 passed
- `ruff check` / `ruff format --check`: clean