### PR TITLE
fix: get_alert_details sends 'alertids' to alerts/extra-details (closes #47)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to FortiAnalyzer MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **`get_alert_details` works again: the extra-details request now sends `alertids` (plural).** `GET /eventmgmt/adom/{adom}/alerts/extra-details` requires the `alertids` array parameter (per the bundled 7.6.7 and 8.0.0 specs), but the client sent `alertid` — the key `alertlogs` uses — so FAZ rejected every call with `Invalid params: No Params.` and the tool had never returned data. Verified live. Closes [#47](https://github.com/rstierli/fortianalyzer-mcp/issues/47).
+
 ## [2.7.1] - 2026-07-04
 
 ### Fixed

--- a/src/fortianalyzer_mcp/api/client.py
+++ b/src/fortianalyzer_mcp/api/client.py
@@ -1169,7 +1169,8 @@ class FortiAnalyzerClient:
             "get",
             f"/eventmgmt/adom/{adom}/alerts/extra-details",
             apiver=API_VERSION,
-            alertid=alert_ids,
+            # Spec param is "alertids" (plural) — unlike alertlogs' "alertid".
+            alertids=alert_ids,
         )
 
     async def add_alert_comment(

--- a/tests/test_event_tools.py
+++ b/tests/test_event_tools.py
@@ -88,6 +88,27 @@ class TestAlertClient:
         assert alerts[0]["alertid"] == "alert-001"
         assert alerts[0]["severity"] == "high"
 
+    async def test_get_alert_extra_details_sends_alertids_param(
+        self, mock_client_with_events: FortiAnalyzerClient
+    ) -> None:
+        """Regression for #47: extra-details requires "alertids" (plural).
+
+        Unlike alertlogs (whose spec param is "alertid"), the
+        alerts/extra-details request param is "alertids"; sending the
+        singular key makes FAZ reject every call with "No Params".
+        """
+        from unittest.mock import AsyncMock, patch
+
+        with patch.object(
+            mock_client_with_events, "_raw_request", AsyncMock(return_value={})
+        ) as raw:
+            await mock_client_with_events.get_alert_extra_details(
+                adom="root", alert_ids=["a-1", "a-2"]
+            )
+        kwargs = raw.await_args.kwargs
+        assert kwargs.get("alertids") == ["a-1", "a-2"]
+        assert "alertid" not in kwargs
+
     async def test_get_alerts_count_success(
         self, mock_client_with_events: FortiAnalyzerClient
     ) -> None:


### PR DESCRIPTION
One-key fix: `client.get_alert_extra_details()` sent `alertid`, but `GET /eventmgmt/adom/{adom}/alerts/extra-details` requires **`alertids`** (array of strings) — verified in the bundled 7.6.7 and 8.0.0 specs, which agree. FAZ rejected every call with `Invalid params: No Params.`, so the `get_alert_details` tool has never returned data. (`alertlogs` genuinely uses the singular `alertid`; only extra-details differs.)

**Live-verified** against a real FAZ: the call now returns `status: success` with detail records (`alertid`, `devs`, `epids`, `euids`).

Includes a regression test pinning the request param key at the `_raw_request` layer, and the CHANGELOG entry.

Found by the first live validation of the skills layer (#44 / PR #46), whose `triage` skill composes this tool. Closes #47.