### PR TITLE
RFC #40 Phase 1 prototype: verified field allowlist + tool-boundary output masking

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,14 @@ MCP_SERVER_MODE=auto
 # - 'dynamic': Load discovery tools only (lower context usage, ~3K tokens)
 FAZ_TOOL_MODE=full
 
+# Reversible data masking (RFC #40, beta): mask IOC/PII fields (IPs, MACs,
+# hostnames, usernames, domains, emails) in every tool output via
+# format-preserving encryption before they reach the LLM. Requires
+# FAZ_MASKING_KEY (AES key as 32/48/64 hex chars; treat as a secret --
+# rotation makes all previously issued tokens unrecoverable).
+# MASKING_ENABLED=false
+# FAZ_MASKING_KEY=
+
 # =============================================================================
 # Logging Configuration
 # =============================================================================

--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,10 @@ FAZ_TOOL_MODE=full
 # rotation makes all previously issued tokens unrecoverable).
 # MASKING_ENABLED=false
 # FAZ_MASKING_KEY=
+# Also mask device-identity fields (devname, devid, sn, csf). Off by default:
+# they identify the reporting estate rather than people, but leaving them clear
+# means a masked record still fingerprints the device that reported it.
+# FAZ_MASK_DEVICE_IDENTITY=false
 
 # =============================================================================
 # Logging Configuration

--- a/src/fortianalyzer_mcp/masking/__init__.py
+++ b/src/fortianalyzer_mcp/masking/__init__.py
@@ -1,9 +1,11 @@
 """Reversible data masking for LLM-bound IOC data (RFC #40).
 
-Phase 0: the FPE token engine. Later phases add the tool-boundary
-mask/unmask wrapper and configuration wiring.
+Phase 0: the FPE token engine.
+Phase 1 (prototype): field allowlist + tool-boundary output masking.
+Later phases add tool-argument unmasking and configuration hardening.
 """
 
 from fortianalyzer_mcp.masking.fpe_engine import FPEEngine, MaskingError
+from fortianalyzer_mcp.masking.wrapper import OutputMasker, install_masking
 
-__all__ = ["FPEEngine", "MaskingError"]
+__all__ = ["FPEEngine", "MaskingError", "OutputMasker", "install_masking"]

--- a/src/fortianalyzer_mcp/masking/fields.py
+++ b/src/fortianalyzer_mcp/masking/fields.py
@@ -21,14 +21,22 @@ Matching is by key name at any nesting depth, so alert sub-objects
 (``event_details`` carries ``src_ip``/``dst_ip``/``host_name``) and
 wrapped log rows are covered by the same table.
 
+FortiView and UEBA use yet another vocabulary: ``fortigate`` and
+``detectkey`` name the reporting appliance, and ``devvds`` packs device
+and vdom into ``"<devname>[<vdom>]"``. All three are device identity and
+follow the ``FAZ_MASK_DEVICE_IDENTITY`` flag; ``devvds`` needs a composite
+handler because the brackets fall outside the hostname alphabet, so a
+plain hostname mask would burn it to an irreversible placeholder.
+
 Out of scope here, by design:
-- Device-identity fields (devname, devid, sn, csf, ...) identify the
-  reporting estate rather than people. They are a separate deployment
-  decision, so they live in ``DEVICE_IDENTITY_TYPES`` and are masked only
-  when ``FAZ_MASK_DEVICE_IDENTITY`` is set. Leaving them clear keeps the
-  model able to reason about which appliance saw what, at the cost of
-  fingerprinting the estate: a leak test still finds the firewall name and
-  serial in a masked record unless the flag is on.
+- Device-identity fields (devname, devid, sn, csf, fortigate, devvds,
+  detectkey, ...) identify the reporting estate rather than people. They
+  are a separate deployment decision, so they live in
+  ``DEVICE_IDENTITY_TYPES`` (plus ``COMPOSITE_DEVICE_VDOM``) and are
+  masked only when ``FAZ_MASK_DEVICE_IDENTITY`` is set. Leaving them clear
+  keeps the model able to reason about which appliance saw what, at the
+  cost of fingerprinting the estate: a leak test still finds the firewall
+  name and serial in a masked record unless the flag is on.
 - ``incident_reporter`` is polymorphic: a username on a manually created
   incident, an alert id on an auto-raised one. Masking it would corrupt
   the alert id, so it is left alone pending a type-aware decision.
@@ -36,6 +44,28 @@ Out of scope here, by design:
   length) and are deferred with it.
 - ``catdesc`` is a category label, not an identifier — masking it would
   only destroy analytic value.
+- Alert-handler config (``name``, ``template-url``, ``mitre-domain``)
+  carries product metadata, not customer data: live values are
+  ``Default-Botnet-Communication-Detection-By-Endpoint``,
+  ``/fazcfg-template/basic-handler/fgt`` and ``enterprise``. Note
+  ``mitre-domain`` is an ATT&CK domain, not a DNS name; do not be tempted
+  to type it as ``DOMAIN``. Only the operator-authored ``description`` is
+  scanned, as free text.
+
+Known gaps, recorded rather than guessed at:
+- ``socialid`` (ueba ``endusers``) is a container, ``{"data": [...]}``, and
+  is empty on every record of the reference estate. Its populated shape is
+  unknown, so no type is assigned: the recursive walk descends into it and
+  masks whatever allowlisted keys it turns out to hold. Revisit with a
+  populated sample.
+- ``threat``/``obf_url`` (fortiview ``top-threats``) hold a browsed domain
+  on webfilter rows (``mask.icloud.com``, obfuscated as
+  ``mask[dot]icloud[dot]com``) but a signature label on ips/virus rows,
+  where a name like ``Adobe.Flash.Exploit`` is indistinguishable from a
+  domain by shape alone. The sibling ``logtype`` almost certainly
+  disambiguates them, but the reference estate produced no ips/virus row
+  to confirm the mapping, so both are left clear rather than masked on a
+  guess. This is a real leak of browsing destinations; see the RFC thread.
 """
 
 # Value-type tags understood by the wrapper. "email" falls back to
@@ -143,6 +173,7 @@ FIELD_TYPES: dict[str, str] = {
     "extrainfo": TEXT,
     "ui": TEXT,  # event: frequently embeds the admin source IP, e.g. GUI(10.0.0.1)
     "prompt": TEXT,  # app-ctrl: GenAI prompt text
+    "description": TEXT,  # eventmgmt handler config: operator-authored prose
     # --- eventmgmt / incidentmgmt object keys (NOT log fields; found by
     # leak-testing verbatim alert and incident records)
     "endpoint": IP_OR_HOST,  # incident: an address or an endpoint name
@@ -168,6 +199,13 @@ COMPOSITE_PREFIXED = ("groupby1", "groupby2")
 COMPOSITE_JSON = ("grpby",)
 COMPOSITE_TARGET = ("target",)
 
+#: fortiview ``devvds``: ``"<devname>[<vdom>]"``, comma-joined when a row
+#: aggregates several devices. The brackets are outside the hostname
+#: alphabet, so the device name must be lifted out before masking or the
+#: whole string fails closed to an irreversible placeholder. Follows
+#: ``FAZ_MASK_DEVICE_IDENTITY`` like the flat device keys below.
+COMPOSITE_DEVICE_VDOM = ("devvds",)
+
 #: Estate identity, not personal data. Masked only when the deployment
 #: opts in via ``FAZ_MASK_DEVICE_IDENTITY``; see the module docstring.
 DEVICE_IDENTITY_TYPES: dict[str, str] = {
@@ -178,6 +216,8 @@ DEVICE_IDENTITY_TYPES: dict[str, str] = {
     "csf": HOSTNAME,
     "sndetected": HOSTNAME,
     "snclosest": HOSTNAME,
+    "fortigate": HOSTNAME,  # fortiview: reporting device, comma-joined when aggregated
+    "detectkey": HOSTNAME,  # ueba endpoints: serial of the detecting appliance
 }
 
 #: ``target[].name`` values, mapped to the type of the sibling ``value``.

--- a/src/fortianalyzer_mcp/masking/fields.py
+++ b/src/fortianalyzer_mcp/masking/fields.py
@@ -59,8 +59,8 @@ Known gaps, recorded rather than guessed at:
   masks whatever allowlisted keys it turns out to hold. Revisit with a
   populated sample.
 - ``threat``/``obf_url`` (fortiview ``top-threats``) hold a browsed domain
-  on webfilter rows (``mask.icloud.com``, obfuscated as
-  ``mask[dot]icloud[dot]com``) but a signature label on ips/virus rows,
+  on webfilter rows (``threat.example.net``, obfuscated as
+  ``threat[dot]example[dot]net``) but a signature label on ips/virus rows,
   where a name like ``Adobe.Flash.Exploit`` is indistinguishable from a
   domain by shape alone. The sibling ``logtype`` almost certainly
   disambiguates them, but the reference estate produced no ips/virus row

--- a/src/fortianalyzer_mcp/masking/fields.py
+++ b/src/fortianalyzer_mcp/masking/fields.py
@@ -1,12 +1,21 @@
 """Field allowlist for tool-output masking (RFC #40 Phase 1).
 
-Every entry below was verified against live FAZ 7.6.7 and 8.0.0 schemas
+The log field names were verified against live FAZ 7.6.7 and 8.0.0 schemas
 (``get_log_fields`` across traffic, event, attack, webfilter, dns, virus,
-emailfilter and app-ctrl, plus real rows and alert records) — see the
-field-verification discussion on issue #40. Names the RFC drafted that do
-not exist in any schema (src, srcaddr, dst, dstaddr, srchost, dsthost,
-srcuser, remotename, email, message, domain) are deliberately absent:
-masking a nonexistent field is a silent no-op.
+emailfilter and app-ctrl) — see the field-verification discussion on issue
+#40. Names the RFC drafted that do not exist in any schema (src, srcaddr,
+dst, dstaddr, srchost, dsthost, srcuser, remotename, email, message,
+domain) are deliberately absent: masking a nonexistent field is a silent
+no-op.
+
+**Logs are not the only surface.** ``get_log_fields`` describes logview
+rows. Alerts come from eventmgmt and incidents from incidentmgmt, and they
+carry identifiers under different key names (``epip``, ``epname``,
+``endpoint``, ``reporter``) plus composite keys that hold identifiers
+inside a larger string (``groupby1``, ``grpby``, ``target[].value``). A
+leak test over verbatim live records found real hostnames, domains, IPs
+and usernames surviving a mask built from log names alone. Those keys are
+covered below and by the composite handlers in ``wrapper.py``.
 
 Matching is by key name at any nesting depth, so alert sub-objects
 (``event_details`` carries ``src_ip``/``dst_ip``/``host_name``) and
@@ -14,8 +23,15 @@ wrapped log rows are covered by the same table.
 
 Out of scope here, by design:
 - Device-identity fields (devname, devid, sn, csf, ...) identify the
-  reporting estate rather than people; whether to mask them is a separate
-  deployment decision and not part of the default allowlist.
+  reporting estate rather than people. They are a separate deployment
+  decision, so they live in ``DEVICE_IDENTITY_TYPES`` and are masked only
+  when ``FAZ_MASK_DEVICE_IDENTITY`` is set. Leaving them clear keeps the
+  model able to reason about which appliance saw what, at the cost of
+  fingerprinting the estate: a leak test still finds the firewall name and
+  serial in a masked record unless the flag is on.
+- ``incident_reporter`` is polymorphic: a username on a manually created
+  incident, an alert id on an auto-raised one. Masking it would corrupt
+  the alert id, so it is left alone pending a type-aware decision.
 - ``url``/``referralurl`` need a URL-specific token design (alphabet and
   length) and are deferred with it.
 - ``catdesc`` is a category label, not an identifier — masking it would
@@ -32,6 +48,11 @@ USERNAME = "username"
 DOMAIN = "domain"
 EMAIL = "email"
 TEXT = "text"  # free text: embedded IOCs are masked in place
+#: Holds either an address or a name depending on the record. Masks as
+#: whichever it parses as; the two token forms stay distinguishable on the
+#: way back (a hostname token carries the ``host-`` prefix, an IP token
+#: parses as an IP), so the round trip is unambiguous.
+IP_OR_HOST = "ip_or_host"
 
 FIELD_TYPES: dict[str, str] = {
     # --- IP carriers (log fields + alert/event_details variants)
@@ -75,8 +96,8 @@ FIELD_TYPES: dict[str, str] = {
     "srcname": HOSTNAME,
     "dstname": HOSTNAME,
     "hostname": HOSTNAME,
-    "epname": HOSTNAME,
-    "dstepname": HOSTNAME,
+    "epname": IP_OR_HOST,
+    "dstepname": IP_OR_HOST,
     "fqdn": HOSTNAME,
     "host": HOSTNAME,
     "dst_host": HOSTNAME,
@@ -122,12 +143,50 @@ FIELD_TYPES: dict[str, str] = {
     "extrainfo": TEXT,
     "ui": TEXT,  # event: frequently embeds the admin source IP, e.g. GUI(10.0.0.1)
     "prompt": TEXT,  # app-ctrl: GenAI prompt text
+    # --- eventmgmt / incidentmgmt object keys (NOT log fields; found by
+    # leak-testing verbatim alert and incident records)
+    "endpoint": IP_OR_HOST,  # incident: an address or an endpoint name
+    "reporter": USERNAME,  # incident: who raised it
+    "lastuser": USERNAME,  # incident: who last touched it
+    "dstendpoint": IP_OR_HOST,  # inside the incident grpby JSON blob
+    "srcendpoint": IP_OR_HOST,
     # --- response echo keys: tool responses reflect caller inputs at the
-    # top level; a filter like srcip=="10.1.2.3" re-leaks the raw value
+    # top level; a filter like srcip=="192.0.2.1" re-leaks the raw value
     # outside the log rows unless these are scanned too.
     "filter": TEXT,
     "filter_applied": TEXT,
     "device": HOSTNAME,
+}
+
+#: Composite keys whose value is a single string holding one or more
+#: identifiers inside a larger structure. Name matching cannot reach them,
+#: so ``wrapper.py`` parses each shape and masks the parts.
+#:   groupby1/groupby2  "<fieldname>:<value>"   e.g. "dstip:192.0.2.1"
+#:   grpby              JSON, e.g. '[{"dstendpoint": "192.0.2.1"}]'
+#:   target             [{"name": "ip", "value": "192.0.2.1"}, ...]
+COMPOSITE_PREFIXED = ("groupby1", "groupby2")
+COMPOSITE_JSON = ("grpby",)
+COMPOSITE_TARGET = ("target",)
+
+#: Estate identity, not personal data. Masked only when the deployment
+#: opts in via ``FAZ_MASK_DEVICE_IDENTITY``; see the module docstring.
+DEVICE_IDENTITY_TYPES: dict[str, str] = {
+    "devname": HOSTNAME,
+    "devid": HOSTNAME,
+    "sn": HOSTNAME,
+    "serialno": HOSTNAME,
+    "csf": HOSTNAME,
+    "sndetected": HOSTNAME,
+    "snclosest": HOSTNAME,
+}
+
+#: ``target[].name`` values, mapped to the type of the sibling ``value``.
+TARGET_NAME_TYPES: dict[str, str] = {
+    "ip": IP,
+    "domain": DOMAIN,
+    "device": IP_OR_HOST,
+    "endpoint": IP_OR_HOST,
+    "user": USERNAME,
 }
 
 # Values that carry no identifier and pass through unmasked.

--- a/src/fortianalyzer_mcp/masking/fields.py
+++ b/src/fortianalyzer_mcp/masking/fields.py
@@ -1,0 +1,134 @@
+"""Field allowlist for tool-output masking (RFC #40 Phase 1).
+
+Every entry below was verified against live FAZ 7.6.7 and 8.0.0 schemas
+(``get_log_fields`` across traffic, event, attack, webfilter, dns, virus,
+emailfilter and app-ctrl, plus real rows and alert records) — see the
+field-verification discussion on issue #40. Names the RFC drafted that do
+not exist in any schema (src, srcaddr, dst, dstaddr, srchost, dsthost,
+srcuser, remotename, email, message, domain) are deliberately absent:
+masking a nonexistent field is a silent no-op.
+
+Matching is by key name at any nesting depth, so alert sub-objects
+(``event_details`` carries ``src_ip``/``dst_ip``/``host_name``) and
+wrapped log rows are covered by the same table.
+
+Out of scope here, by design:
+- Device-identity fields (devname, devid, sn, csf, ...) identify the
+  reporting estate rather than people; whether to mask them is a separate
+  deployment decision and not part of the default allowlist.
+- ``url``/``referralurl`` need a URL-specific token design (alphabet and
+  length) and are deferred with it.
+- ``catdesc`` is a category label, not an identifier — masking it would
+  only destroy analytic value.
+"""
+
+# Value-type tags understood by the wrapper. "email" falls back to
+# username masking when the value carries no "@" (the from/to fields are
+# email addresses in virus/emailfilter logs but plain labels elsewhere).
+IP = "ip"
+MAC = "mac"
+HOSTNAME = "hostname"
+USERNAME = "username"
+DOMAIN = "domain"
+EMAIL = "email"
+TEXT = "text"  # free text: embedded IOCs are masked in place
+
+FIELD_TYPES: dict[str, str] = {
+    # --- IP carriers (log fields + alert/event_details variants)
+    "srcip": IP,
+    "dstip": IP,
+    "trueclntip": IP,
+    "transip": IP,
+    "tranip": IP,
+    "ipaddr": IP,  # dns: resolved answer, may be a list
+    "botnetip": IP,
+    "ip": IP,
+    "nat": IP,
+    "locip": IP,
+    "remip": IP,
+    "assignip": IP,
+    "tunnelip": IP,
+    "tunnelsrcip": IP,
+    "tunneldstip": IP,
+    "srcremote": IP,
+    "vipincomingip": IP,
+    "dns_ip": IP,
+    "ddnsserver": IP,
+    "gateway": IP,
+    "domainctrlip": IP,
+    "epip": IP,
+    "dstepip": IP,
+    "ipv6": IP,  # event schema, new in FAZ 8.0.0
+    "src_ip": IP,  # alert event_details
+    "dst_ip": IP,  # alert event_details
+    # --- MAC carriers
+    "srcmac": MAC,
+    "dstmac": MAC,
+    "mastersrcmac": MAC,
+    "masterdstmac": MAC,
+    "mac": MAC,
+    "bssid": MAC,
+    "stamac": MAC,
+    "tamac": MAC,
+    "source_mac": MAC,
+    # --- host / device-name carriers (people-adjacent, not estate identity)
+    "srcname": HOSTNAME,
+    "dstname": HOSTNAME,
+    "hostname": HOSTNAME,
+    "epname": HOSTNAME,
+    "dstepname": HOSTNAME,
+    "fqdn": HOSTNAME,
+    "host": HOSTNAME,
+    "dst_host": HOSTNAME,
+    "host_name": HOSTNAME,  # alert event_details
+    "dns_name": HOSTNAME,
+    "servername": HOSTNAME,
+    "serveraddr": HOSTNAME,
+    "remotedevname": HOSTNAME,
+    "domainctrlname": HOSTNAME,
+    # --- username carriers
+    "user": USERNAME,
+    "dstuser": USERNAME,
+    "unauthuser": USERNAME,
+    "xauthuser": USERNAME,
+    "eapuser": USERNAME,
+    "useralt": USERNAME,
+    "clouduser": USERNAME,
+    "aiuser": USERNAME,
+    "initiator": USERNAME,
+    "admin": USERNAME,
+    "remoteadmin": USERNAME,
+    "euname": USERNAME,
+    "dsteuname": USERNAME,
+    "domainctrlusername": USERNAME,
+    # --- domain carriers
+    "qname": DOMAIN,
+    "srcdomain": DOMAIN,
+    "botnetdomain": DOMAIN,
+    "domainctrldomain": DOMAIN,
+    "scertcname": DOMAIN,
+    # --- email carriers (from/to fall back to username when no "@")
+    "sender": EMAIL,
+    "recipient": EMAIL,
+    "from": EMAIL,
+    "to": EMAIL,
+    "cc": EMAIL,
+    "collectedemail": EMAIL,
+    "dstcollectedemail": EMAIL,
+    # --- free text: embedded IOCs masked in place
+    "msg": TEXT,
+    "logdesc": TEXT,
+    "subject": TEXT,
+    "extrainfo": TEXT,
+    "ui": TEXT,  # event: frequently embeds the admin source IP, e.g. GUI(10.0.0.1)
+    "prompt": TEXT,  # app-ctrl: GenAI prompt text
+    # --- response echo keys: tool responses reflect caller inputs at the
+    # top level; a filter like srcip=="10.1.2.3" re-leaks the raw value
+    # outside the log rows unless these are scanned too.
+    "filter": TEXT,
+    "filter_applied": TEXT,
+    "device": HOSTNAME,
+}
+
+# Values that carry no identifier and pass through unmasked.
+SKIP_VALUES = frozenset({"", "N/A", "n/a", "unknown", "none", "-"})

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -12,9 +12,9 @@ to strip out of free text once we know what it masks to:
 1. **Structured pass.** Allowlisted keys are masked by type at any nesting
    depth, and composite keys are parsed and masked part by part
    (``groupby1``/``groupby2`` are ``"<field>:<value>"``, ``grpby`` is an
-   embedded JSON blob, ``target`` is a list of ``{name, value}``). Every
-   real value masked here is recorded in a response-scoped raw-to-token
-   map.
+   embedded JSON blob, ``target`` is a list of ``{name, value}``,
+   ``devvds`` is ``"<devname>[<vdom>]"``). Every real value masked here is
+   recorded in a response-scoped raw-to-token map.
 2. **Free-text pass.** ``msg``, ``logdesc``, ``subject``, ``extrainfo``,
    the echoed ``filter`` strings and friends get an in-place scan for
    embedded IPv4s, MACs and emails, then every raw value from pass 1 is
@@ -38,8 +38,9 @@ consistent.
 
 Scope (deliberately Phase 1 only): tool OUTPUT masking. Unmasking of
 tool-call arguments (Phase 2) and URL handling are not here. Device
-identity (``devname``, ``devid``, ``sn``, ``csf``) is out of the default
-allowlist, so a masked record still fingerprints the reporting device.
+identity (``devname``, ``devid``, ``sn``, ``csf``, ``fortigate``,
+``devvds``, ``detectkey``) is out of the default allowlist, so a masked
+record still fingerprints the reporting device.
 """
 
 import hashlib
@@ -54,6 +55,7 @@ from functools import wraps
 from typing import Any
 
 from fortianalyzer_mcp.masking.fields import (
+    COMPOSITE_DEVICE_VDOM,
     COMPOSITE_JSON,
     COMPOSITE_PREFIXED,
     COMPOSITE_TARGET,
@@ -77,6 +79,7 @@ logger = logging.getLogger(__name__)
 _IPV4_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
 _MAC_RE = re.compile(r"\b[0-9a-fA-F]{2}(?::[0-9a-fA-F]{2}){5}\b")
 _EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
+_DEVVDS_RE = re.compile(r"^(?P<dev>[^\[\]]+)\[(?P<vdom>[^\[\]]*)\]$")
 
 #: Values shorter than this are not substituted into free text: a two or
 #: three character username would match inside unrelated words.
@@ -94,6 +97,7 @@ class OutputMasker:
         # brute-forceable from a leaked transcript. The env var is present
         # because the engine was just built from it.
         self._placeholder_key = os.environ.get(MASKING_KEY_ENV, "").encode()
+        self._mask_device_identity = mask_device_identity
         self._field_types = dict(FIELD_TYPES)
         if mask_device_identity:
             self._field_types.update(DEVICE_IDENTITY_TYPES)
@@ -184,6 +188,26 @@ class OutputMasker:
             # Not JSON after all: at least strip the IOCs a regex can see.
             return self.mask_text(value, mapping)
         return json.dumps(self._mask_structured(parsed, mapping))
+
+    def _mask_device_vdom(self, value: str, mapping: dict[str, str]) -> str:
+        """``"<devname>[<vdom>]"``, comma-joined (fortiview ``devvds``).
+
+        The vdom stays clear, like the flat ``vd`` log field. Only the
+        device name is estate identity, so the whole key follows
+        ``FAZ_MASK_DEVICE_IDENTITY``.
+        """
+        if not self._mask_device_identity:
+            return value
+        out: list[str] = []
+        for part in value.split(","):
+            match = _DEVVDS_RE.match(part.strip())
+            if match is None:
+                # Bare device name, or a shape we have not seen: mask whole.
+                out.append(self._mask_scalar(HOSTNAME, part, mapping))
+                continue
+            device = self._mask_scalar(HOSTNAME, match.group("dev"), mapping)
+            out.append(f"{device}[{match.group('vdom')}]")
+        return ",".join(out)
 
     def _mask_target(self, value: list[Any], mapping: dict[str, str]) -> list[Any]:
         """``[{"name": "ip", "value": "..."}]`` (alert ``target``)."""
@@ -285,6 +309,8 @@ class OutputMasker:
             return self._mask_json_blob(value, mapping)
         if lowered in COMPOSITE_TARGET and isinstance(value, list):
             return self._mask_target(value, mapping)
+        if lowered in COMPOSITE_DEVICE_VDOM and isinstance(value, str):
+            return self._mask_device_vdom(value, mapping)
 
         vtype = self._field_types.get(key)
         if vtype is not None and vtype != TEXT:

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -74,6 +74,14 @@ class OutputMasker:
     def _mask_scalar(self, vtype: str, value: str) -> str:
         if value.strip() in SKIP_VALUES:
             return value
+        if vtype != TEXT and "," in value:
+            # FAZ packs multi-valued fields into one comma-joined string
+            # (live example: the dns ``ipaddr`` answer list). Mask each
+            # element; an unmaskable element still fails closed on its own.
+            return ",".join(
+                part if part.strip() in SKIP_VALUES or not part else self._mask_scalar(vtype, part)
+                for part in value.split(",")
+            )
         try:
             if vtype == IP:
                 return self._engine.mask_ip(value)

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -6,28 +6,47 @@ with module-level ``@mcp.tool()`` at import time), so ``install_masking``
 patches ``mcp.tool`` on the shared FastMCP instance BEFORE the tool
 modules are imported; every subsequently registered tool is wrapped.
 
+Masking runs in two passes over the result, because a value is only safe
+to strip out of free text once we know what it masks to:
+
+1. **Structured pass.** Allowlisted keys are masked by type at any nesting
+   depth, and composite keys are parsed and masked part by part
+   (``groupby1``/``groupby2`` are ``"<field>:<value>"``, ``grpby`` is an
+   embedded JSON blob, ``target`` is a list of ``{name, value}``). Every
+   real value masked here is recorded in a response-scoped raw-to-token
+   map.
+2. **Free-text pass.** ``msg``, ``logdesc``, ``subject``, ``extrainfo``,
+   the echoed ``filter`` strings and friends get an in-place scan for
+   embedded IPv4s, MACs and emails, then every raw value from pass 1 is
+   substituted wherever it appears. That second step is what catches
+   hostnames and domains inside prose: you cannot regex a hostname safely,
+   but you can replace the exact strings you just masked elsewhere in the
+   same response. It also removes the "masked under one key, cleartext two
+   keys away" failure that a leak test over live alert records exposed.
+
 Fail-closed by construction:
 
 - A value that cannot be masked (outside the FPE alphabet, malformed) is
-  replaced with an irreversible keyed placeholder — never passed through
+  replaced with an irreversible keyed placeholder, never passed through
   raw, never logged.
 - If masking a whole result fails unexpectedly, the tool returns a
-  ``masking_failed`` error envelope — the raw result is withheld.
+  ``masking_failed`` error envelope and the raw result is withheld.
 
-Free-text fields (``msg``, ``logdesc``, echoed ``filter`` strings, ...)
-get an in-place IOC scan: embedded IPv4s, MACs and emails are replaced
-with their deterministic tokens. Because FPE is deterministic, a re-masked
-echo of an unmasked argument yields exactly the token the caller sent, so
-follow-up turns stay consistent.
+Because FPE is deterministic, a re-masked echo of an unmasked argument
+yields exactly the token the caller sent, so follow-up turns stay
+consistent.
 
 Scope (deliberately Phase 1 only): tool OUTPUT masking. Unmasking of
-tool-call arguments (Phase 2) and URL/IPv6-in-text handling are not here.
+tool-call arguments (Phase 2) and URL handling are not here. Device
+identity (``devname``, ``devid``, ``sn``, ``csf``) is out of the default
+allowlist, so a masked record still fingerprints the reporting device.
 """
 
 import hashlib
 import hmac
 import inspect
 import ipaddress
+import json
 import logging
 import os
 import re
@@ -35,13 +54,19 @@ from functools import wraps
 from typing import Any
 
 from fortianalyzer_mcp.masking.fields import (
+    COMPOSITE_JSON,
+    COMPOSITE_PREFIXED,
+    COMPOSITE_TARGET,
+    DEVICE_IDENTITY_TYPES,
     DOMAIN,
     EMAIL,
     FIELD_TYPES,
     HOSTNAME,
     IP,
+    IP_OR_HOST,
     MAC,
     SKIP_VALUES,
+    TARGET_NAME_TYPES,
     TEXT,
     USERNAME,
 )
@@ -53,40 +78,53 @@ _IPV4_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
 _MAC_RE = re.compile(r"\b[0-9a-fA-F]{2}(?::[0-9a-fA-F]{2}){5}\b")
 _EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
 
+#: Values shorter than this are not substituted into free text: a two or
+#: three character username would match inside unrelated words.
+_MIN_SUBSTITUTION_LEN = 4
+
+_PLACEHOLDER_MARK = "masked-unrepresentable-"
+
 
 class OutputMasker:
     """Recursive result masker bound to one FPE engine."""
 
-    def __init__(self, engine: FPEEngine) -> None:
+    def __init__(self, engine: FPEEngine, mask_device_identity: bool = False) -> None:
         self._engine = engine
         # Keyed so placeholders are deterministic (correlatable) but not
         # brute-forceable from a leaked transcript. The env var is present
         # because the engine was just built from it.
         self._placeholder_key = os.environ.get(MASKING_KEY_ENV, "").encode()
+        self._field_types = dict(FIELD_TYPES)
+        if mask_device_identity:
+            self._field_types.update(DEVICE_IDENTITY_TYPES)
 
     # -- fail-closed primitives ---------------------------------------- #
 
     def placeholder(self, value: str) -> str:
         """Irreversible, deterministic stand-in for an unmaskable value."""
         digest = hmac.new(self._placeholder_key, value.encode(), hashlib.sha256).hexdigest()[:10]
-        return f"masked-unrepresentable-{digest}"
+        return f"{_PLACEHOLDER_MARK}{digest}"
 
-    def _mask_scalar(self, vtype: str, value: str) -> str:
-        if value.strip() in SKIP_VALUES:
-            return value
-        if vtype != TEXT and "," in value:
-            # FAZ packs multi-valued fields into one comma-joined string
-            # (live example: the dns ``ipaddr`` answer list). Mask each
-            # element; an unmaskable element still fails closed on its own.
-            return ",".join(
-                part if part.strip() in SKIP_VALUES or not part else self._mask_scalar(vtype, part)
-                for part in value.split(",")
-            )
+    def _mask_ip_or_host(self, value: str) -> str:
+        """Mask a field that holds either an address or a name.
+
+        The token forms stay distinguishable on the way back: a hostname
+        token carries the ``host-`` prefix, an IP token parses as an IP.
+        """
+        try:
+            ipaddress.ip_address(value.strip())
+        except ValueError:
+            return self._engine.mask_hostname(value)
+        return self._engine.mask_ip(value)
+
+    def _mask_one(self, vtype: str, value: str) -> str:
         try:
             if vtype == IP:
                 return self._engine.mask_ip(value)
             if vtype == MAC:
                 return self._engine.mask_mac(value)
+            if vtype == IP_OR_HOST:
+                return self._mask_ip_or_host(value)
             if vtype == HOSTNAME:
                 return self._engine.mask_hostname(value)
             if vtype == USERNAME:
@@ -99,8 +137,6 @@ class OutputMasker:
                 if "@" in value:
                     return self._engine.mask_email(value)
                 return self._engine.mask_username(value)
-            if vtype == TEXT:
-                return self.mask_text(value)
         except MaskingError:
             return self.placeholder(value)
         except Exception:
@@ -110,10 +146,70 @@ class OutputMasker:
             return self.placeholder(value)
         return self.placeholder(value)  # unknown type tag: fail closed
 
+    def _mask_scalar(self, vtype: str, value: str, mapping: dict[str, str] | None = None) -> str:
+        if value.strip() in SKIP_VALUES:
+            return value
+        if "," in value:
+            # FAZ packs multi-valued fields into one comma-joined string
+            # (live example: the dns ``ipaddr`` answer list). Mask each
+            # element; an unmaskable element still fails closed on its own.
+            return ",".join(
+                part
+                if part.strip() in SKIP_VALUES or not part
+                else self._mask_scalar(vtype, part, mapping)
+                for part in value.split(",")
+            )
+        token = self._mask_one(vtype, value)
+        if mapping is not None and token != value and _PLACEHOLDER_MARK not in token:
+            mapping[value] = token
+        return token
+
+    # -- composite keys ------------------------------------------------- #
+
+    def _mask_prefixed(self, value: str, mapping: dict[str, str]) -> str:
+        """``"<fieldname>:<value>"`` (alert ``groupby1``/``groupby2``)."""
+        field, sep, raw = value.partition(":")
+        if not sep or not raw:
+            return value
+        vtype = self._field_types.get(field.lower())
+        if vtype is None or vtype == TEXT:
+            return value
+        return f"{field}{sep}{self._mask_scalar(vtype, raw, mapping)}"
+
+    def _mask_json_blob(self, value: str, mapping: dict[str, str]) -> str:
+        """An embedded JSON string (incident ``grpby``)."""
+        try:
+            parsed = json.loads(value)
+        except (ValueError, TypeError):
+            # Not JSON after all: at least strip the IOCs a regex can see.
+            return self.mask_text(value, mapping)
+        return json.dumps(self._mask_structured(parsed, mapping))
+
+    def _mask_target(self, value: list[Any], mapping: dict[str, str]) -> list[Any]:
+        """``[{"name": "ip", "value": "..."}]`` (alert ``target``)."""
+        out: list[Any] = []
+        for item in value:
+            if not isinstance(item, dict):
+                out.append(self._mask_structured(item, mapping))
+                continue
+            entry = dict(item)
+            vtype = TARGET_NAME_TYPES.get(str(entry.get("name", "")).lower())
+            raw = entry.get("value")
+            if vtype and isinstance(raw, str):
+                token = self._mask_scalar(vtype, raw, mapping)
+                entry["value"] = token
+                # asset_value repeats the identifier on some targets and
+                # carries an internal numeric id on others; mask only the
+                # former.
+                if entry.get("asset_value") == raw:
+                    entry["asset_value"] = token
+            out.append(entry)
+        return out
+
     # -- free-text IOC scan --------------------------------------------- #
 
-    def mask_text(self, text: str) -> str:
-        """Replace embedded IPv4/MAC/email IOCs inside free text."""
+    def mask_text(self, text: str, mapping: dict[str, str] | None = None) -> str:
+        """Mask embedded IPv4/MAC/email IOCs, then any known raw value."""
 
         def ip_sub(m: re.Match[str]) -> str:
             candidate = m.group(0)
@@ -140,34 +236,94 @@ class OutputMasker:
 
         out = _IPV4_RE.sub(ip_sub, text)
         out = _MAC_RE.sub(mac_sub, out)
-        return _EMAIL_RE.sub(email_sub, out)
+        out = _EMAIL_RE.sub(email_sub, out)
+        return self._substitute_known(out, mapping)
 
-    # -- recursive structure walk ---------------------------------------- #
+    def _substitute_known(self, text: str, mapping: dict[str, str] | None) -> str:
+        """Replace values that were masked elsewhere in this response.
+
+        Hostnames and domains cannot be recognized by pattern, but they can
+        be recognized by identity: a value masked in a structured field of
+        the same response is the same identifier wherever it appears in
+        prose, and gets the same token. Longest first, so a domain is not
+        partially rewritten by one of its own labels.
+        """
+        if not mapping:
+            return text
+        for raw in sorted(mapping, key=len, reverse=True):
+            if len(raw) < _MIN_SUBSTITUTION_LEN:
+                continue
+            token = mapping[raw]
+            for variant in dict.fromkeys((raw, raw.lower())):
+                pattern = re.compile(
+                    r"(?<![A-Za-z0-9._-])" + re.escape(variant) + r"(?![A-Za-z0-9._-])"
+                )
+                text = pattern.sub(token, text)
+        return text
+
+    # -- the two passes -------------------------------------------------- #
 
     def mask_result(self, obj: Any) -> Any:
-        """Mask a tool result in depth: allowlisted keys at any nesting."""
+        """Mask a tool result: structured pass, then free-text pass."""
+        mapping: dict[str, str] = {}
+        staged = self._mask_structured(obj, mapping)
+        return self._mask_free_text(staged, mapping)
+
+    def _mask_structured(self, obj: Any, mapping: dict[str, str]) -> Any:
+        """Pass 1: mask allowlisted and composite keys, record raw -> token."""
         if isinstance(obj, dict):
-            return {key: self._mask_entry(key, value) for key, value in obj.items()}
+            return {key: self._mask_entry(key, value, mapping) for key, value in obj.items()}
         if isinstance(obj, list):
-            return [self.mask_result(item) for item in obj]
+            return [self._mask_structured(item, mapping) for item in obj]
         return obj
 
-    def _mask_entry(self, key: str, value: Any) -> Any:
-        vtype = FIELD_TYPES.get(key)
-        if vtype is not None:
+    def _mask_entry(self, key: str, value: Any, mapping: dict[str, str]) -> Any:
+        lowered = key.lower()
+        if lowered in COMPOSITE_PREFIXED and isinstance(value, str):
+            return self._mask_prefixed(value, mapping)
+        if lowered in COMPOSITE_JSON and isinstance(value, str):
+            return self._mask_json_blob(value, mapping)
+        if lowered in COMPOSITE_TARGET and isinstance(value, list):
+            return self._mask_target(value, mapping)
+
+        vtype = self._field_types.get(key)
+        if vtype is not None and vtype != TEXT:
             if isinstance(value, str):
-                return self._mask_scalar(vtype, value)
+                return self._mask_scalar(vtype, value, mapping)
             if isinstance(value, list):
                 # e.g. dns "ipaddr" is a list of resolved addresses
                 return [
-                    self._mask_scalar(vtype, item)
+                    self._mask_scalar(vtype, item, mapping)
                     if isinstance(item, str)
-                    else self.mask_result(item)
+                    else self._mask_structured(item, mapping)
                     for item in value
                 ]
         if isinstance(value, dict | list):
-            return self.mask_result(value)
-        return value
+            return self._mask_structured(value, mapping)
+        return value  # TEXT values are deliberately left for pass 2
+
+    def _mask_free_text(self, obj: Any, mapping: dict[str, str]) -> Any:
+        """Pass 2: mask TEXT fields, now that the raw -> token map is known."""
+        if isinstance(obj, dict):
+            out: dict[str, Any] = {}
+            for key, value in obj.items():
+                if self._field_types.get(key) == TEXT and isinstance(value, str):
+                    out[key] = self._mask_scalar_text(value, mapping)
+                else:
+                    out[key] = self._mask_free_text(value, mapping)
+            return out
+        if isinstance(obj, list):
+            return [self._mask_free_text(item, mapping) for item in obj]
+        return obj
+
+    def _mask_scalar_text(self, value: str, mapping: dict[str, str]) -> str:
+        if value.strip() in SKIP_VALUES:
+            return value
+        try:
+            return self.mask_text(value, mapping)
+        except Exception:
+            logger.exception("unexpected error masking free text; placeholder used")
+            return self.placeholder(value)
 
     # -- tool-result entry point ----------------------------------------- #
 
@@ -188,10 +344,12 @@ def install_masking(mcp: Any) -> OutputMasker:
 
     Must run BEFORE the tool modules are imported (they register at import
     time). Raises MaskingError at startup if ``FAZ_MASKING_KEY`` is absent
-    or invalid — a deployment that asked for masking must not run without it.
+    or invalid: a deployment that asked for masking must not run without it.
     """
+    from fortianalyzer_mcp.utils.config import get_settings
+
     engine = FPEEngine.from_env()
-    masker = OutputMasker(engine)
+    masker = OutputMasker(engine, mask_device_identity=get_settings().FAZ_MASK_DEVICE_IDENTITY)
     original_tool = mcp.tool
 
     def patched_tool(*args: Any, **kwargs: Any) -> Any:

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -1,0 +1,211 @@
+"""Tool-boundary output masking (RFC #40 Phase 1 prototype).
+
+Masks every tool result before it leaves the MCP toward the LLM. There is
+no central tool-registration function to hook (tool modules self-register
+with module-level ``@mcp.tool()`` at import time), so ``install_masking``
+patches ``mcp.tool`` on the shared FastMCP instance BEFORE the tool
+modules are imported; every subsequently registered tool is wrapped.
+
+Fail-closed by construction:
+
+- A value that cannot be masked (outside the FPE alphabet, malformed) is
+  replaced with an irreversible keyed placeholder — never passed through
+  raw, never logged.
+- If masking a whole result fails unexpectedly, the tool returns a
+  ``masking_failed`` error envelope — the raw result is withheld.
+
+Free-text fields (``msg``, ``logdesc``, echoed ``filter`` strings, ...)
+get an in-place IOC scan: embedded IPv4s, MACs and emails are replaced
+with their deterministic tokens. Because FPE is deterministic, a re-masked
+echo of an unmasked argument yields exactly the token the caller sent, so
+follow-up turns stay consistent.
+
+Scope (deliberately Phase 1 only): tool OUTPUT masking. Unmasking of
+tool-call arguments (Phase 2) and URL/IPv6-in-text handling are not here.
+"""
+
+import hashlib
+import hmac
+import inspect
+import ipaddress
+import logging
+import os
+import re
+from functools import wraps
+from typing import Any
+
+from fortianalyzer_mcp.masking.fields import (
+    DOMAIN,
+    EMAIL,
+    FIELD_TYPES,
+    HOSTNAME,
+    IP,
+    MAC,
+    SKIP_VALUES,
+    TEXT,
+    USERNAME,
+)
+from fortianalyzer_mcp.masking.fpe_engine import MASKING_KEY_ENV, FPEEngine, MaskingError
+
+logger = logging.getLogger(__name__)
+
+_IPV4_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+_MAC_RE = re.compile(r"\b[0-9a-fA-F]{2}(?::[0-9a-fA-F]{2}){5}\b")
+_EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
+
+
+class OutputMasker:
+    """Recursive result masker bound to one FPE engine."""
+
+    def __init__(self, engine: FPEEngine) -> None:
+        self._engine = engine
+        # Keyed so placeholders are deterministic (correlatable) but not
+        # brute-forceable from a leaked transcript. The env var is present
+        # because the engine was just built from it.
+        self._placeholder_key = os.environ.get(MASKING_KEY_ENV, "").encode()
+
+    # -- fail-closed primitives ---------------------------------------- #
+
+    def placeholder(self, value: str) -> str:
+        """Irreversible, deterministic stand-in for an unmaskable value."""
+        digest = hmac.new(self._placeholder_key, value.encode(), hashlib.sha256).hexdigest()[:10]
+        return f"masked-unrepresentable-{digest}"
+
+    def _mask_scalar(self, vtype: str, value: str) -> str:
+        if value.strip() in SKIP_VALUES:
+            return value
+        try:
+            if vtype == IP:
+                return self._engine.mask_ip(value)
+            if vtype == MAC:
+                return self._engine.mask_mac(value)
+            if vtype == HOSTNAME:
+                return self._engine.mask_hostname(value)
+            if vtype == USERNAME:
+                return self._engine.mask_username(value)
+            if vtype == DOMAIN:
+                return self._engine.mask_domain(value)
+            if vtype == EMAIL:
+                # from/to are emails in virus/emailfilter logs but plain
+                # labels elsewhere; only actual addresses mask as email.
+                if "@" in value:
+                    return self._engine.mask_email(value)
+                return self._engine.mask_username(value)
+            if vtype == TEXT:
+                return self.mask_text(value)
+        except MaskingError:
+            return self.placeholder(value)
+        except Exception:
+            # Never let a masking bug leak the raw value. The value itself
+            # is deliberately not logged.
+            logger.exception("unexpected error masking a %s value; placeholder used", vtype)
+            return self.placeholder(value)
+        return self.placeholder(value)  # unknown type tag: fail closed
+
+    # -- free-text IOC scan --------------------------------------------- #
+
+    def mask_text(self, text: str) -> str:
+        """Replace embedded IPv4/MAC/email IOCs inside free text."""
+
+        def ip_sub(m: re.Match[str]) -> str:
+            candidate = m.group(0)
+            try:
+                ipaddress.IPv4Address(candidate)
+            except ValueError:
+                return candidate  # e.g. 999.1.1.1 or a dotted version string
+            try:
+                return self._engine.mask_ip(candidate)
+            except MaskingError:
+                return self.placeholder(candidate)
+
+        def mac_sub(m: re.Match[str]) -> str:
+            try:
+                return self._engine.mask_mac(m.group(0))
+            except MaskingError:
+                return self.placeholder(m.group(0))
+
+        def email_sub(m: re.Match[str]) -> str:
+            try:
+                return self._engine.mask_email(m.group(0))
+            except MaskingError:
+                return self.placeholder(m.group(0))
+
+        out = _IPV4_RE.sub(ip_sub, text)
+        out = _MAC_RE.sub(mac_sub, out)
+        return _EMAIL_RE.sub(email_sub, out)
+
+    # -- recursive structure walk ---------------------------------------- #
+
+    def mask_result(self, obj: Any) -> Any:
+        """Mask a tool result in depth: allowlisted keys at any nesting."""
+        if isinstance(obj, dict):
+            return {key: self._mask_entry(key, value) for key, value in obj.items()}
+        if isinstance(obj, list):
+            return [self.mask_result(item) for item in obj]
+        return obj
+
+    def _mask_entry(self, key: str, value: Any) -> Any:
+        vtype = FIELD_TYPES.get(key)
+        if vtype is not None:
+            if isinstance(value, str):
+                return self._mask_scalar(vtype, value)
+            if isinstance(value, list):
+                # e.g. dns "ipaddr" is a list of resolved addresses
+                return [
+                    self._mask_scalar(vtype, item)
+                    if isinstance(item, str)
+                    else self.mask_result(item)
+                    for item in value
+                ]
+        if isinstance(value, dict | list):
+            return self.mask_result(value)
+        return value
+
+    # -- tool-result entry point ----------------------------------------- #
+
+    def mask_tool_result(self, result: Any, tool_name: str) -> Any:
+        try:
+            return self.mask_result(result)
+        except Exception:
+            logger.exception("output masking failed for %s; raw result withheld", tool_name)
+            return {
+                "status": "error",
+                "error": "masking_failed",
+                "message": f"{tool_name}: output masking failed; raw result withheld (fail-closed)",
+            }
+
+
+def install_masking(mcp: Any) -> OutputMasker:
+    """Patch ``mcp.tool`` so every tool registered afterwards masks its output.
+
+    Must run BEFORE the tool modules are imported (they register at import
+    time). Raises MaskingError at startup if ``FAZ_MASKING_KEY`` is absent
+    or invalid — a deployment that asked for masking must not run without it.
+    """
+    engine = FPEEngine.from_env()
+    masker = OutputMasker(engine)
+    original_tool = mcp.tool
+
+    def patched_tool(*args: Any, **kwargs: Any) -> Any:
+        decorator = original_tool(*args, **kwargs)
+
+        def register(fn: Any) -> Any:
+            if inspect.iscoroutinefunction(fn):
+
+                @wraps(fn)
+                async def async_wrapped(*fa: Any, **fk: Any) -> Any:
+                    return masker.mask_tool_result(await fn(*fa, **fk), fn.__name__)
+
+                return decorator(async_wrapped)
+
+            @wraps(fn)
+            def sync_wrapped(*fa: Any, **fk: Any) -> Any:
+                return masker.mask_tool_result(fn(*fa, **fk), fn.__name__)
+
+            return decorator(sync_wrapped)
+
+        return register
+
+    mcp.tool = patched_tool
+    logger.info("output masking installed: all tools registered from now on are wrapped")
+    return masker

--- a/src/fortianalyzer_mcp/server.py
+++ b/src/fortianalyzer_mcp/server.py
@@ -52,6 +52,16 @@ mcp = FastMCP(
     transport_security=_transport_security,
 )
 
+if settings.MASKING_ENABLED:
+    # RFC #40 Phase 1: wrap tool registration BEFORE any tool module is
+    # imported (tools self-register at import). Raises at startup if
+    # FAZ_MASKING_KEY is missing/invalid: a deployment that asked for
+    # masking must not run without it.
+    from fortianalyzer_mcp.masking.wrapper import install_masking  # noqa: E402
+
+    install_masking(mcp)
+    logger.info("MASKING_ENABLED - tool outputs are masked (RFC #40 Phase 1)")
+
 
 # Health check resource
 @mcp.resource("health://status")

--- a/src/fortianalyzer_mcp/utils/config.py
+++ b/src/fortianalyzer_mcp/utils/config.py
@@ -131,6 +131,12 @@ class Settings(BaseSettings):
         description="Mask IOC/PII fields in tool outputs via FPE (requires FAZ_MASKING_KEY). "
         "Off by default; no behavior change unless enabled.",
     )
+    FAZ_MASK_DEVICE_IDENTITY: bool = Field(
+        default=False,
+        description="Also mask device-identity fields (devname, devid, sn, csf). "
+        "Off by default: these identify the reporting estate, not people, and masking "
+        "them costs the model its sense of which appliance saw what.",
+    )
 
     # Logging Configuration
     LOG_LEVEL: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = Field(

--- a/src/fortianalyzer_mcp/utils/config.py
+++ b/src/fortianalyzer_mcp/utils/config.py
@@ -125,6 +125,13 @@ class Settings(BaseSettings):
         description="Tool loading mode: 'full' loads all tools, 'dynamic' loads meta-tools only",
     )
 
+    # Reversible data masking (RFC #40) — additive, off by default
+    MASKING_ENABLED: bool = Field(
+        default=False,
+        description="Mask IOC/PII fields in tool outputs via FPE (requires FAZ_MASKING_KEY). "
+        "Off by default; no behavior change unless enabled.",
+    )
+
     # Logging Configuration
     LOG_LEVEL: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = Field(
         default="INFO",

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -1,0 +1,216 @@
+"""Adversarial leak tests for output masking (RFC #40).
+
+The other masking tests assert that allowlisted fields get masked. That is
+the wrong question, and it is why a coverage hole survived a green suite:
+alerts and incidents are not log rows, they carry identifiers under keys a
+log-derived allowlist never mentions, and inside composite strings that key
+matching cannot reach.
+
+The right question is the one here: take a whole record, mask it, then
+search the output for the exact original values. Masked IPs are valid IPs
+and masked hostnames are plausible hostnames, so scanning the output for
+"looks like an IP" proves nothing. Only identity comparison does.
+
+Records below mirror the shape of real FAZ alert, incident and traffic
+objects, with documentation values (RFC 5737 / RFC 2606) throughout.
+"""
+
+from typing import Any
+
+import pytest
+
+from fortianalyzer_mcp.masking.fpe_engine import FPEEngine
+from fortianalyzer_mcp.masking.wrapper import OutputMasker
+
+KEY = "2DE79D232DF5585D68CE47882AE256D6"
+
+# Every identifier that must not survive masking.
+ENDPOINT_NAME = "tablet-a3"
+ENDPOINT_IP = "192.0.2.19"
+GATEWAY_IP = "192.0.2.1"
+BAD_DOMAIN = "suspicious.example.com"
+PEER_IP = "198.51.100.7"
+SRC_NAME = "workstation-14"
+ANALYST = "jdoe"
+# Device identity: masked only when the deployment opts in.
+DEV_NAME = "fgt-branch-01"
+DEV_SERIAL = "fgtserial0001"
+FABRIC = "fabric-alpha"
+
+ALERT: dict[str, Any] = {
+    "alertid": "202607101000000020",
+    "epid": "1107",
+    "epname": ENDPOINT_NAME,
+    "subject": f"DNS request to suspicious destination from {ENDPOINT_NAME} detected",
+    "epip": ENDPOINT_IP,
+    "dstepname": GATEWAY_IP,  # this key holds an address on some records
+    "dstepip": GATEWAY_IP,
+    "devname": DEV_NAME,
+    "devid": DEV_SERIAL,
+    "csf": FABRIC,
+    "groupby1": f"qname:{BAD_DOMAIN}",
+    "groupby2": f"endpoint:{ENDPOINT_NAME}",
+    "extrainfo": f"Domain:{BAD_DOMAIN} traffic path {GATEWAY_IP}:53",
+    "event_details": {"devid": DEV_SERIAL, "dst_ip": GATEWAY_IP, "src_ip": ENDPOINT_IP},
+    "target": [
+        {"name": "domain", "value": BAD_DOMAIN},
+        {"name": "device", "value": ENDPOINT_NAME, "asset_value": ENDPOINT_NAME},
+        {"name": "device", "value": ENDPOINT_NAME, "asset_value": "1107"},
+    ],
+}
+INCIDENT: dict[str, Any] = {
+    "incid": "IN00000001",
+    "endpoint": ENDPOINT_IP,
+    "reporter": ANALYST,
+    "lastuser": ANALYST,
+    "grpby": f'[{{"dstendpoint": "{PEER_IP}"}}]',
+}
+TRAFFIC: dict[str, Any] = {
+    "srcip": ENDPOINT_IP,
+    "dstip": PEER_IP,
+    "srcname": SRC_NAME,
+    "devname": DEV_NAME,
+    "msg": f"session from {SRC_NAME} ({ENDPOINT_IP}) to {PEER_IP}",
+}
+
+PERSONAL = [ENDPOINT_NAME, ENDPOINT_IP, GATEWAY_IP, BAD_DOMAIN, PEER_IP, SRC_NAME, ANALYST]
+DEVICE_IDENTITY = [DEV_NAME, DEV_SERIAL, FABRIC]
+
+
+def survivors(masked: Any, secrets: list[str]) -> dict[str, list[str]]:
+    """Original values that still appear anywhere in the masked structure."""
+    hits: dict[str, list[str]] = {}
+
+    def walk(node: Any, path: str) -> None:
+        if isinstance(node, dict):
+            for k, v in node.items():
+                walk(v, f"{path}.{k}")
+        elif isinstance(node, list):
+            for i, v in enumerate(node):
+                walk(v, f"{path}[{i}]")
+        elif isinstance(node, str):
+            for s in secrets:
+                if s in node:
+                    hits.setdefault(s, []).append(path)
+
+    walk(masked, "")
+    return hits
+
+
+@pytest.fixture
+def masker(monkeypatch: pytest.MonkeyPatch) -> OutputMasker:
+    monkeypatch.setenv("FAZ_MASKING_KEY", KEY)
+    return OutputMasker(FPEEngine(KEY))
+
+
+@pytest.fixture
+def full_masker(monkeypatch: pytest.MonkeyPatch) -> OutputMasker:
+    monkeypatch.setenv("FAZ_MASKING_KEY", KEY)
+    return OutputMasker(FPEEngine(KEY), mask_device_identity=True)
+
+
+class TestNoIdentifierSurvives:
+    @pytest.mark.parametrize(
+        "record", [ALERT, INCIDENT, TRAFFIC], ids=["alert", "incident", "traffic"]
+    )
+    def test_no_personal_identifier_survives(self, masker: OutputMasker, record: dict[str, Any]):
+        leaked = survivors(masker.mask_result(record), PERSONAL)
+        assert leaked == {}, f"masking leaked: {leaked}"
+
+    @pytest.mark.parametrize(
+        "record", [ALERT, INCIDENT, TRAFFIC], ids=["alert", "incident", "traffic"]
+    )
+    def test_device_identity_survives_by_default(
+        self, masker: OutputMasker, record: dict[str, Any]
+    ):
+        """Documented, deliberate: estate identity stays readable unless opted in."""
+        present = [d for d in DEVICE_IDENTITY if d in str(record)]
+        leaked = survivors(masker.mask_result(record), DEVICE_IDENTITY)
+        assert sorted(leaked) == sorted(present)
+
+    @pytest.mark.parametrize(
+        "record", [ALERT, INCIDENT, TRAFFIC], ids=["alert", "incident", "traffic"]
+    )
+    def test_nothing_survives_with_device_identity_masked(
+        self, full_masker: OutputMasker, record: dict[str, Any]
+    ):
+        leaked = survivors(full_masker.mask_result(record), PERSONAL + DEVICE_IDENTITY)
+        assert leaked == {}, f"masking leaked: {leaked}"
+
+
+class TestCompositeKeys:
+    def test_prefixed_groupby_masks_only_the_value_half(self, masker: OutputMasker):
+        masked = masker.mask_result({"groupby1": f"qname:{BAD_DOMAIN}"})
+        assert masked["groupby1"].startswith("qname:")
+        assert BAD_DOMAIN not in masked["groupby1"]
+        assert masked["groupby1"].endswith(".masked.invalid")
+
+    def test_unknown_prefix_left_alone(self, masker: OutputMasker):
+        masked = masker.mask_result({"groupby1": "action:deny"})
+        assert masked["groupby1"] == "action:deny"
+
+    def test_json_blob_is_parsed_and_remasked(self, masker: OutputMasker):
+        masked = masker.mask_result({"grpby": f'[{{"dstendpoint": "{PEER_IP}"}}]'})
+        assert PEER_IP not in masked["grpby"]
+        import json
+
+        assert json.loads(masked["grpby"])[0]["dstendpoint"] != PEER_IP
+
+    def test_malformed_json_blob_still_scrubs_ips(self, masker: OutputMasker):
+        masked = masker.mask_result({"grpby": f"not json at all {PEER_IP}"})
+        assert PEER_IP not in masked["grpby"]
+
+    def test_target_uses_sibling_name_as_type_hint(self, masker: OutputMasker):
+        masked = masker.mask_result({"target": [{"name": "domain", "value": BAD_DOMAIN}]})
+        assert masked["target"][0]["value"].endswith(".masked.invalid")
+
+    def test_target_asset_value_masked_only_when_it_repeats_the_identifier(
+        self, masker: OutputMasker
+    ):
+        masked = masker.mask_result(
+            {
+                "target": [
+                    {"name": "device", "value": ENDPOINT_NAME, "asset_value": ENDPOINT_NAME},
+                    {"name": "device", "value": ENDPOINT_NAME, "asset_value": "1107"},
+                ]
+            }
+        )
+        assert masked["target"][0]["asset_value"] == masked["target"][0]["value"]
+        assert masked["target"][1]["asset_value"] == "1107"  # an internal id, not an identifier
+
+
+class TestFreeTextSubstitution:
+    def test_hostname_masked_in_a_field_is_also_masked_in_prose(self, masker: OutputMasker):
+        masked = masker.mask_result(
+            {"srcname": SRC_NAME, "msg": f"blocked session from {SRC_NAME} at the edge"}
+        )
+        assert SRC_NAME not in masked["msg"]
+        assert masked["srcname"] in masked["msg"]  # same identifier, same token
+
+    def test_domain_from_a_composite_key_is_masked_in_prose(self, masker: OutputMasker):
+        masked = masker.mask_result(
+            {"groupby1": f"qname:{BAD_DOMAIN}", "extrainfo": f"Domain:{BAD_DOMAIN} blocked"}
+        )
+        assert BAD_DOMAIN not in masked["extrainfo"]
+
+    def test_ip_or_host_field_holding_an_address_masks_as_an_ip(self, masker: OutputMasker):
+        import ipaddress
+
+        masked = masker.mask_result({"epname": GATEWAY_IP})
+        ipaddress.ip_address(masked["epname"])  # still a valid address, not a host- token
+
+    def test_ip_or_host_field_holding_a_name_masks_as_a_hostname(self, masker: OutputMasker):
+        masked = masker.mask_result({"epname": ENDPOINT_NAME})
+        assert masked["epname"].startswith("host-")
+
+    def test_short_values_are_not_substituted_into_prose(self, masker: OutputMasker):
+        """A three-character username must not rewrite unrelated words."""
+        masked = masker.mask_result({"user": "wad", "msg": "forwarded by wadware upstream"})
+        assert "wadware" in masked["msg"]
+
+    def test_substitution_respects_token_boundaries(self, masker: OutputMasker):
+        masked = masker.mask_result(
+            {"srcname": SRC_NAME, "msg": f"{SRC_NAME}-backup is a different host"}
+        )
+        # "workstation-14-backup" must not be rewritten as "<token>-backup"
+        assert f"{SRC_NAME}-backup" in masked["msg"]

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -11,8 +11,10 @@ search the output for the exact original values. Masked IPs are valid IPs
 and masked hostnames are plausible hostnames, so scanning the output for
 "looks like an IP" proves nothing. Only identity comparison does.
 
-Records below mirror the shape of real FAZ alert, incident and traffic
-objects, with documentation values (RFC 5737 / RFC 2606) throughout.
+Records below mirror the shape of real FAZ alert, incident, traffic,
+fortiview, ueba and event-handler objects, with documentation values
+(RFC 5737 / RFC 2606) throughout. The shapes were taken from live 7.6.7
+responses; no value from any real estate appears here.
 """
 
 from typing import Any
@@ -32,10 +34,17 @@ BAD_DOMAIN = "suspicious.example.com"
 PEER_IP = "198.51.100.7"
 SRC_NAME = "workstation-14"
 ANALYST = "jdoe"
+SOC_EMAIL = "soc@example.org"
 # Device identity: masked only when the deployment opts in.
 DEV_NAME = "fgt-branch-01"
+DEV_PEER = "fgt-branch-02"
 DEV_SERIAL = "fgtserial0001"
+DETECT_KEY = "fazserial0001"
 FABRIC = "fabric-alpha"
+VDOM = "root"
+# Left clear by design; see the "known gaps" note in fields.py.
+THREAT_DOMAIN = "threat.example.net"
+OBF_URL = "threat[dot]example[dot]net"
 
 ALERT: dict[str, Any] = {
     "alertid": "202607101000000020",
@@ -73,8 +82,73 @@ TRAFFIC: dict[str, Any] = {
     "msg": f"session from {SRC_NAME} ({ENDPOINT_IP}) to {PEER_IP}",
 }
 
-PERSONAL = [ENDPOINT_NAME, ENDPOINT_IP, GATEWAY_IP, BAD_DOMAIN, PEER_IP, SRC_NAME, ANALYST]
-DEVICE_IDENTITY = [DEV_NAME, DEV_SERIAL, FABRIC]
+
+# The wrapper masks every tool's output, but alert/incident/traffic rows are
+# only three of the shapes that flow through it. The five below come from
+# fortiview, ueba and the event-handler config, whose keys no log schema
+# mentions and which the first version of this file never exercised.
+FORTIVIEW_THREAT: dict[str, Any] = {
+    "fortigate": DEV_NAME,
+    "devvds": f"{DEV_NAME}[{VDOM}]",
+    "threat": THREAT_DOMAIN,
+    "obf_url": OBF_URL,
+    "threatlevel": 4,
+}
+FORTIVIEW_COUNTRY: dict[str, Any] = {
+    "fortigate": f"{DEV_NAME},{DEV_PEER}",
+    "devvds": f"{DEV_NAME}[{VDOM}],{DEV_PEER}[{VDOM}]",
+    "dstcountry": "Canada",
+}
+UEBA_ENDUSER: dict[str, Any] = {
+    "euid": "1025",
+    "euname": ENDPOINT_IP,  # live records put an address in this "name" field
+    "socialid": {"data": []},
+    "importance": 0,
+}
+UEBA_ENDPOINT: dict[str, Any] = {
+    "epid": "1025",
+    "epname": ".self",
+    "detectkey": DETECT_KEY,
+}
+HANDLER: dict[str, Any] = {
+    "name": "Default-Botnet-Communication-Detection-By-Endpoint",
+    "description": f"Escalate when {GATEWAY_IP} beacons out; page {SOC_EMAIL}",
+    "template-url": "/fazcfg-template/basic-handler/fgt",
+    "mitre-domain": "enterprise",
+}
+
+RECORDS = [
+    ALERT,
+    INCIDENT,
+    TRAFFIC,
+    FORTIVIEW_THREAT,
+    FORTIVIEW_COUNTRY,
+    UEBA_ENDUSER,
+    UEBA_ENDPOINT,
+    HANDLER,
+]
+RECORD_IDS = [
+    "alert",
+    "incident",
+    "traffic",
+    "fv-threat",
+    "fv-country",
+    "ueba-enduser",
+    "ueba-endpoint",
+    "handler",
+]
+
+PERSONAL = [
+    ENDPOINT_NAME,
+    ENDPOINT_IP,
+    GATEWAY_IP,
+    BAD_DOMAIN,
+    PEER_IP,
+    SRC_NAME,
+    ANALYST,
+    SOC_EMAIL,
+]
+DEVICE_IDENTITY = [DEV_NAME, DEV_PEER, DEV_SERIAL, DETECT_KEY, FABRIC]
 
 
 def survivors(masked: Any, secrets: list[str]) -> dict[str, list[str]]:
@@ -110,16 +184,12 @@ def full_masker(monkeypatch: pytest.MonkeyPatch) -> OutputMasker:
 
 
 class TestNoIdentifierSurvives:
-    @pytest.mark.parametrize(
-        "record", [ALERT, INCIDENT, TRAFFIC], ids=["alert", "incident", "traffic"]
-    )
+    @pytest.mark.parametrize("record", RECORDS, ids=RECORD_IDS)
     def test_no_personal_identifier_survives(self, masker: OutputMasker, record: dict[str, Any]):
         leaked = survivors(masker.mask_result(record), PERSONAL)
         assert leaked == {}, f"masking leaked: {leaked}"
 
-    @pytest.mark.parametrize(
-        "record", [ALERT, INCIDENT, TRAFFIC], ids=["alert", "incident", "traffic"]
-    )
+    @pytest.mark.parametrize("record", RECORDS, ids=RECORD_IDS)
     def test_device_identity_survives_by_default(
         self, masker: OutputMasker, record: dict[str, Any]
     ):
@@ -128,9 +198,7 @@ class TestNoIdentifierSurvives:
         leaked = survivors(masker.mask_result(record), DEVICE_IDENTITY)
         assert sorted(leaked) == sorted(present)
 
-    @pytest.mark.parametrize(
-        "record", [ALERT, INCIDENT, TRAFFIC], ids=["alert", "incident", "traffic"]
-    )
+    @pytest.mark.parametrize("record", RECORDS, ids=RECORD_IDS)
     def test_nothing_survives_with_device_identity_masked(
         self, full_masker: OutputMasker, record: dict[str, Any]
     ):
@@ -214,3 +282,77 @@ class TestFreeTextSubstitution:
         )
         # "workstation-14-backup" must not be rewritten as "<token>-backup"
         assert f"{SRC_NAME}-backup" in masked["msg"]
+
+
+class TestFortiViewDeviceVdom:
+    """``devvds`` is ``"<devname>[<vdom>]"``: brackets break a plain mask."""
+
+    def test_composite_keeps_the_vdom_and_stays_reversible(self, full_masker: OutputMasker):
+        masked = full_masker.mask_result({"devvds": f"{DEV_NAME}[{VDOM}]"})
+        assert DEV_NAME not in masked["devvds"]
+        assert masked["devvds"].endswith(f"[{VDOM}]")
+        # A hostname mask over the whole string fails closed to a placeholder,
+        # which is irreversible and destroys the vdom with it.
+        assert "masked-unrepresentable-" not in masked["devvds"]
+
+    def test_comma_joined_devices_are_masked_element_by_element(self, full_masker: OutputMasker):
+        masked = full_masker.mask_result({"devvds": f"{DEV_NAME}[{VDOM}],{DEV_PEER}[{VDOM}]"})
+        first, second = masked["devvds"].split(",")
+        assert first.startswith("host-") and second.startswith("host-")
+        assert first != second  # distinct devices keep distinct tokens
+        assert first.endswith(f"[{VDOM}]") and second.endswith(f"[{VDOM}]")
+        assert "masked-unrepresentable-" not in masked["devvds"]
+
+    def test_bare_device_name_without_brackets_still_masks(self, full_masker: OutputMasker):
+        masked = full_masker.mask_result({"devvds": DEV_NAME})
+        assert masked["devvds"].startswith("host-")
+
+    def test_untouched_when_device_identity_masking_is_off(self, masker: OutputMasker):
+        record = {"devvds": f"{DEV_NAME}[{VDOM}]"}
+        assert masker.mask_result(record) == record
+
+    def test_the_same_device_gets_the_same_token_in_devvds_and_fortigate(
+        self, full_masker: OutputMasker
+    ):
+        masked = full_masker.mask_result(FORTIVIEW_THREAT)
+        assert masked["devvds"] == f"{masked['fortigate']}[{VDOM}]"
+
+
+class TestDocumentedGaps:
+    """Pins for limits we chose not to close. A pin failing means someone
+    changed the behavior, and the reasoning in fields.py needs revisiting."""
+
+    def test_threat_and_obf_url_are_left_clear(self, full_masker: OutputMasker):
+        """A browsed domain leaks here. ``threat`` also holds signature names
+        like ``Adobe.Flash.Exploit`` on ips rows, which no shape test can tell
+        from a domain, and the reference estate produced no such row."""
+        masked = full_masker.mask_result(FORTIVIEW_THREAT)
+        assert masked["threat"] == THREAT_DOMAIN
+        assert masked["obf_url"] == OBF_URL
+
+    def test_bare_username_in_prose_is_not_masked(self, masker: OutputMasker):
+        """Free text is only as good as the response it sits in: a username
+        that is masked nowhere else in the same response has no raw-to-token
+        entry to substitute, and no regex can recognize one safely."""
+        masked = masker.mask_result({"description": "escalate to jrivera"})
+        assert "jrivera" in masked["description"]
+
+    def test_handler_metadata_is_not_masked(self, full_masker: OutputMasker):
+        masked = full_masker.mask_result(HANDLER)
+        assert masked["name"] == HANDLER["name"]
+        assert masked["template-url"] == HANDLER["template-url"]
+        assert masked["mitre-domain"] == "enterprise"  # ATT&CK domain, not a DNS name
+
+    def test_socialid_container_is_walked_not_typed(self, masker: OutputMasker):
+        """Empty on every reference record; shape unknown, so it is only
+        descended into. Whatever allowlisted keys it turns out to hold get
+        masked by the ordinary recursive walk."""
+        masked = masker.mask_result({"socialid": {"data": [{"srcip": ENDPOINT_IP}]}})
+        assert masked["socialid"]["data"][0]["srcip"] != ENDPOINT_IP
+
+
+class TestHandlerDescription:
+    def test_embedded_ip_and_email_are_masked_in_the_description(self, masker: OutputMasker):
+        masked = masker.mask_result(HANDLER)
+        assert GATEWAY_IP not in masked["description"]
+        assert SOC_EMAIL not in masked["description"]

--- a/tests/test_masking_wrapper.py
+++ b/tests/test_masking_wrapper.py
@@ -1,0 +1,198 @@
+"""Tests for the Phase 1 output-masking wrapper (RFC #40).
+
+Covers the recursive field walk, per-type dispatch, the from/to email
+duality, list-valued fields, free-text IOC scanning, response echo keys,
+fail-closed placeholders, and the mcp.tool registration patch.
+"""
+
+import ipaddress
+import re
+
+import pytest
+
+from fortianalyzer_mcp.masking.fields import FIELD_TYPES
+from fortianalyzer_mcp.masking.fpe_engine import FPEEngine
+from fortianalyzer_mcp.masking.wrapper import OutputMasker, install_masking
+
+KEY = "2DE79D232DF5585D68CE47882AE256D6"
+
+
+@pytest.fixture
+def masker(monkeypatch: pytest.MonkeyPatch) -> OutputMasker:
+    monkeypatch.setenv("FAZ_MASKING_KEY", KEY)
+    return OutputMasker(FPEEngine(KEY))
+
+
+@pytest.fixture
+def engine() -> FPEEngine:
+    return FPEEngine(KEY)
+
+
+class TestFieldTable:
+    def test_rfc_dead_names_absent(self):
+        # Names the RFC drafted that do not exist in any FAZ schema must
+        # not be in the table (masking them would be a silent no-op that
+        # feigns coverage).
+        for dead in (
+            "src",
+            "srcaddr",
+            "dst",
+            "dstaddr",
+            "srchost",
+            "dsthost",
+            "srcuser",
+            "remotename",
+            "email",
+            "message",
+            "domain",
+        ):
+            assert dead not in FIELD_TYPES
+
+    def test_core_fields_present(self):
+        for name in (
+            "srcip",
+            "dstip",
+            "srcmac",
+            "user",
+            "dstuser",
+            "srcname",
+            "qname",
+            "sender",
+            "msg",
+            "filter",
+            "ipv6",
+            "bssid",
+            "prompt",
+        ):
+            assert name in FIELD_TYPES
+
+
+class TestStructureWalk:
+    def test_masks_allowlisted_fields_at_any_depth(self, masker: OutputMasker, engine: FPEEngine):
+        result = {
+            "status": "success",
+            "logs": [
+                {"srcip": "192.0.2.102", "user": "jdoe", "action": "deny", "bytes": 42},
+                {"srcip": "192.0.2.103", "srcmac": "00:1a:2b:3c:4d:5e"},
+            ],
+            "nested": {"event_details": {"src_ip": "192.0.2.7", "host_name": "edge-fw-01"}},
+        }
+        masked = masker.mask_result(result)
+        assert masked["status"] == "success"
+        assert masked["logs"][0]["action"] == "deny"
+        assert masked["logs"][0]["bytes"] == 42
+        assert masked["logs"][0]["srcip"] != "192.0.2.102"
+        ipaddress.IPv4Address(masked["logs"][0]["srcip"])
+        assert engine.unmask_ip(masked["logs"][0]["srcip"]) == "192.0.2.102"
+        assert masked["logs"][0]["user"].startswith("user-")
+        assert masked["logs"][1]["srcmac"] != "00:1a:2b:3c:4d:5e"
+        assert masked["nested"]["event_details"]["src_ip"] != "192.0.2.7"
+        assert masked["nested"]["event_details"]["host_name"].startswith("host-")
+
+    def test_list_valued_ip_field(self, masker: OutputMasker):
+        masked = masker.mask_result({"ipaddr": ["192.0.2.1", "192.0.2.2"]})
+        assert len(masked["ipaddr"]) == 2
+        for item in masked["ipaddr"]:
+            assert item not in ("192.0.2.1", "192.0.2.2")
+            ipaddress.IPv4Address(item)
+
+    def test_skip_values_pass_through(self, masker: OutputMasker):
+        masked = masker.mask_result({"user": "N/A", "srcip": "", "dstuser": "unknown"})
+        assert masked == {"user": "N/A", "srcip": "", "dstuser": "unknown"}
+
+    def test_non_string_scalars_untouched(self, masker: OutputMasker):
+        masked = masker.mask_result({"count": 5, "has_more": False, "tid": None})
+        assert masked == {"count": 5, "has_more": False, "tid": None}
+
+
+class TestEmailDuality:
+    def test_email_value_masks_as_email(self, masker: OutputMasker, engine: FPEEngine):
+        masked = masker.mask_result({"from": "alice@example.com"})
+        assert masked["from"].endswith(".masked.invalid")
+        assert engine.unmask_email(masked["from"]) == "alice@example.com"
+
+    def test_non_email_value_masks_as_username(self, masker: OutputMasker):
+        # webfilter/event logs use from/to as plain labels, not addresses
+        masked = masker.mask_result({"from": "wad"})
+        assert masked["from"].startswith("user-")
+
+
+class TestTextScan:
+    def test_embedded_ip_and_email_masked(self, masker: OutputMasker):
+        text = "blocked 192.0.2.102 for alice@example.com (rule 7)"
+        out = masker.mask_text(text)
+        assert "192.0.2.102" not in out
+        assert "alice@example.com" not in out
+        assert "(rule 7)" in out
+
+    def test_invalid_ipv4_lookalike_untouched(self, masker: OutputMasker):
+        assert masker.mask_text("version 999.1.2.3 ok") == "version 999.1.2.3 ok"
+
+    def test_embedded_mac_masked(self, masker: OutputMasker):
+        out = masker.mask_text("client ae:42:a1:52:45:d6 associated")
+        assert "ae:42:a1:52:45:d6" not in out
+        assert re.search(r"([0-9a-f]{2}:){5}[0-9a-f]{2}", out)
+
+    def test_echo_keys_scanned(self, masker: OutputMasker):
+        masked = masker.mask_result({"filter": 'srcip=="192.0.2.102"', "device": "FGT-BRANCH-01"})
+        assert "192.0.2.102" not in masked["filter"]
+        assert masked["device"].startswith("host-")
+
+    def test_echo_remask_matches_field_token(self, masker: OutputMasker, engine: FPEEngine):
+        # Deterministic FPE: the IP inside an echoed filter string masks to
+        # the same token as the srcip field, so follow-up turns correlate.
+        masked = masker.mask_result(
+            {"filter": 'srcip=="192.0.2.102"', "logs": [{"srcip": "192.0.2.102"}]}
+        )
+        assert masked["logs"][0]["srcip"] in masked["filter"]
+
+
+class TestFailClosed:
+    def test_unmaskable_value_becomes_placeholder(self, masker: OutputMasker):
+        masked = masker.mask_result({"user": "DOMAIN\\user with spaces"})
+        assert masked["user"].startswith("masked-unrepresentable-")
+
+    def test_placeholder_is_deterministic_and_distinct(self, masker: OutputMasker):
+        a1 = masker.placeholder("DOMAIN\\alice")
+        a2 = masker.placeholder("DOMAIN\\alice")
+        b = masker.placeholder("DOMAIN\\bob")
+        assert a1 == a2 != b
+
+    def test_result_level_failure_withholds_raw(self, masker: OutputMasker, monkeypatch):
+        def boom(obj):
+            raise RuntimeError("engine exploded")
+
+        monkeypatch.setattr(masker, "mask_result", boom)
+        out = masker.mask_tool_result({"srcip": "192.0.2.102"}, "get_alerts")
+        assert out["status"] == "error"
+        assert out["error"] == "masking_failed"
+        assert "192.0.2.102" not in str(out)
+
+
+class TestInstallMasking:
+    async def test_tools_registered_after_install_are_wrapped(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        from mcp.server.fastmcp import FastMCP
+
+        monkeypatch.setenv("FAZ_MASKING_KEY", KEY)
+        mcp = FastMCP("test")
+        install_masking(mcp)
+
+        @mcp.tool()
+        async def fake_tool() -> dict:
+            return {"logs": [{"srcip": "192.0.2.102", "user": "jdoe"}], "count": 1}
+
+        result = await fake_tool()
+        assert result["count"] == 1
+        assert result["logs"][0]["srcip"] != "192.0.2.102"
+        assert result["logs"][0]["user"].startswith("user-")
+
+    def test_install_without_key_fails_loud(self, monkeypatch: pytest.MonkeyPatch):
+        from mcp.server.fastmcp import FastMCP
+
+        from fortianalyzer_mcp.masking.fpe_engine import MaskingError
+
+        monkeypatch.delenv("FAZ_MASKING_KEY", raising=False)
+        with pytest.raises(MaskingError, match="FAZ_MASKING_KEY"):
+            install_masking(FastMCP("test"))

--- a/tests/test_masking_wrapper.py
+++ b/tests/test_masking_wrapper.py
@@ -96,6 +96,15 @@ class TestStructureWalk:
             assert item not in ("192.0.2.1", "192.0.2.2")
             ipaddress.IPv4Address(item)
 
+    def test_comma_joined_ip_string(self, masker: OutputMasker, engine: FPEEngine):
+        # Live FAZ packs dns answers into one comma-joined string.
+        masked = masker.mask_result({"ipaddr": "192.0.2.1,192.0.2.2,2001:db8::1"})
+        parts = masked["ipaddr"].split(",")
+        assert len(parts) == 3
+        assert "192.0.2.1" not in parts and "2001:db8::1" not in parts
+        assert engine.unmask_ip(parts[0]) == "192.0.2.1"
+        assert engine.unmask_ip(parts[2]) == "2001:db8::1"
+
     def test_skip_values_pass_through(self, masker: OutputMasker):
         masked = masker.mask_result({"user": "N/A", "srcip": "", "dstuser": "unknown"})
         assert masked == {"user": "N/A", "srcip": "", "dstuser": "unknown"}


### PR DESCRIPTION
Working prototype of Phase 1 (tool-output masking), built on top of the Phase 0 engine. The PR targets `feat/masking-fpe` so the diff shows only the wrapper work. Treat it as a starting point to adopt, cannibalize or reject; I wanted the open questions from #40 answered with running code rather than prose.

## What is in here

**`masking/fields.py`** is the field allowlist from the live verification on #40, as code: the 11 dead RFC names are absent, the missing sensitive fields are in, the response echo keys (`filter`, `filter_applied`, `device`) are covered, and `ipv6` is included for 8.0.0. It also carries the eventmgmt and incidentmgmt keys that a log-derived allowlist does not know about (see the coverage section below), and an `IP_OR_HOST` type for keys like `epname` and `endpoint` that hold an address on some records and a name on others.

**`masking/wrapper.py`** answers open question 2 with the constraint made explicit: there is no central registration point to wrap, because tool modules self-register with module-level `@mcp.tool()` at import time. So `install_masking(mcp)` patches `mcp.tool` before the tool modules are imported, and every tool registered afterwards is wrapped. A FastMCP middleware would be the cleaner long-term home if we want per-request context; the patch has the advantage of zero new dependencies and covers dynamic-mode registrations too.

Masking runs in two passes, because a value is only safe to strip out of free text once you know what it masks to:

1. **Structured pass.** Allowlisted keys are masked by type at any depth, including the alert `event_details` sub-object and list-valued fields like the dns `ipaddr` answer array. Composite keys are parsed and masked part by part: `groupby1`/`groupby2` are `"<field>:<value>"`, `grpby` is an embedded JSON blob, `target` is a list of `{name, value}` where the sibling `name` is the type hint. Every real value masked here goes into a response-scoped raw-to-token map.
2. **Free-text pass.** `msg`, `logdesc`, `subject`, `extrainfo` and the echoed `filter` strings get a regex scan for IPs, MACs and emails, then every raw value from pass 1 is substituted wherever it appears. That is what removes hostnames and domains from prose: you cannot regex a hostname safely, but you can replace the exact strings you just masked elsewhere in the same response. Substitution is boundary-safe and skips values under 4 characters, so a short username cannot rewrite unrelated words.

**Fail-closed everywhere.** A value the engine cannot mask becomes an irreversible keyed placeholder, deterministic so it still correlates, never the raw value, never logged. If masking a whole result fails, the tool returns a `masking_failed` envelope instead of the raw result. If `MASKING_ENABLED` is set without a valid `FAZ_MASKING_KEY`, the server refuses to start.

**Config:** `MASKING_ENABLED` (default off, zero behavior change unless enabled) and `FAZ_MASK_DEVICE_IDENTITY` (default off, see below).

## The coverage hole this PR started with, and how it was found

The first version of this branch passed 693 tests and still leaked. The tests asked whether allowlisted fields get masked. That is the wrong question. The right one is: mask a whole record, then search the output for the exact original values. Masked IPs are valid IPs and masked hostnames are plausible hostnames, so scanning for "looks like an IP" proves nothing; only identity comparison does.

Run against a verbatim live alert, the masked output still contained the endpoint hostname, the queried domain, and the reporting username. Root cause is mine, from the field verification on #40: I built the allowlist from `get_log_fields`, which describes logview rows. Alerts come from eventmgmt and incidents from incidentmgmt. They are not logs, they use different key names, and they hide identifiers inside composite strings. They are also exactly the objects the skills layer in #44 returns.

`tests/test_masking_leak.py` is the test that should have existed first: it masks realistic alert, incident and traffic records and asserts no original identifier survives anywhere in the output. Ten of its assertions fail on the pre-fix code.

## Device identity is now a decision, not a caveat

`devname`, `devid`, `sn`, `csf` identify the reporting estate rather than people. They used to be excluded with a prose note. They now live behind `FAZ_MASK_DEVICE_IDENTITY`, default off, and the leak test asserts both behaviors: with the flag off the firewall name and serial are still readable in a masked record, with it on nothing survives. Leaving it off keeps the model able to reason about which appliance saw what. It is a real tradeoff and it should be a deployment choice rather than a comment.

## Real-data audit

Engine run over unique field values harvested from live logs, alerts and events on 7.6.7 and 8.0.0:

| Type | Real values | Masked clean | Fail-closed |
|---|---|---|---|
| IP | 195 | 195 | 0 |
| MAC | 85 | 85 | 0 |
| Hostname | 104 | 103 | 1 (a wildcard name containing `*`) |
| Domain (dns qname) | 30 | 30 | 0 |
| Username | 8 | 8 | 0 |

FAZ delivers multi-value IP fields as one comma-joined string (the dns `ipaddr` answer), which the naive per-value path failed closed on for 17 of 195 real IPs; the wrapper splits and masks each element. The free-text scan replaced embedded IOCs in 58 of 328 real `msg`/`logdesc`/`extrainfo`/`subject` values.

## Known limits

- `incident_reporter` is left alone: it is a username on manually created incidents and an alert id on auto-raised ones. Masking it would corrupt the alert id. It needs a type-aware decision.
- A hostname that is a strict prefix of another hostname appearing only in prose (`web-01` inside `web-01-backup`) is not substituted, because rewriting it would corrupt a different identifier.
- `url` and `referralurl` still need a URL-specific token design and are not masked.
- Free text is only as good as the response it sits in: a hostname that appears in `msg` but in no structured field of the same response has nothing to match against.

## Deliberately out of scope

Phase 2 (unmasking tool arguments) is built on a branch stacked on this one; see the comment below. Note for its design: with #44's dispatcher, tokens arrive inside a nested `params` dict and inside filter expressions, so the unmasker needs a deep walk plus substring resolution.

## Verification

- 714 passed on this branch. `ruff check`, `ruff format --check`, `mypy` clean.
- 39 masking tests across `test_masking_wrapper.py` (structure walk, per-type dispatch, list and comma-joined fields, from/to duality, text scan, echo keys, fail-closed determinism, registration patch, missing-key startup failure) and `test_masking_leak.py` (whole-record leak tests, composite keys, free-text substitution, boundary safety).
