### PR TITLE
fix(masking): tolerate uppercased tokens on every unmask path

### DIFF
--- a/src/fortianalyzer_mcp/masking/fpe_engine.py
+++ b/src/fortianalyzer_mcp/masking/fpe_engine.py
@@ -249,7 +249,7 @@ class FPEEngine:
 
     def unmask_email(self, token: str) -> str:
         """Reverse :meth:`mask_email`."""
-        local, _, domain = token.strip().partition("@")
+        local, _, domain = token.strip().lower().partition("@")
         if not local or not domain:
             raise MaskingError(f"not a masked email token: {token!r}")
         return (
@@ -275,11 +275,13 @@ class FPEEngine:
         Raises:
             MaskingError: If a marker matches but the payload does not decrypt.
         """
-        candidate = token.strip()
+        # Tokens are lowercase by construction, so lowercasing the input is
+        # lossless and tolerates a model title-casing a token in prose.
+        candidate = token.strip().lower()
         # Suffix first: it is the strongest marker. A domain-token payload
         # may itself start with "host-"/"user-" by chance, but a prefix
         # token ending in ".<mask_suffix>" is astronomically unlikely.
-        if candidate.lower().endswith("." + self._mask_suffix):
+        if candidate.endswith("." + self._mask_suffix):
             if "@" in candidate:
                 return self.unmask_email(candidate)
             return self.unmask_domain(candidate)
@@ -350,7 +352,9 @@ class FPEEngine:
 
     @staticmethod
     def _strip_prefix(token: str, prefix: str) -> str:
-        candidate = token.strip()
+        # Lowercased for the same reason as _strip_domain_suffix: tokens are
+        # emitted lowercase, so any casing we get back is safe to normalize.
+        candidate = token.strip().lower()
         if not candidate.startswith(prefix):
             raise MaskingError(f"not a {prefix}* token: {token!r}")
         return candidate[len(prefix) :]

--- a/tests/test_fpe_engine.py
+++ b/tests/test_fpe_engine.py
@@ -251,3 +251,16 @@ class TestUnmaskToken:
     def test_marker_with_garbage_payload_raises(self, engine: FPEEngine):
         with pytest.raises(MaskingError):
             engine.unmask_token("host-###")
+
+    def test_unmask_tolerates_uppercased_tokens(self, engine: FPEEngine):
+        # Tokens are lowercase by construction, but a model may title-case one
+        # at the start of a sentence before handing it back as an argument.
+        cases = {
+            engine.mask_hostname("edge-fw-01"): "edge-fw-01",
+            engine.mask_username("jdoe"): "jdoe",
+            engine.mask_domain("example.com"): "example.com",
+            engine.mask_email("alice@example.com"): "alice@example.com",
+        }
+        for token, real in cases.items():
+            assert engine.unmask_token(token.upper()) == real
+            assert engine.unmask_token(token.capitalize()) == real


### PR DESCRIPTION
Small follow-up to my review comment on this PR: the unmask paths reject uppercase inconsistently. `_strip_domain_suffix` lowercases its candidate, but `_strip_prefix` and `unmask_email` do not, so a title-cased token raises MaskingError instead of resolving. That bites as soon as the Phase 2 wrapper meets a model that starts a sentence with "Host-abc12 is the source of the traffic" and hands the token back as an argument.

Tokens are lowercase by construction, so lowercasing the input is lossless. Three one-line changes plus a test covering all four marked token types, uppercased and capitalized.

Suite on this branch: 675 passed, ruff and mypy clean. Take it or fold it into your own commit, whichever is easier.
