### PR TITLE
fix(incidents): create_incident sends required reporter/endpoint/category (closes #54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to FortiAnalyzer MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **`create_incident` works again: the create request now sends the required `reporter` and `endpoint` params.** `ADD /incidentmgmt/adom/{adom}/incident` requires `reporter`, `endpoint` and `category` (per the bundled 7.6.7/8.0.0 specs, which agree; confirmed live on both), but the client sent neither of the first two and the tool exposed no way to provide them, so every create had always failed. The tool now requires `endpoint` and `category` (`category` is passed through unvalidated, since the spec types it as a free string and the valid set is appliance-defined), defaults `reporter` to `"faz-mcp"`, validates `severity` against the incident enum (`high`/`medium`/`low`, narrower than the alert set), and exposes the optional spec params `status` (validated), `epid` and `euid`. `name` is absent from the spec but verified live to persist on the incident record, so it stays exposed as optional. The ADD success response carries `incid` at the top level with no `data` wrapper, asymmetric with `get_incident`; documented in the client so nobody "fixes" one to match the other. Verified live on 7.6.7 and 8.0.0. Closes [#54](https://github.com/rstierli/fortianalyzer-mcp/issues/54).
+- **Incident status values match the spec enum.** `_VALID_INCIDENT_STATUSES` listed `new`/`investigating`/`contained`/`resolved`, values the appliance rejects with `not a valid enum value for 'status'` (verified live on both versions), while blocking the legal ones, so `update_incident` could never move an incident to any real non-closed state. The set is now the spec enum: `draft`/`analysis`/`response`/`closed`/`cancelled`.
+
 ## [2.7.2] - 2026-07-09
 
 Patch release: two request-shape bugs in tools that had never worked against a live FAZ — both found by the skills-layer live validation (#44 / PR #46), spec-verified against the bundled 7.6.7/8.0.0 FNDN specs (which agree), confirmed by Roland against FNDN, and live-verified after the fix (PRs #48, #50).

--- a/src/fortianalyzer_mcp/api/client.py
+++ b/src/fortianalyzer_mcp/api/client.py
@@ -1662,24 +1662,46 @@ class FortiAnalyzerClient:
     async def create_incident(
         self,
         adom: str,
-        name: str,
+        endpoint: str,
+        category: str,
+        reporter: str = "faz-mcp",
         severity: str = "medium",
-        category: str | None = None,
+        status: str | None = None,
         description: str | None = None,
+        epid: int | None = None,
+        euid: int | None = None,
+        name: str | None = None,
     ) -> dict[str, Any]:
         """Create a new incident.
 
         FNDN: ADD /incidentmgmt/adom/{adom}/incident
+
+        ``reporter``, ``endpoint`` and ``category`` are required by the API
+        on 7.6.7 and 8.0.0. ``name`` is absent from the spec but the
+        appliance persists it on the incident record, so it stays exposed.
+
+        The ADD success response carries ``incid`` at the TOP level (no
+        ``data`` wrapper), unlike get_incident where the record arrives
+        under ``data``. Asymmetric on purpose; do not "fix" one to match
+        the other.
         """
         params: dict[str, Any] = {
             "apiver": API_VERSION,
-            "name": name,
+            "reporter": reporter,
+            "endpoint": endpoint,
+            "category": category,
             "severity": severity,
         }
-        if category:
-            params["category"] = category
+        if status:
+            params["status"] = status
         if description:
             params["description"] = description
+        if epid is not None:
+            params["epid"] = epid
+        if euid is not None:
+            params["euid"] = euid
+        if name:
+            params["name"] = name
 
         return await self._raw_request_dict("add", f"/incidentmgmt/adom/{adom}/incident", **params)
 

--- a/src/fortianalyzer_mcp/tools/incident_tools.py
+++ b/src/fortianalyzer_mcp/tools/incident_tools.py
@@ -225,10 +225,10 @@ async def create_incident(
     Args:
         endpoint: What the incident is about - an endpoint name or a
             plain IP address. Required by the FAZ API.
-        category: FAZ incident category value. Required by the FAZ API.
-            The valid set is defined on the appliance (numeric strings
-            like "1"), not by the API spec, so it is passed through
-            unvalidated.
+        category: FAZ incident category value (e.g. "CAT1".."CAT3" on
+            auto-raised incidents; a plain "1" is also accepted). Required
+            by the FAZ API. The valid set is defined on the appliance, not
+            by the API spec, so it is passed through unvalidated.
         severity: Incident severity: "high", "medium" or "low"
             (default: "medium").
         adom: ADOM name (default: from config DEFAULT_ADOM)

--- a/src/fortianalyzer_mcp/tools/incident_tools.py
+++ b/src/fortianalyzer_mcp/tools/incident_tools.py
@@ -19,8 +19,14 @@ from fortianalyzer_mcp.utils.validation import (
     validate_severity,
 )
 
-# FAZ incident workflow states accepted by update_incident.
-_VALID_INCIDENT_STATUSES = {"new", "investigating", "contained", "resolved", "closed"}
+# FAZ incident workflow states, from the incidentmgmt spec enum. Verified
+# live on 7.6.7 and 8.0.0: the appliance rejects anything else with
+# "not a valid enum value for 'status'".
+_VALID_INCIDENT_STATUSES = {"draft", "analysis", "response", "closed", "cancelled"}
+
+# The incident spec's severity enum is narrower than the shared
+# VALID_SEVERITIES set (no "critical", no "info").
+_VALID_INCIDENT_SEVERITIES = {"high", "medium", "low"}
 
 logger = logging.getLogger(__name__)
 
@@ -201,57 +207,94 @@ async def get_incident_count(
 
 @mcp.tool()
 async def create_incident(
-    name: str,
-    severity: str,
+    endpoint: str,
+    category: str,
+    severity: str = "medium",
     adom: str | None = None,
-    category: str | None = None,
+    status: str | None = None,
     description: str | None = None,
+    reporter: str = "faz-mcp",
+    name: str | None = None,
+    epid: int | None = None,
+    euid: int | None = None,
 ) -> dict[str, Any]:
     """Create a new security incident.
 
     Creates a manual incident for SOC tracking and investigation.
 
     Args:
-        name: Incident name/title
-        severity: Incident severity:
-            - "critical": Critical severity
-            - "high": High severity
-            - "medium": Medium severity
-            - "low": Low severity
+        endpoint: What the incident is about - an endpoint name or a
+            plain IP address. Required by the FAZ API.
+        category: FAZ incident category value. Required by the FAZ API.
+            The valid set is defined on the appliance (numeric strings
+            like "1"), not by the API spec, so it is passed through
+            unvalidated.
+        severity: Incident severity: "high", "medium" or "low"
+            (default: "medium").
         adom: ADOM name (default: from config DEFAULT_ADOM)
-        category: Incident category (optional)
+        status: Initial workflow status (optional): "draft", "analysis",
+            "response", "closed" or "cancelled".
         description: Detailed description (optional)
+        reporter: Reporting user recorded on the incident
+            (default: "faz-mcp").
+        name: Incident name/title (optional). Not in the API spec, but
+            the appliance persists it on the incident record.
+        epid: Endpoint ID, for the UEBA tie-in (optional).
+        euid: Enduser ID, for the UEBA tie-in (optional).
 
     Returns:
-        dict with created incident details
+        dict with created incident details. The FAZ response carries the
+        new incident id at the top level of "data" (as "incid").
 
     Example:
         >>> result = await create_incident(
-        ...     name="Suspicious Login Activity",
+        ...     endpoint="192.0.2.10",
+        ...     category="1",
         ...     severity="high",
-        ...     description="Multiple failed login attempts detected"
+        ...     description="Multiple failed login attempts detected",
         ... )
-        >>> print(f"Created incident: {result['data']['id']}")
+        >>> print(f"Created incident: {result['data']['incid']}")
     """
     try:
         adom = validate_adom(adom or get_default_adom())
         severity = validate_severity(severity)
+        if severity not in _VALID_INCIDENT_SEVERITIES:
+            valid = ", ".join(sorted(_VALID_INCIDENT_SEVERITIES))
+            return {
+                "status": "error",
+                "message": f"Validation error: Invalid severity '{severity}' for an "
+                f"incident. Must be one of: {valid}",
+            }
+        if status is not None:
+            status = status.strip().lower()
+            if status not in _VALID_INCIDENT_STATUSES:
+                valid = ", ".join(sorted(_VALID_INCIDENT_STATUSES))
+                return {
+                    "status": "error",
+                    "message": f"Validation error: Invalid status '{status}'. "
+                    f"Must be one of: {valid}",
+                }
         client = _get_client()
 
-        logger.info(f"Creating incident '{name}' in ADOM {adom}")
+        logger.info(f"Creating incident in ADOM {adom}")
 
         result = await client.create_incident(
             adom=adom,
-            name=name,
-            severity=severity,
+            endpoint=endpoint,
             category=category,
+            reporter=reporter,
+            severity=severity,
+            status=status,
             description=description,
+            epid=epid,
+            euid=euid,
+            name=name,
         )
 
         return {
             "status": "success",
             "adom": adom,
-            "name": name,
+            "endpoint": endpoint,
             "severity": severity,
             "data": result,
         }
@@ -278,11 +321,11 @@ async def update_incident(
         incident_id: Incident ID to update
         adom: ADOM name (default: from config DEFAULT_ADOM)
         status: New status (optional):
-            - "new": New incident
-            - "investigating": Under investigation
-            - "contained": Threat contained
-            - "resolved": Incident resolved
+            - "draft": Draft incident
+            - "analysis": Under analysis
+            - "response": In response
             - "closed": Incident closed
+            - "cancelled": Incident cancelled
         severity: New severity (optional)
         assignee: Assign to user (optional)
 
@@ -292,7 +335,7 @@ async def update_incident(
     Example:
         >>> result = await update_incident(
         ...     incident_id="INC-001",
-        ...     status="investigating",
+        ...     status="analysis",
         ...     assignee="analyst1"
         ... )
     """

--- a/tests/test_incident_tools.py
+++ b/tests/test_incident_tools.py
@@ -40,16 +40,21 @@ class TestIncidentHelpers:
         assert range_map["7-day"] == timedelta(days=7)
 
     def test_severity_values(self) -> None:
-        """Test valid severity values."""
-        valid_severities = ["critical", "high", "medium", "low"]
-        for sev in valid_severities:
-            assert sev in valid_severities
+        """The incident spec's severity enum: high/medium/low only."""
+        from fortianalyzer_mcp.tools.incident_tools import _VALID_INCIDENT_SEVERITIES
+
+        assert _VALID_INCIDENT_SEVERITIES == {"high", "medium", "low"}
 
     def test_status_values(self) -> None:
-        """Test valid incident status values."""
-        valid_statuses = ["new", "investigating", "contained", "resolved", "closed"]
-        for status in valid_statuses:
-            assert status in valid_statuses
+        """The incident spec's status enum, verified live on 7.6.7/8.0.0.
+
+        FAZ rejects anything else with "not a valid enum value for
+        'status'" - the old invented set (new/investigating/contained/
+        resolved) never worked against a real appliance.
+        """
+        from fortianalyzer_mcp.tools.incident_tools import _VALID_INCIDENT_STATUSES
+
+        assert _VALID_INCIDENT_STATUSES == {"draft", "analysis", "response", "closed", "cancelled"}
 
 
 class TestIncidentClient:
@@ -187,9 +192,70 @@ class TestIncidentClient:
         with pytest.raises(ConnectionError, match="Not connected"):
             await client.create_incident(
                 adom="root",
-                name="Test Incident",
+                endpoint="192.0.2.10",
+                category="1",
                 severity="high",
             )
+
+    async def test_create_incident_sends_required_params(
+        self, mock_client_with_incidents: FortiAnalyzerClient
+    ) -> None:
+        """Regression for #54: the create payload must carry reporter,
+        endpoint and category - FAZ rejects the request without all three.
+        Optional params stay out of the payload when not given."""
+        from unittest.mock import AsyncMock, patch
+
+        with patch.object(
+            mock_client_with_incidents,
+            "_raw_request",
+            AsyncMock(return_value={"incid": "IN00000042", "revision": "0"}),
+        ) as raw:
+            result = await mock_client_with_incidents.create_incident(
+                adom="root",
+                endpoint="192.0.2.10",
+                category="1",
+            )
+        assert raw.await_args.args[0] == "add"
+        assert raw.await_args.args[1] == "/incidentmgmt/adom/root/incident"
+        sent = raw.await_args.kwargs
+        assert sent["reporter"] == "faz-mcp"
+        assert sent["endpoint"] == "192.0.2.10"
+        assert sent["category"] == "1"
+        assert sent["severity"] == "medium"
+        for absent in ("status", "description", "epid", "euid", "name"):
+            assert absent not in sent
+        # The ADD response carries incid at the TOP level, no data wrapper
+        # (asymmetric with get_incident, which unwraps data). Keep it raw.
+        assert result["incid"] == "IN00000042"
+
+    async def test_create_incident_sends_optional_params_when_given(
+        self, mock_client_with_incidents: FortiAnalyzerClient
+    ) -> None:
+        from unittest.mock import AsyncMock, patch
+
+        with patch.object(
+            mock_client_with_incidents,
+            "_raw_request",
+            AsyncMock(return_value={"incid": "IN00000043"}),
+        ) as raw:
+            await mock_client_with_incidents.create_incident(
+                adom="root",
+                endpoint="host-14",
+                category="2",
+                reporter="analyst1",
+                severity="high",
+                status="draft",
+                description="probe",
+                epid=7,
+                euid=9,
+                name="Suspicious Login Activity",
+            )
+        sent = raw.await_args.kwargs
+        assert sent["reporter"] == "analyst1"
+        assert sent["status"] == "draft"
+        assert sent["epid"] == 7
+        assert sent["euid"] == 9
+        assert sent["name"] == "Suspicious Login Activity"
 
     async def test_update_incident_not_connected(self) -> None:
         """Test update_incident raises when not connected."""
@@ -204,7 +270,7 @@ class TestIncidentClient:
             await client.update_incident(
                 adom="root",
                 incident_id="inc-001",
-                status="investigating",
+                status="analysis",
             )
 
     async def test_get_incident_stats_not_connected(self) -> None:

--- a/tests/test_security_regressions.py
+++ b/tests/test_security_regressions.py
@@ -100,7 +100,25 @@ class TestIncidentInputValidation:
     """create_incident/update_incident must reject invalid severity/status."""
 
     async def test_create_incident_rejects_invalid_severity(self) -> None:
-        result = await incident_tools.create_incident(name="Test", severity="catastrophic")
+        result = await incident_tools.create_incident(
+            endpoint="192.0.2.10", category="1", severity="catastrophic"
+        )
+        assert result["status"] == "error"
+        assert "Validation error" in result["message"]
+
+    async def test_create_incident_rejects_severity_outside_incident_enum(self) -> None:
+        """The incident spec allows high/medium/low only; "critical" is an
+        alert severity, not an incident one."""
+        result = await incident_tools.create_incident(
+            endpoint="192.0.2.10", category="1", severity="critical"
+        )
+        assert result["status"] == "error"
+        assert "Validation error" in result["message"]
+
+    async def test_create_incident_rejects_invalid_status(self) -> None:
+        result = await incident_tools.create_incident(
+            endpoint="192.0.2.10", category="1", status="investigating"
+        )
         assert result["status"] == "error"
         assert "Validation error" in result["message"]
 
@@ -119,13 +137,36 @@ class TestIncidentInputValidation:
     ) -> None:
         class FakeClient:
             async def create_incident(self, **kwargs: Any) -> dict[str, Any]:
-                return {"id": "INC-9"}
+                return {"incid": "IN00000009"}
 
         monkeypatch.setattr(incident_tools, "get_faz_client", lambda: FakeClient())
 
-        result = await incident_tools.create_incident(name="Test", severity="High")
+        result = await incident_tools.create_incident(
+            endpoint="192.0.2.10", category="1", severity="High"
+        )
         assert result["status"] == "success"
         assert result["severity"] == "high"
+
+    async def test_create_incident_normalizes_status_and_forwards_args(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen: dict[str, Any] = {}
+
+        class FakeClient:
+            async def create_incident(self, **kwargs: Any) -> dict[str, Any]:
+                seen.update(kwargs)
+                return {"incid": "IN00000009"}
+
+        monkeypatch.setattr(incident_tools, "get_faz_client", lambda: FakeClient())
+
+        result = await incident_tools.create_incident(
+            endpoint="192.0.2.10", category="1", status="Draft", reporter="analyst1"
+        )
+        assert result["status"] == "success"
+        assert seen["status"] == "draft"
+        assert seen["endpoint"] == "192.0.2.10"
+        assert seen["category"] == "1"
+        assert seen["reporter"] == "analyst1"
 
 
 class TestDvmMutationValidation:


### PR DESCRIPTION
Implements the parameter surface agreed on #54, live-verified on both boxes before opening this.

What changed:

- `endpoint` and `category` are required tool arguments. `category` passes through unvalidated and the docstring says why: the spec types it as a free string, the valid set is appliance-defined.
- `reporter` is optional with default `"faz-mcp"`, so automation callers do not have to invent one.
- `severity` validates against the incident enum (`high`/`medium`/`low`). The shared severity validator also allows `critical` and `info`, which the incident spec does not, so the tool narrows it.
- `status`, `epid` and `euid` are exposed as optional, `status` validated against the spec enum.
- The client documents the response asymmetry where it lives: create returns top-level `incid` with no `data` wrapper, `get_incident` unwraps `data`. The payload test pins the raw shape.

On the `name` question: I ran the live check you asked for. The stored incident record carries a `name` key with exactly the value sent, on 7.6.7 and 8.0.0 both. The spec omits it but the appliance persists it, so it stays on the tool as optional and is only sent when provided.

One finding beyond the create path, fixed here because the create `status` param made it unavoidable: `_VALID_INCIDENT_STATUSES` was `new`/`investigating`/`contained`/`resolved`/`closed`. Live FAZ rejects everything in that set except `closed` with `Invalid params: 'investigating' is not a valid enum value for 'status'` (verified on both versions), and the tool client-side blocked the values FAZ does accept, so `update_incident` could never move an incident into any real working state. The constant is now the spec enum and `update_incident`'s docstring matches. If you would rather have that as its own issue and PR, say so and I will split it out.

Live verification of the fixed tool, both boxes: create with `endpoint`/`category`/`status="draft"` succeeds and returns top-level `incid`, `update_incident` to `analysis` succeeds (it could not before), probe incidents closed afterwards.

622 tests passing, ruff and mypy clean. Closes #54.
