### PR TITLE
fix(skills): order timeline by normalized timestamps; warn on full attachment page

### DIFF
--- a/src/fortianalyzer_mcp/skills/handlers.py
+++ b/src/fortianalyzer_mcp/skills/handlers.py
@@ -17,6 +17,7 @@ the server's tool-mode branch has run.
 
 import json
 import logging
+from datetime import datetime
 from typing import Any
 
 from fortianalyzer_mcp.skills.models import (
@@ -131,7 +132,7 @@ def _first_record(payload: Any) -> dict[str, Any] | None:
 
 
 async def _fetch_attached_alerts(
-    adom: str | None, incid: str, limit: int = 200
+    adom: str | None, incid: str, limit: int = 200, warnings: list[str] | None = None
 ) -> tuple[list[dict[str, Any]], str | None]:
     """Alerts attached to an incident, via incident attachments.
 
@@ -144,6 +145,8 @@ async def _fetch_attached_alerts(
     This is a thin read-only ``client.get()`` wrapper as sanctioned by
     RFC #44's constraints; it lives here pending the RFC's open question
     on reader placement. Returns ``(alerts, None)`` or ``([], reason)``.
+    When ``warnings`` is given, a full attachment page appends a truncation
+    warning to it.
     """
     from fortianalyzer_mcp.api.client import API_VERSION
     from fortianalyzer_mcp.server import get_faz_client
@@ -164,8 +167,9 @@ async def _fetch_attached_alerts(
     except Exception as exc:
         return [], f"attachments lookup: {exc}"
 
+    records = _records(res)
     alerts: list[dict[str, Any]] = []
-    for rec in _records(res):
+    for rec in records:
         if rec.get("attachtype") != "alertevent":
             continue
         snapshot: dict[str, Any] = {}
@@ -181,6 +185,13 @@ async def _fetch_attached_alerts(
             snapshot = raw
         snapshot.setdefault("alertid", rec.get("attachsrcid"))
         alerts.append(snapshot)
+    if warnings is not None and len(records) >= limit:
+        # A full page means FAZ may hold more attachments than we asked for;
+        # say so rather than presenting a truncated set as complete.
+        warnings.append(
+            f"incident {incid}: attachment page filled at limit {limit}; "
+            "correlated alerts may be incomplete"
+        )
     return alerts, None
 
 
@@ -229,7 +240,7 @@ async def run_incidents(params: IncidentsParams) -> IncidentsResult:
         # Authoritative source: incident attachments (attachtype=alertevent).
         incid = incident.get("incid")
         if params.include_alerts and incid and attachments_failed is None:
-            attached, err = await _fetch_attached_alerts(params.adom, str(incid))
+            attached, err = await _fetch_attached_alerts(params.adom, str(incid), warnings=warnings)
             if err is not None:
                 attachments_failed = err
             elif attached:
@@ -480,7 +491,7 @@ async def run_triage(params: TriageParams) -> TriageResult:
         subject = _first_record(inc_res.get("data")) or {}
 
         incid = str(subject.get("incid") or params.incident_id)
-        related, attach_err = await _fetch_attached_alerts(params.adom, incid)
+        related, attach_err = await _fetch_attached_alerts(params.adom, incid, warnings=warnings)
         if attach_err is not None or not related:
             if attach_err is not None:
                 warnings.append(
@@ -533,6 +544,32 @@ async def run_triage(params: TriageParams) -> TriageResult:
 # --------------------------------------------------------------------- #
 
 
+def _sort_key(timestamp: int | str) -> tuple[int, float, str]:
+    """Total order over the timestamp shapes FAZ actually returns.
+
+    Live data mixes epoch ints, epoch-digit strings ("1704067300", from the
+    attachment alert snapshots) and FAZ datetime strings ("2026-07-08
+    10:22:41", from an incident's createtime/lastupdate). Comparing those
+    lexicographically puts every epoch string before every datetime string
+    regardless of when the events happened, so both forms are normalized to
+    epoch seconds first. Datetimes are read as FAZ-local wall-clock, which
+    is the same clock the epoch values come from. Anything unparseable sorts
+    last, in stable string order, rather than corrupting the ordering of the
+    entries that are parseable.
+    """
+    if isinstance(timestamp, int):
+        return (0, float(timestamp), "")
+    text = timestamp.strip()
+    if text.isdigit():
+        return (0, float(text), "")
+    for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%dT%H:%M:%S"):
+        try:
+            return (0, datetime.strptime(text, fmt).timestamp(), "")
+        except ValueError:
+            continue
+    return (1, 0.0, text)
+
+
 def _timeline(incident: dict[str, Any], evidence: list[AlertEvidence]) -> list[TimelineEntry]:
     """Chronological entries from whatever timestamp fields are present."""
     entries: list[TimelineEntry] = []
@@ -562,8 +599,7 @@ def _timeline(incident: dict[str, Any], evidence: list[AlertEvidence]) -> list[T
                 f"{item.alert.get('name') or item.alert.get('description') or 'raised'}",
             )
         )
-    # Mixed int/str timestamps sort as strings of their repr to stay total.
-    return sorted(entries, key=lambda e: (isinstance(e.timestamp, str), str(e.timestamp)))
+    return sorted(entries, key=lambda e: _sort_key(e.timestamp))
 
 
 async def run_investigation_report(params: InvestigationReportParams) -> InvestigationReport:
@@ -584,7 +620,7 @@ async def run_investigation_report(params: InvestigationReportParams) -> Investi
     # Related alerts: incident attachments first, linkage keys as fallback.
     evidence: list[AlertEvidence] = []
     incid = str(incident.get("incid") or params.incident_id)
-    linked, attach_err = await _fetch_attached_alerts(params.adom, incid)
+    linked, attach_err = await _fetch_attached_alerts(params.adom, incid, warnings=warnings)
     if attach_err is not None or not linked:
         if attach_err is not None:
             warnings.append(

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -233,6 +233,16 @@ class TestAttachmentCorrelation:
         assert rec.correlated_alerts == [{**self.SNAPSHOT, "alertid": "alert-001"}]
         assert result.warnings == []
 
+    async def test_full_attachment_page_warns_about_truncation(self):
+        page = [alertevent_attachment(f"alert-{i}", self.SNAPSHOT) for i in range(200)]
+        with (
+            t(GET_INCIDENTS, return_value=ok(data=[INCIDENT])),
+            t(GET_ALERTS, return_value=ok(data=[])),
+            attachment_client(page),
+        ):
+            result = await handlers.run_incidents(IncidentsParams())
+        assert any("may be incomplete" in w for w in result.warnings)
+
     async def test_incidents_falls_back_when_attachments_unavailable(self):
         # No get_faz_client patch -> reader reports the client as missing.
         with (
@@ -492,6 +502,46 @@ class TestInvestigationReportSkill:
                 await handlers.run_investigation_report(
                     InvestigationReportParams(incident_id="inc-404")
                 )
+
+    async def test_timeline_orders_mixed_timestamp_formats(self):
+        """Live data mixes epoch-digit strings with FAZ datetime strings.
+
+        A lexicographic sort puts every "17..." epoch string before every
+        "2026-..." datetime string regardless of real order; both forms must
+        normalize to epoch seconds first.
+        """
+        incident = {
+            "incid": "inc-001",
+            "name": "Late incident",
+            "createtime": "2026-07-08 10:22:41",
+        }
+        alerts = [
+            {"alertid": "a-early", "incids": ["inc-001"], "alerttime": "1704067300"},  # 2024
+            {"alertid": "a-late", "incids": ["inc-001"], "alerttime": "1783629554"},  # 2026, after
+        ]
+        with (
+            t(GET_INCIDENT, return_value=ok(data=incident)),
+            t(GET_ALERTS, return_value=ok(data=alerts)),
+            t(GET_ALERT_LOGS, return_value=ok(data=[])),
+        ):
+            result = await handlers.run_investigation_report(
+                InvestigationReportParams(incident_id="inc-001", include_top_threats=False)
+            )
+        # 2024 alert, then the 2026-07-08 incident, then the 2026-07-09 alert.
+        assert [e.source for e in result.timeline] == ["alert", "incident", "alert"]
+
+    async def test_timeline_unparseable_timestamp_sorts_last(self):
+        incident = {"incid": "inc-001", "timestamp": 1704067200}
+        alerts = [{"alertid": "a-1", "incids": ["inc-001"], "alerttime": "not-a-time"}]
+        with (
+            t(GET_INCIDENT, return_value=ok(data=incident)),
+            t(GET_ALERTS, return_value=ok(data=alerts)),
+            t(GET_ALERT_LOGS, return_value=ok(data=[])),
+        ):
+            result = await handlers.run_investigation_report(
+                InvestigationReportParams(incident_id="inc-001", include_top_threats=False)
+            )
+        assert [e.source for e in result.timeline] == ["incident", "alert"]
 
 
 # --------------------------------------------------------------------- #

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -503,12 +503,33 @@ class TestInvestigationReportSkill:
                     InvestigationReportParams(incident_id="inc-404")
                 )
 
-    async def test_timeline_orders_mixed_timestamp_formats(self):
-        """Live data mixes epoch-digit strings with FAZ datetime strings.
+    async def test_timeline_orders_int_and_string_timestamps(self):
+        """The shape this repo's own fixtures produce: int + epoch string.
 
-        A lexicographic sort puts every "17..." epoch string before every
-        "2026-..." datetime string regardless of real order; both forms must
-        normalize to epoch seconds first.
+        The old key sorted on (isinstance(ts, str), str(ts)), which groups
+        every int before every string regardless of when the events happened.
+        An incident with an int ``timestamp`` therefore always preceded an
+        alert whose snapshot carries ``alerttime`` as a string, even when the
+        alert came first.
+        """
+        incident = {"incid": "inc-001", "name": "Later incident", "timestamp": 1704067200}
+        alerts = [{"alertid": "a-early", "incids": ["inc-001"], "alerttime": "1704067100"}]
+        with (
+            t(GET_INCIDENT, return_value=ok(data=incident)),
+            t(GET_ALERTS, return_value=ok(data=alerts)),
+            t(GET_ALERT_LOGS, return_value=ok(data=[])),
+        ):
+            result = await handlers.run_investigation_report(
+                InvestigationReportParams(incident_id="inc-001", include_top_threats=False)
+            )
+        # The alert (1704067100) precedes the incident (1704067200).
+        assert [e.source for e in result.timeline] == ["alert", "incident"]
+
+    async def test_timeline_orders_datetime_strings_defensively(self):
+        """Defensive: a datetime string sorts lexicographically against an
+        epoch string. Not observed on live FAZ (7.6.7 and 8.0.0 return epoch
+        strings for createtime/lastupdate), but the key must not depend on
+        that remaining true.
         """
         incident = {
             "incid": "inc-001",


### PR DESCRIPTION
Two items from my review of #46 that had clean fixes. Both tests fail on the pre-fix code and pass after.

**Timeline ordering.** The sort key `(isinstance(ts, str), str(ts))` is wrong in two ways: it groups every int ahead of every string regardless of time, and it compares heterogeneous string formats lexicographically.

I want to be precise about what this does and does not break, because my first take on #46 overstated it. On live FAZ (7.6.7 and 8.0.0) an incident carries `createtime`/`lastupdate` as epoch-digit strings and an alert snapshot carries `alerttime` the same way, and no incident or alert carries a `timestamp` key at all. Equal-length digit strings sort lexicographically the same as numerically, so **there is no misordering on live data today**, and I have not seen a datetime string come back from either version.

What does break is an int/string mix, and that shape is produced by this repo's own fixtures: incidents and alerts in `test_skills.py` use an int `timestamp`, while attachment snapshots use a string `alerttime`. Any incident with an int timestamp sorts ahead of an earlier alert. `_sort_key` normalizes both string forms and ints to epoch seconds; unparseable values sort last rather than corrupting the order of everything else.

So: a robustness fix on a fragile key, not a live bug fix. Worth having because the timeline is the part of `investigation_report` a human actually reads, and because the key silently depends on FAZ never returning a number.

**Silent attachment truncation.** A full attachment page was cut off without a word, unlike every other cap in the skills layer. `_fetch_attached_alerts` takes an optional warnings list and appends a truncation warning when the page fills; all three call sites pass theirs.

Deliberately not included: the bounded-gather fan-out and the alertid-filter subject lookup. Both are behavior changes I would rather you weigh in on first (the alertid filter is verified working on 7.6.7 and 8.0.0, see my comment on #46).

Suite on this branch: 655 passed, ruff and mypy clean.
