### PR TITLE
RFC #40 Phase 2 prototype: unmask tool arguments before validators

### DIFF
--- a/src/fortianalyzer_mcp/masking/__init__.py
+++ b/src/fortianalyzer_mcp/masking/__init__.py
@@ -2,10 +2,11 @@
 
 Phase 0: the FPE token engine.
 Phase 1 (prototype): field allowlist + tool-boundary output masking.
-Later phases add tool-argument unmasking and configuration hardening.
+Phase 2 (prototype): tool-argument unmasking before validators.
 """
 
 from fortianalyzer_mcp.masking.fpe_engine import FPEEngine, MaskingError
+from fortianalyzer_mcp.masking.unmask import ArgUnmasker
 from fortianalyzer_mcp.masking.wrapper import OutputMasker, install_masking
 
-__all__ = ["FPEEngine", "MaskingError", "OutputMasker", "install_masking"]
+__all__ = ["ArgUnmasker", "FPEEngine", "MaskingError", "OutputMasker", "install_masking"]

--- a/src/fortianalyzer_mcp/masking/unmask.py
+++ b/src/fortianalyzer_mcp/masking/unmask.py
@@ -28,12 +28,22 @@ sensible, it is passed through unchanged: it is far more likely to be a
 real address the user typed than a corrupted token, and passing a real
 address through is correct behavior.
 
-Known ambiguity, documented rather than papered over: with masking on,
-a user who types a *real* IP into ``srcip`` gets it unmasked as if it
-were a token, producing a different real IP. Deterministic FPE has no way
-to distinguish the two. Deployments that expect operators to paste raw
-IPs should keep masking off, or the prose companion should mask what the
-operator types on the way in.
+Known ambiguities, documented rather than papered over:
+
+- With masking on, a user who types a *real* IP into ``srcip`` gets it
+  unmasked as if it were a token, producing a different real IP.
+  Deterministic FPE has no way to distinguish the two. Deployments that
+  expect operators to paste raw IPs should keep masking off, or the prose
+  companion should mask what the operator types on the way in.
+- Hostname case is lost at *mask* time, because the hostname alphabet is
+  lowercase. ``FGT-BRANCH-01`` round trips to ``fgt-branch-01``. Harmless
+  for DNS names, which are case insensitive; it matters for device names
+  that are not.
+- A fortiview ``devvds`` value masks to ``"<token>[<vdom>]"``. Fed back as
+  an argument it will not decrypt as a whole, so it passes through and the
+  tool's validator rejects it. That is deliberate: a device argument wants
+  a device name, and silently discarding the vdom half to salvage one
+  would be guessing at what the caller meant.
 """
 
 import logging

--- a/src/fortianalyzer_mcp/masking/unmask.py
+++ b/src/fortianalyzer_mcp/masking/unmask.py
@@ -1,0 +1,162 @@
+"""Tool-argument unmasking (RFC #40 Phase 2 prototype).
+
+When the model sends a token back as a tool argument, the real value must
+be restored *before* input validators and the FAZ API see it: a masked
+token would otherwise be rejected by ``validate_ip_or_cidr`` and friends,
+or would query FAZ for a value that does not exist there.
+
+Three resolution paths, in order of confidence:
+
+1. **Marked tokens, anywhere.** ``host-``/``user-`` prefixes and the
+   ``.<mask_suffix>`` domain/email forms are self-identifying, so they are
+   resolved wherever they appear: a bare string argument, an item in a
+   list, a value nested in a dict, or a substring inside a filter
+   expression.
+2. **Unmarked tokens by argument name.** Masked IPs and MACs look like
+   ordinary IPs and MACs (the "IP wrinkle"), so they can only be resolved
+   where the *name* says what the value is: an argument called ``srcip``
+   or a filter clause ``srcip=="..."``. The name table is the same
+   allowlist used for output masking.
+3. **Everything else passes through untouched.**
+
+Failure policy mirrors the output side but inverts the default: if a
+value carries a marker and does not decrypt, that is an error worth
+surfacing (the caller sent a corrupted or foreign token) and the argument
+is left as-is so the validator downstream rejects it loudly. If an
+unmarked value in an IP/MAC-named field does not decrypt to anything
+sensible, it is passed through unchanged: it is far more likely to be a
+real address the user typed than a corrupted token, and passing a real
+address through is correct behavior.
+
+Known ambiguity, documented rather than papered over: with masking on,
+a user who types a *real* IP into ``srcip`` gets it unmasked as if it
+were a token, producing a different real IP. Deterministic FPE has no way
+to distinguish the two. Deployments that expect operators to paste raw
+IPs should keep masking off, or the prose companion should mask what the
+operator types on the way in.
+"""
+
+import logging
+import re
+from typing import Any
+
+from fortianalyzer_mcp.masking.fields import FIELD_TYPES, IP, IP_OR_HOST, MAC, SKIP_VALUES
+from fortianalyzer_mcp.masking.fpe_engine import FPEEngine, MaskingError
+
+logger = logging.getLogger(__name__)
+
+# field==value / field!=value / field contain value, single or double quoted
+_FILTER_CLAUSE_RE = re.compile(
+    r"(?P<field>[A-Za-z_][A-Za-z0-9_]*)"
+    r"\s*(?P<op>==|!=|<=|>=|=~|<|>|\bcontain\b|\b!contain\b)\s*"
+    r"(?P<quote>[\"']?)(?P<value>[^\"'\s()]+)(?P=quote)"
+)
+
+
+class ArgUnmasker:
+    """Resolve masked tokens in tool arguments back to real values."""
+
+    def __init__(self, engine: FPEEngine) -> None:
+        self._engine = engine
+
+    # -- scalar resolution ------------------------------------------------ #
+
+    def _unmask_marked(self, value: str) -> str | None:
+        """Resolve a self-identifying token, or None if it carries no marker.
+
+        Raises MaskingError only through :meth:`resolve_scalar`, which
+        decides what a bad payload means for the caller.
+        """
+        return self._engine.unmask_token(value)
+
+    def _unmask_by_type(self, vtype: str, value: str) -> str:
+        """Resolve an unmarked IP/MAC token; pass through on failure.
+
+        ``IP_OR_HOST`` fields only reach here when the value carries no
+        ``host-`` marker, so whatever is left must be an address.
+        """
+        try:
+            if vtype in (IP, IP_OR_HOST):
+                return self._engine.unmask_ip(value)
+            if vtype == MAC:
+                return self._engine.unmask_mac(value)
+        except MaskingError:
+            # Very likely a real address the operator typed, not a token.
+            return value
+        return value
+
+    def resolve_scalar(self, value: str, vtype: str | None = None) -> str:
+        """Resolve one argument value. ``vtype`` comes from the field name."""
+        if not value or value.strip() in SKIP_VALUES:
+            return value
+        candidate = value.strip()
+        try:
+            marked = self._unmask_marked(candidate)
+        except MaskingError:
+            # Marker present but payload will not decrypt: leave it alone so
+            # the downstream validator rejects it instead of us guessing.
+            logger.warning("argument carries a masking marker but does not decrypt; passed through")
+            return value
+        if marked is not None:
+            return marked
+        if vtype in (IP, MAC, IP_OR_HOST):
+            return self._unmask_by_type(vtype, candidate)
+        return value
+
+    # -- filter expressions ------------------------------------------------ #
+
+    def unmask_filter(self, expression: str) -> str:
+        """Resolve tokens inside a FAZ filter expression.
+
+        ``srcip=="93.209.148.131" and user=="user-3f2a-k9x2q4"`` becomes the
+        expression over real values. Field names drive IP/MAC resolution;
+        marked tokens resolve regardless of the field they sit in.
+        """
+
+        def clause_sub(match: re.Match[str]) -> str:
+            field = match.group("field")
+            raw = match.group("value")
+            vtype = FIELD_TYPES.get(field.lower())
+            resolved = self.resolve_scalar(raw, vtype)
+            if resolved == raw:
+                return match.group(0)
+            return match.group(0).replace(raw, resolved)
+
+        return _FILTER_CLAUSE_RE.sub(clause_sub, expression)
+
+    # -- recursive argument walk ------------------------------------------- #
+
+    def unmask_args(self, args: dict[str, Any]) -> dict[str, Any]:
+        """Resolve tokens across a tool's keyword arguments, at any depth."""
+        return {key: self._unmask_entry(key, value) for key, value in args.items()}
+
+    def _unmask_entry(self, key: str, value: Any) -> Any:
+        lowered = key.lower()
+        if isinstance(value, str):
+            if lowered in ("filter", "filter_applied"):
+                return self.unmask_filter(value)
+            vtype = FIELD_TYPES.get(lowered)
+            if vtype in (IP, MAC, IP_OR_HOST):
+                # comma-joined multi-values, same convention as the output side
+                if "," in value:
+                    return ",".join(self.resolve_scalar(part, vtype) for part in value.split(","))
+                return self.resolve_scalar(value, vtype)
+            return self.resolve_scalar(value)
+        if isinstance(value, list):
+            return [
+                self._unmask_entry(key, item) if isinstance(item, str) else self._unmask_any(item)
+                for item in value
+            ]
+        if isinstance(value, dict):
+            # e.g. the #44 dispatcher's nested "params" object
+            return self.unmask_args(value)
+        return value
+
+    def _unmask_any(self, value: Any) -> Any:
+        if isinstance(value, dict):
+            return self.unmask_args(value)
+        if isinstance(value, list):
+            return [self._unmask_any(item) for item in value]
+        if isinstance(value, str):
+            return self.resolve_scalar(value)
+        return value

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -36,11 +36,12 @@ Because FPE is deterministic, a re-masked echo of an unmasked argument
 yields exactly the token the caller sent, so follow-up turns stay
 consistent.
 
-Scope (deliberately Phase 1 only): tool OUTPUT masking. Unmasking of
-tool-call arguments (Phase 2) and URL handling are not here. Device
-identity (``devname``, ``devid``, ``sn``, ``csf``, ``fortigate``,
-``devvds``, ``detectkey``) is out of the default allowlist, so a masked
-record still fingerprints the reporting device.
+This module is the OUTPUT side. Argument unmasking (Phase 2) lives in
+``unmask.py`` and is applied by the same registration patch. URL masking
+and IPv6-in-text scanning are not yet handled. Device identity
+(``devname``, ``devid``, ``sn``, ``csf``, ``fortigate``, ``devvds``,
+``detectkey``) is masked only when ``FAZ_MASK_DEVICE_IDENTITY`` is set, so
+by default a masked record still fingerprints the reporting device.
 """
 
 import hashlib
@@ -73,6 +74,7 @@ from fortianalyzer_mcp.masking.fields import (
     USERNAME,
 )
 from fortianalyzer_mcp.masking.fpe_engine import MASKING_KEY_ENV, FPEEngine, MaskingError
+from fortianalyzer_mcp.masking.unmask import ArgUnmasker
 
 logger = logging.getLogger(__name__)
 
@@ -365,8 +367,12 @@ class OutputMasker:
             }
 
 
-def install_masking(mcp: Any) -> OutputMasker:
-    """Patch ``mcp.tool`` so every tool registered afterwards masks its output.
+def install_masking(mcp: Any) -> tuple[OutputMasker, ArgUnmasker]:
+    """Patch ``mcp.tool`` so every tool registered afterwards is masked.
+
+    Wrapped tools unmask their keyword arguments on the way in (Phase 2,
+    before the tool body reaches any validator) and mask their result on
+    the way out (Phase 1).
 
     Must run BEFORE the tool modules are imported (they register at import
     time). Raises MaskingError at startup if ``FAZ_MASKING_KEY`` is absent
@@ -376,6 +382,7 @@ def install_masking(mcp: Any) -> OutputMasker:
 
     engine = FPEEngine.from_env()
     masker = OutputMasker(engine, mask_device_identity=get_settings().FAZ_MASK_DEVICE_IDENTITY)
+    unmasker = ArgUnmasker(engine)
     original_tool = mcp.tool
 
     def patched_tool(*args: Any, **kwargs: Any) -> Any:
@@ -386,18 +393,20 @@ def install_masking(mcp: Any) -> OutputMasker:
 
                 @wraps(fn)
                 async def async_wrapped(*fa: Any, **fk: Any) -> Any:
-                    return masker.mask_tool_result(await fn(*fa, **fk), fn.__name__)
+                    return masker.mask_tool_result(
+                        await fn(*fa, **unmasker.unmask_args(fk)), fn.__name__
+                    )
 
                 return decorator(async_wrapped)
 
             @wraps(fn)
             def sync_wrapped(*fa: Any, **fk: Any) -> Any:
-                return masker.mask_tool_result(fn(*fa, **fk), fn.__name__)
+                return masker.mask_tool_result(fn(*fa, **unmasker.unmask_args(fk)), fn.__name__)
 
             return decorator(sync_wrapped)
 
         return register
 
     mcp.tool = patched_tool
-    logger.info("output masking installed: all tools registered from now on are wrapped")
-    return masker
+    logger.info("masking installed: tools registered from now on unmask args and mask output")
+    return masker, unmasker

--- a/tests/test_masking_unmask.py
+++ b/tests/test_masking_unmask.py
@@ -1,0 +1,161 @@
+"""Tests for Phase 2 tool-argument unmasking (RFC #40)."""
+
+import pytest
+
+from fortianalyzer_mcp.masking.fpe_engine import FPEEngine
+from fortianalyzer_mcp.masking.unmask import ArgUnmasker
+from fortianalyzer_mcp.masking.wrapper import OutputMasker, install_masking
+
+KEY = "2DE79D232DF5585D68CE47882AE256D6"
+
+
+@pytest.fixture
+def engine() -> FPEEngine:
+    return FPEEngine(KEY)
+
+
+@pytest.fixture
+def unmasker(engine: FPEEngine) -> ArgUnmasker:
+    return ArgUnmasker(engine)
+
+
+@pytest.fixture
+def masker(engine: FPEEngine, monkeypatch: pytest.MonkeyPatch) -> OutputMasker:
+    monkeypatch.setenv("FAZ_MASKING_KEY", KEY)
+    return OutputMasker(engine)
+
+
+class TestScalarResolution:
+    def test_marked_tokens_resolve_without_field_context(
+        self, unmasker: ArgUnmasker, engine: FPEEngine
+    ):
+        for real, token in [
+            ("edge-fw-01", engine.mask_hostname("edge-fw-01")),
+            ("jdoe", engine.mask_username("jdoe")),
+            ("example.com", engine.mask_domain("example.com")),
+            ("alice@example.com", engine.mask_email("alice@example.com")),
+        ]:
+            assert unmasker.resolve_scalar(token) == real
+
+    def test_unmarked_ip_resolves_only_with_field_type(
+        self, unmasker: ArgUnmasker, engine: FPEEngine
+    ):
+        token = engine.mask_ip("192.0.2.102")
+        assert unmasker.resolve_scalar(token) == token  # no context: untouched
+        assert unmasker.resolve_scalar(token, "ip") == "192.0.2.102"
+
+    def test_unmarked_mac_resolves_with_field_type(self, unmasker: ArgUnmasker, engine: FPEEngine):
+        token = engine.mask_mac("00:1a:2b:3c:4d:5e")
+        assert unmasker.resolve_scalar(token, "mac") == "00:1a:2b:3c:4d:5e"
+
+    def test_plain_values_pass_through(self, unmasker: ArgUnmasker):
+        assert unmasker.resolve_scalar("traffic") == "traffic"
+        assert unmasker.resolve_scalar("24-hour") == "24-hour"
+        assert unmasker.resolve_scalar("") == ""
+
+    def test_corrupt_marked_token_passes_through_for_validator(self, unmasker: ArgUnmasker):
+        # Marker present, payload undecryptable: leave it so the downstream
+        # validator rejects it loudly instead of us guessing a real value.
+        assert unmasker.resolve_scalar("host-###") == "host-###"
+
+
+class TestFilterExpressions:
+    def test_ip_clause_resolved_by_field_name(self, unmasker: ArgUnmasker, engine: FPEEngine):
+        token = engine.mask_ip("192.0.2.102")
+        out = unmasker.unmask_filter(f'srcip=="{token}"')
+        assert out == 'srcip=="192.0.2.102"'
+
+    def test_marked_token_resolved_in_any_clause(self, unmasker: ArgUnmasker, engine: FPEEngine):
+        token = engine.mask_username("jdoe")
+        assert unmasker.unmask_filter(f'user=="{token}"') == 'user=="jdoe"'
+
+    def test_multi_clause_expression(self, unmasker: ArgUnmasker, engine: FPEEngine):
+        ip = engine.mask_ip("192.0.2.102")
+        user = engine.mask_username("jdoe")
+        out = unmasker.unmask_filter(f'srcip=="{ip}" and user=="{user}" and action=="deny"')
+        assert out == 'srcip=="192.0.2.102" and user=="jdoe" and action=="deny"'
+
+    def test_unquoted_and_operators_preserved(self, unmasker: ArgUnmasker, engine: FPEEngine):
+        ip = engine.mask_ip("192.0.2.102")
+        assert unmasker.unmask_filter(f"srcip=={ip}") == "srcip==192.0.2.102"
+        assert unmasker.unmask_filter("dstport>=443") == "dstport>=443"
+
+    def test_non_ioc_clauses_untouched(self, unmasker: ArgUnmasker):
+        expr = 'action=="deny" and dstport==443'
+        assert unmasker.unmask_filter(expr) == expr
+
+
+class TestArgumentWalk:
+    def test_flat_args(self, unmasker: ArgUnmasker, engine: FPEEngine):
+        args = {
+            "srcip": engine.mask_ip("192.0.2.102"),
+            "logtype": "traffic",
+            "limit": 100,
+        }
+        out = unmasker.unmask_args(args)
+        assert out == {"srcip": "192.0.2.102", "logtype": "traffic", "limit": 100}
+
+    def test_filter_argument(self, unmasker: ArgUnmasker, engine: FPEEngine):
+        token = engine.mask_ip("192.0.2.102")
+        out = unmasker.unmask_args({"filter": f'srcip=="{token}"'})
+        assert out["filter"] == 'srcip=="192.0.2.102"'
+
+    def test_nested_dispatcher_params(self, unmasker: ArgUnmasker, engine: FPEEngine):
+        # RFC #44's faz_skill(skill, params) nests everything one level down.
+        ip = engine.mask_ip("192.0.2.102")
+        args = {
+            "skill": "log_search",
+            "params": {"logtype": "traffic", "filter": f'srcip=="{ip}"', "limit": 10},
+        }
+        out = unmasker.unmask_args(args)
+        assert out["params"]["filter"] == 'srcip=="192.0.2.102"'
+        assert out["skill"] == "log_search"
+        assert out["params"]["limit"] == 10
+
+    def test_list_of_marked_tokens(self, unmasker: ArgUnmasker, engine: FPEEngine):
+        tokens = [engine.mask_hostname("edge-fw-01"), engine.mask_hostname("core-sw-02")]
+        out = unmasker.unmask_args({"devices": tokens})
+        assert out["devices"] == ["edge-fw-01", "core-sw-02"]
+
+    def test_comma_joined_ip_argument(self, unmasker: ArgUnmasker, engine: FPEEngine):
+        joined = ",".join(engine.mask_ip(ip) for ip in ("192.0.2.1", "192.0.2.2"))
+        out = unmasker.unmask_args({"ipaddr": joined})
+        assert out["ipaddr"] == "192.0.2.1,192.0.2.2"
+
+    def test_non_string_values_untouched(self, unmasker: ArgUnmasker):
+        args = {"limit": 50, "include_alerts": True, "adom": None}
+        assert unmasker.unmask_args(args) == args
+
+
+class TestRoundTrip:
+    def test_masked_output_token_resolves_as_argument(
+        self, masker: OutputMasker, unmasker: ArgUnmasker
+    ):
+        # The exact loop the RFC needs: mask an IP into a result, feed the
+        # token back as a tool argument, get the real IP at the API boundary.
+        masked = masker.mask_result({"logs": [{"srcip": "192.0.2.102", "user": "jdoe"}]})
+        token_ip = masked["logs"][0]["srcip"]
+        token_user = masked["logs"][0]["user"]
+        args = unmasker.unmask_args({"srcip": token_ip, "filter": f'user=="{token_user}"'})
+        assert args["srcip"] == "192.0.2.102"
+        assert args["filter"] == 'user=="jdoe"'
+
+    async def test_wrapped_tool_unmasks_args_and_masks_output(
+        self, monkeypatch: pytest.MonkeyPatch, engine: FPEEngine
+    ):
+        from mcp.server.fastmcp import FastMCP
+
+        monkeypatch.setenv("FAZ_MASKING_KEY", KEY)
+        mcp = FastMCP("test")
+        install_masking(mcp)
+        seen: dict[str, str] = {}
+
+        @mcp.tool()
+        async def fake_search(srcip: str) -> dict:
+            seen["srcip"] = srcip  # what the tool body (and validators) observe
+            return {"logs": [{"srcip": srcip}]}
+
+        token = engine.mask_ip("192.0.2.102")
+        result = await fake_search(srcip=token)
+        assert seen["srcip"] == "192.0.2.102"  # unmasked before the body ran
+        assert result["logs"][0]["srcip"] == token  # re-masked on the way out

--- a/tests/test_masking_unmask.py
+++ b/tests/test_masking_unmask.py
@@ -159,3 +159,78 @@ class TestRoundTrip:
         result = await fake_search(srcip=token)
         assert seen["srcip"] == "192.0.2.102"  # unmasked before the body ran
         assert result["logs"][0]["srcip"] == token  # re-masked on the way out
+
+
+@pytest.fixture
+def full_masker(engine: FPEEngine, monkeypatch: pytest.MonkeyPatch) -> OutputMasker:
+    monkeypatch.setenv("FAZ_MASKING_KEY", KEY)
+    return OutputMasker(engine, mask_device_identity=True)
+
+
+# (field, real value) for every masking type the wrapper can emit, including
+# the shapes live FAZ actually returns: epname holds an address on some
+# records and a name on others, and euname holds an address on ueba rows.
+ROUND_TRIP_FIELDS = [
+    ("srcip", "192.0.2.19"),
+    ("srcmac", "00:1a:2b:3c:4d:5e"),
+    ("srcname", "workstation-14"),
+    ("user", "jdoe"),
+    ("qname", "suspicious.example.com"),
+    ("sender", "soc@example.org"),
+    ("epname", "192.0.2.19"),
+    ("epname", "tablet-a3"),
+    ("euname", "192.0.2.19"),
+    ("device", "fgt-branch-01"),
+    ("endpoint", "192.0.2.19"),
+    ("reporter", "jdoe"),
+]
+
+
+class TestRoundTripEveryType:
+    """Masking is only useful if the token survives the trip back.
+
+    The output tests prove a value leaves masked. These prove the model can
+    hand that token to a tool and the API sees the real value again. A type
+    that masks but does not unmask is worse than one that does neither: the
+    model gets a token it can never use.
+    """
+
+    @pytest.mark.parametrize(
+        "field,raw", ROUND_TRIP_FIELDS, ids=[f"{f}-{r}" for f, r in ROUND_TRIP_FIELDS]
+    )
+    def test_token_from_output_resolves_as_an_argument(
+        self, masker: OutputMasker, unmasker: ArgUnmasker, field: str, raw: str
+    ):
+        token = masker.mask_result({field: raw})[field]
+        assert token != raw, f"{field} was never masked, so this proves nothing"
+        assert unmasker.unmask_args({field: token})[field] == raw
+
+    def test_device_identity_token_resolves_under_any_argument_name(
+        self, full_masker: OutputMasker, unmasker: ArgUnmasker
+    ):
+        """``fortigate`` is not an argument name the unmasker knows, but a
+        hostname token carries its own ``host-`` marker, so it resolves
+        wherever the model puts it."""
+        token = full_masker.mask_result({"fortigate": "fgt-branch-01"})["fortigate"]
+        assert unmasker.unmask_args({"device": token})["device"] == "fgt-branch-01"
+        assert unmasker.unmask_args({"fortigate": token})["fortigate"] == "fgt-branch-01"
+
+
+class TestRoundTripDocumentedLimits:
+    def test_devvds_token_does_not_resolve_as_an_argument(
+        self, full_masker: OutputMasker, unmasker: ArgUnmasker
+    ):
+        """``"<token>[<vdom>]"`` is a fortiview display string, not a device
+        argument. It carries a marker but will not decrypt as a whole, so it
+        passes through untouched and the tool's validator rejects it. Failing
+        closed here beats guessing that the caller meant the device half."""
+        token = full_masker.mask_result({"devvds": "fgt-branch-01[root]"})["devvds"]
+        assert token.startswith("host-") and token.endswith("[root]")
+        assert unmasker.unmask_args({"device": token})["device"] == token
+
+    def test_hostname_case_is_not_preserved(self, masker: OutputMasker, unmasker: ArgUnmasker):
+        """The hostname alphabet is lowercase, so case is lost at mask time,
+        not at unmask time. Harmless for DNS names, which are case
+        insensitive; worth knowing for device names that are not."""
+        token = masker.mask_result({"srcname": "FGT-BRANCH-01"})["srcname"]
+        assert unmasker.unmask_args({"srcname": token})["srcname"] == "fgt-branch-01"


### PR DESCRIPTION
The Phase 2 half announced on #51, now that the base contains everything it stacked on. Two commits, four files: the unmasker, its wiring into `install_masking`, and the tests.

What it does:

- `masking/unmask.py` resolves masked tokens in tool arguments back to real values before input validators and the FAZ API see them. Marked tokens (`host-`/`user-` prefixes, the domain and email suffix forms) are self-identifying and resolve anywhere they appear: bare arguments, list items, nested dicts, substrings inside filter expressions. Unmarked IP and MAC tokens look like ordinary addresses, so they only resolve where the name says what the value is: an argument called `srcip`, or a filter clause `srcip=="..."`. Everything else passes through untouched.
- Filter expressions are parsed clause by clause, and the argument walk recurses into nested dicts, which covers the `faz_skill(skill, params)` shape from #44 where the token sits one level down inside `params`.
- `install_masking` now unmasks kwargs on the way in and masks the result on the way out, so the whole round trip happens at one boundary. One test masks an IP into a tool result, feeds the token straight back as an argument, and asserts the tool body sees the real IP while the response comes back re-masked.
- Failure policy mirrors the output side. A value carrying a marker that will not decrypt is left alone so the downstream validator rejects it loudly rather than us guessing. An unmarked value in an IP-named field that will not decrypt passes through, because it is far more likely to be a real address someone typed than a corrupted token.
- Documented rather than papered over: with masking on, an operator who types a real IP into `srcip` gets it "unmasked" into a different real IP. Deterministic FPE cannot tell a token from a real value of the same shape. That is the IP wrinkle from the other direction and I think it stays a deployment caveat.

Rebased onto the current branch head, so it sits on top of the key-id token contract from fc6dae0. That change needed no code here: the unmasker delegates all token parsing to the engine, so a rotated-key token now surfaces through the same marker-that-will-not-decrypt path and is left for the validator, with the engine's loud key-id error in the log.

22 tests in `tests/test_masking_unmask.py`, suite is 787 passing on this branch, ruff and mypy clean.

Same note as before on placement: if you would rather this boundary be FastMCP middleware than the patch on `mcp.tool`, the unmasker itself does not change, only where it gets called from.
