### PR TITLE
docs(masking): chunking equality leaks and IPv6 canonical form (last #45 review notes)

### DIFF
--- a/src/fortianalyzer_mcp/masking/fpe_engine.py
+++ b/src/fortianalyzer_mcp/masking/fpe_engine.py
@@ -54,7 +54,17 @@ string values are padded with ``~`` (never legal in the value types we
 mask) up to the cipher's minimum length; padding is stripped after
 decryption. Values longer than the cipher's maximum length are encrypted
 in chunks, each chunk with a position-varied tweak so identical chunks at
-different positions do not produce identical ciphertext.
+different positions do not produce identical ciphertext. Two equality
+leaks follow from chunking, both one notch beyond the whole-value
+equality deterministic FPE already discloses by design: two long values
+sharing their first block produce the same first ciphertext block
+(shared-prefix equality is visible), and chunk 0 shares its tweak with
+unchunked values, so a short value equal to another value's first block
+correlates with it.
+
+Unmasked IPv6 addresses come back in Python's canonical compressed form
+(``2001:db8::1``), not necessarily the textual form originally masked —
+the same address, differently spelled; not a round-trip bug.
 
 The key is a secret (AES-128/192/256 as hex). It must never be logged;
 this module never includes key material in exceptions.
@@ -210,7 +220,11 @@ class FPEEngine:
         return str(ipaddress.IPv6Address(int(ct, 16)))
 
     def unmask_ip(self, token: str) -> str:
-        """Reverse :meth:`mask_ip`."""
+        """Reverse :meth:`mask_ip`.
+
+        IPv6 comes back in canonical compressed form, which may not be the
+        textual form originally masked (same address, different spelling).
+        """
         addr = self._parse_ip(token)
         if addr.version == 4:
             pt = self._hex_ciphers["ipv4"].decrypt(f"{int(addr):08x}")


### PR DESCRIPTION
Closes out the #45 review list: items 1 through 4 landed via fc6dae0, #51 and #52; of the nits, url/referralurl stays deferred by design on #40, and the two remaining docstring notes are here.

- The chunking paragraph now states both equality disclosures: shared-prefix equality between long values (same first block in, same first ciphertext block out) and the chunk-0 tweak being shared with unchunked values, so a short value equal to a long value's first block correlates. Framed as one notch beyond the whole-value equality deterministic FPE already discloses by design.
- Module docstring and unmask_ip now say that unmasked IPv6 returns in canonical compressed form, not necessarily the original spelling, so nobody files the same-address-different-text case as a round-trip bug.

Doc-only, no behavior change. 851 passing on the branch, ruff and mypy clean. With this our side of the #45 review is fully closed; the flag-on live round on both boxes is running next and I will post results on #45.