### PR TITLE
fix: get_incident via the incidents endpoint with incids (closes #49)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to FortiAnalyzer MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **`get_incident` works again: single-incident retrieval goes through the plural `incidents` endpoint.** `GET /incidentmgmt/adom/{adom}/incident/{incid}` does not exist — that path is update-only, and FAZ rejects a GET on it with `Not supported method`, so the tool had never returned data. Retrieval now uses `GET /incidentmgmt/adom/{adom}/incidents` with `incids=[incident_id]` (per the bundled 7.6.7/8.0.0 specs, which agree) at the default detail level — `extended` drops `severity`/`status` (verified live) — unwrapping the single record and raising a clear not-found error for an empty match. Verified live. Closes [#49](https://github.com/rstierli/fortianalyzer-mcp/issues/49).
+
 ## [2.7.1] - 2026-07-04
 
 ### Fixed

--- a/src/fortianalyzer_mcp/api/client.py
+++ b/src/fortianalyzer_mcp/api/client.py
@@ -1616,11 +1616,27 @@ class FortiAnalyzerClient:
     ) -> dict[str, Any]:
         """Get specific incident details.
 
-        FNDN: GET /incidentmgmt/adom/{adom}/incident/{incid}
+        FNDN: GET /incidentmgmt/adom/{adom}/incidents (incids=[...])
+
+        There is no single-incident GET endpoint — ``incident/{incid}``
+        exists only as an update path. Retrieval goes through the plural
+        ``incidents`` endpoint with an ``incids`` list at the default
+        (standard) detail level: "extended" adds eparr/euarr/attachments
+        but drops ``severity``/``status`` (verified live), which callers
+        need.
         """
-        return await self._raw_request_dict(
-            "get", f"/incidentmgmt/adom/{adom}/incident/{incident_id}", apiver=API_VERSION
+        result = await self._raw_request_dict(
+            "get",
+            f"/incidentmgmt/adom/{adom}/incidents",
+            apiver=API_VERSION,
+            incids=[incident_id],
         )
+        data = result.get("data") if isinstance(result, dict) else None
+        if isinstance(data, list):
+            if not data:
+                raise APIError(f"Incident {incident_id} not found")
+            return cast(dict[str, Any], data[0])
+        return result
 
     async def get_incidents_count(
         self,

--- a/tests/test_incident_tools.py
+++ b/tests/test_incident_tools.py
@@ -79,6 +79,44 @@ class TestIncidentClient:
         assert incidents[0]["incid"] == "inc-001"
         assert incidents[0]["severity"] == "high"
 
+    async def test_get_incident_uses_incidents_endpoint_with_incids(
+        self, mock_client_with_incidents: FortiAnalyzerClient
+    ) -> None:
+        """Regression for #49: no single-incident GET endpoint exists.
+
+        Retrieval must go through the plural "incidents" endpoint with an
+        incids list; incident/{incid} is update-only and FAZ rejects a GET
+        on it with "Not supported method".
+        """
+        from unittest.mock import AsyncMock, patch
+
+        with patch.object(
+            mock_client_with_incidents,
+            "_raw_request",
+            AsyncMock(return_value={"data": [{"incid": "IN00000019"}]}),
+        ) as raw:
+            result = await mock_client_with_incidents.get_incident(
+                adom="root", incident_id="IN00000019"
+            )
+        url = raw.await_args.args[1]
+        assert url == "/incidentmgmt/adom/root/incidents"
+        assert raw.await_args.kwargs["incids"] == ["IN00000019"]
+        assert result == {"incid": "IN00000019"}
+
+    async def test_get_incident_not_found_raises(
+        self, mock_client_with_incidents: FortiAnalyzerClient
+    ) -> None:
+        """An empty incids match raises instead of returning an empty dict."""
+        from unittest.mock import AsyncMock, patch
+
+        from fortianalyzer_mcp.utils.errors import APIError
+
+        with patch.object(
+            mock_client_with_incidents, "_raw_request", AsyncMock(return_value={"data": []})
+        ):
+            with pytest.raises(APIError, match="IN00000404"):
+                await mock_client_with_incidents.get_incident(adom="root", incident_id="IN00000404")
+
     async def test_get_incidents_count_success(
         self, mock_client_with_incidents: FortiAnalyzerClient
     ) -> None:


### PR DESCRIPTION
`GET /incidentmgmt/adom/{adom}/incident/{incid}` does not exist — per the bundled 7.6.7 and 8.0.0 specs (which agree), `incident/{incid}` is an **update-only** path, and live FAZ rejects a GET on it with `Not supported method`. So the `get_incident` tool has never returned data. Sibling of #47/#48 (same class: request shape never validated live).

**Fix:** retrieve via `GET /incidentmgmt/adom/{adom}/incidents` with `incids=[incident_id]`, unwrap the single record, raise a clear not-found `APIError` on an empty match.

**Detail-level note (verified live):** `detail-level=extended` adds `eparr`/`euarr`/`attachments`/MITRE fields but **drops `severity`/`status`**, which callers need — so the default (standard) level is used.

**Live-verified** against a real incident: `status: success`, correct `severity`/`status`.

Includes regression tests (endpoint + `incids` param + not-found path) and the CHANGELOG entry. Closes #49.