### PR TITLE
test(traffic): use a placeholder device serial in the fixtures

### DIFF
--- a/tests/test_traffic_tools.py
+++ b/tests/test_traffic_tools.py
@@ -504,7 +504,7 @@ class TestPolicyPortAnalysisToolBounded:
 
         result = await traffic_tools.get_policy_port_analysis(
             adom="root",
-            device="FGT70FTK22019321",
+            device="FGT60FTK00000001",
             policy_ids=[2],
             time_range="2024-01-01 00:00:00|2024-01-31 00:00:00",
         )
@@ -547,7 +547,7 @@ class TestPolicyPortAnalysisToolBounded:
 
         result = await traffic_tools.get_policy_port_analysis(
             adom="root",
-            device="FGT70FTK22019321",
+            device="FGT60FTK00000001",
             policy_ids=[29],
             time_range="2024-01-01 00:00:00|2024-01-31 00:00:00",
             action="accept",
@@ -583,7 +583,7 @@ class TestPolicyPortAnalysisToolBounded:
 
         result = await traffic_tools.get_policy_port_analysis(
             adom="root",
-            device="FGT70FTK22019321",
+            device="FGT60FTK00000001",
             policy_ids=[2],
             # Custom range (same 24-hour window) avoids touching the FAZ
             # client for TZ lookup, which isn't initialized in these
@@ -625,7 +625,7 @@ class TestPolicyPortAnalysisToolBounded:
 
         result = await traffic_tools.get_policy_port_analysis(
             adom="root",
-            device="FGT70FTK22019321",
+            device="FGT60FTK00000001",
             policy_ids=[1, 2],
             # Custom range avoids the TZ client lookup in unit tests.
             time_range="2024-01-01 00:00:00|2024-01-02 00:00:00",
@@ -657,7 +657,7 @@ class TestPolicyToolAuditMetadata:
 
         result = await traffic_tools.get_policy_port_analysis(
             adom="root",
-            device="FGT70FTK22019321",
+            device="FGT60FTK00000001",
             policy_ids=[2],
             action="accept",
             time_range="2024-01-01 00:00:00|2024-01-02 00:00:00",
@@ -758,7 +758,7 @@ class TestPolicyTrafficProfileToolBounded:
 
         result = await traffic_tools.get_policy_traffic_profile(
             adom="root",
-            device="FGT70FTK22019321",
+            device="FGT60FTK00000001",
             policy_ids=[2],
             time_range="2024-01-01 00:00:00|2024-01-31 00:00:00",
         )
@@ -810,7 +810,7 @@ class TestPolicyProtocolSummaryToolBounded:
 
         result = await traffic_tools.get_policy_protocol_summary(
             adom="root",
-            device="FGT70FTK22019321",
+            device="FGT60FTK00000001",
             policy_ids=[5],
             time_range="2024-01-01 00:00:00|2024-01-31 00:00:00",
         )
@@ -1153,7 +1153,7 @@ class TestPerSliceTotalSum:
 
         monkeypatch.setattr(traffic_tools, "_query_policy_log_slice", fake_slice)
         result = await traffic_tools._query_policy_logs_bounded(
-            "root", "FGT70FTK22019321", 2, self._window_30d(), None, policy_count=8
+            "root", "FGT60FTK00000001", 2, self._window_30d(), None, policy_count=8
         )
         assert result["slices_scanned"] == 3
         assert result["total_hits"] == 60
@@ -1183,7 +1183,7 @@ class TestPerSliceTotalSum:
 
         monkeypatch.setattr(traffic_tools, "_query_policy_log_slice", fake_slice)
         result = await traffic_tools._query_policy_logs_bounded(
-            "root", "FGT70FTK22019321", 2, self._window_30d(), None, policy_count=8
+            "root", "FGT60FTK00000001", 2, self._window_30d(), None, policy_count=8
         )
         assert result["total_hits"] is None
         assert result["total_hits_is_known"] is False
@@ -1202,7 +1202,7 @@ class TestPerSliceTotalSum:
 
         monkeypatch.setattr(traffic_tools, "_query_policy_log_slice", fake_slice)
         result = await traffic_tools._query_policy_logs_bounded(
-            "root", "FGT70FTK22019321", 2, self._window_30d(), None, policy_count=8
+            "root", "FGT60FTK00000001", 2, self._window_30d(), None, policy_count=8
         )
         assert result["truncated_slices"] == 0
         assert result["total_hits"] == 15
@@ -1218,7 +1218,7 @@ class TestPerSliceTotalSum:
 
         monkeypatch.setattr(traffic_tools, "_query_policy_log_slice", fake_slice)
         result = await traffic_tools._query_policy_logs_bounded(
-            "root", "FGT70FTK22019321", 2, self._window_30d(), None, policy_count=8
+            "root", "FGT60FTK00000001", 2, self._window_30d(), None, policy_count=8
         )
         assert result["all_slices_exact"] is False
 
@@ -1235,7 +1235,7 @@ class TestPerSliceTotalSum:
 
         monkeypatch.setattr(traffic_tools, "_query_policy_log_slice", fake_slice)
         await traffic_tools._query_policy_logs_bounded(
-            "root", "FGT70FTK22019321", 2, self._window_30d(), None, policy_count=8, limit=99999
+            "root", "FGT60FTK00000001", 2, self._window_30d(), None, policy_count=8, limit=99999
         )
         # _clamp_limit caps at LOG_FETCH_LIMIT (1000); the slice never sees 99999.
         assert seen_limits and all(seen == LOG_FETCH_LIMIT for seen in seen_limits)
@@ -1259,7 +1259,7 @@ class TestPerSliceTotalSum:
         monkeypatch.setattr(traffic_tools, "_query_policy_log_slice", fake_slice)
         result = await traffic_tools.get_policy_port_analysis(
             adom="root",
-            device="FGT70FTK22019321",
+            device="FGT60FTK00000001",
             policy_ids=[2],
             time_range="2024-01-01 00:00:00|2024-01-31 00:00:00",
         )
@@ -1318,7 +1318,7 @@ class TestPolicyPathEnsuresConnection:
 
         result = await traffic_tools.get_policy_port_analysis(
             adom="root",
-            device="FGT70FTK22019321",
+            device="FGT60FTK00000001",
             policy_ids=[2],
             # Custom range skips the TZ client lookup; isolates the connection revive.
             time_range="2024-01-01 00:00:00|2024-01-02 00:00:00",


### PR DESCRIPTION
`tests/test_traffic_tools.py` hardcodes the serial number of a real FortiGate, in 14 places. It is a device that was registered on the lab the traffic tests were originally written against. It went in back in April with the bounded policy analysis work and has been carried in every release tag since.

A serial is not a credential and nothing authenticates with it, so this is not urgent. But it names one specific appliance in a real estate, and it is sitting in a public test fixture where it does no work: the value is only ever passed through as an opaque `device` argument and compared against itself. A placeholder does the identical job.

`FGT60FTK00000001` still satisfies `DEVICE_SERIAL_PATTERN` in `utils/validation.py`, and the zero fill matches the style already used for the fake serials in `conftest.py` and the examples in the validation module.

Worth being clear about what this does and does not do. It does not remove the value from git history, and it does not touch the release tags, which still contain it. Rewriting the mainline and re-cutting tags to purge it would be far more disruptive than the exposure warrants. What this does is take it out of the file people actually open when they read the tests, which is where it would realistically be noticed.

617 tests pass before and after. The diff is the fixture value and nothing else.

Noticed while leak-testing the masking work in #51, which is what sent me grepping the tree for real infrastructure identifiers in the first place.
