### PR TITLE
fix(masking): resolve FAZ_MASKING_KEY from .env consistently with MASKING_ENABLED

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to FortiAnalyzer MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **Masking no longer crashes on startup when `FAZ_MASKING_KEY` is set only in `.env`.** `MASKING_ENABLED` is read through pydantic-settings (which loads `.env`), but the FPE engine read `FAZ_MASKING_KEY` straight from the process environment, which does not — so enabling masking via `.env` alone (exactly as the README documents) turned masking on, failed to find the key, and aborted fail-closed. `install_masking` now bridges the key from settings/`.env` into the environment when it is not already exported (a real environment variable, e.g. a container's, still wins). Regression test added.
+
 ## [2.9.0] - 2026-07-12
 
 Minor release: reversible data masking, RFC #40 Phases 0-2 — beta, behind `MASKING_ENABLED` (default **off**; no behavior change unless enabled; requires `FAZ_MASKING_KEY`). Flag-on live-validated on two estates across FAZ 7.6.7 and 8.0.0.

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -547,8 +547,18 @@ def install_masking(mcp: Any) -> tuple[OutputMasker, ArgUnmasker]:
     """
     from fortianalyzer_mcp.utils.config import get_settings
 
+    settings = get_settings()
+    # The engine and the placeholder key both read FAZ_MASKING_KEY from the
+    # process environment. Settings additionally resolves it from .env (like
+    # MASKING_ENABLED), so bridge that value into the environment here when it
+    # is set there but not already exported — otherwise a deployment that put
+    # both the flag and the key in .env would enable masking, fail to find the
+    # key, and crash fail-closed. A real environment variable still wins.
+    if settings.FAZ_MASKING_KEY and not os.environ.get(MASKING_KEY_ENV):
+        os.environ[MASKING_KEY_ENV] = settings.FAZ_MASKING_KEY
+
     engine = FPEEngine.from_env()
-    masker = OutputMasker(engine, mask_device_identity=get_settings().FAZ_MASK_DEVICE_IDENTITY)
+    masker = OutputMasker(engine, mask_device_identity=settings.FAZ_MASK_DEVICE_IDENTITY)
     unmasker = ArgUnmasker(engine)
     original_tool = mcp.tool
 

--- a/src/fortianalyzer_mcp/utils/config.py
+++ b/src/fortianalyzer_mcp/utils/config.py
@@ -131,6 +131,12 @@ class Settings(BaseSettings):
         description="Mask IOC/PII fields in tool outputs via FPE (requires FAZ_MASKING_KEY). "
         "Off by default; no behavior change unless enabled.",
     )
+    FAZ_MASKING_KEY: str | None = Field(
+        default=None,
+        description="FPE key (32/48/64 hex chars) for masking. Read here so it resolves "
+        "from .env consistently with MASKING_ENABLED; the masking engine otherwise reads "
+        "it from the process environment (e.g. a container's environment block).",
+    )
     FAZ_MASK_DEVICE_IDENTITY: bool = Field(
         default=False,
         description="Also mask device-identity fields (devname, devid, sn, csf). "

--- a/tests/test_masking_wrapper.py
+++ b/tests/test_masking_wrapper.py
@@ -17,6 +17,19 @@ from fortianalyzer_mcp.masking.wrapper import OutputMasker, install_masking
 KEY = "2DE79D232DF5585D68CE47882AE256D6"
 
 
+def _settings_with(**overrides: object) -> object:
+    """A stand-in settings object for install_masking's get_settings() call.
+
+    Defaults device-identity masking off; callers override the fields the
+    test cares about (e.g. FAZ_MASKING_KEY).
+    """
+    from types import SimpleNamespace
+
+    fields = {"FAZ_MASK_DEVICE_IDENTITY": False, "FAZ_MASKING_KEY": None}
+    fields.update(overrides)
+    return SimpleNamespace(**fields)
+
+
 @pytest.fixture
 def masker(monkeypatch: pytest.MonkeyPatch) -> OutputMasker:
     monkeypatch.setenv("FAZ_MASKING_KEY", KEY)
@@ -200,8 +213,35 @@ class TestInstallMasking:
     def test_install_without_key_fails_loud(self, monkeypatch: pytest.MonkeyPatch):
         from mcp.server.fastmcp import FastMCP
 
+        import fortianalyzer_mcp.utils.config as config_mod
         from fortianalyzer_mcp.masking.fpe_engine import MaskingError
 
+        # Neutralize BOTH key sources: the process environment and the
+        # Settings/.env value the fix bridges from (a local .env with a key
+        # would otherwise mask this crash — the very failure the fix prevents).
         monkeypatch.delenv("FAZ_MASKING_KEY", raising=False)
+        monkeypatch.setattr(
+            config_mod, "get_settings", lambda: _settings_with(FAZ_MASKING_KEY=None)
+        )
         with pytest.raises(MaskingError, match="FAZ_MASKING_KEY"):
             install_masking(FastMCP("test"))
+
+    def test_key_resolves_from_settings_when_not_in_environment(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Regression: MASKING_ENABLED reads .env via Settings, but the engine
+        reads FAZ_MASKING_KEY from os.environ. If the key lives only in .env
+        (as the README documents), install_masking must bridge it or the
+        server crashes fail-closed on startup. A real env var still wins."""
+        from mcp.server.fastmcp import FastMCP
+
+        import fortianalyzer_mcp.utils.config as config_mod
+
+        monkeypatch.delenv("FAZ_MASKING_KEY", raising=False)
+        monkeypatch.setattr(config_mod, "get_settings", lambda: _settings_with(FAZ_MASKING_KEY=KEY))
+        masker, _ = install_masking(FastMCP("test"))
+        assert masker is not None
+        # the bridge exported it so the engine and placeholder key both see it
+        import os
+
+        assert os.environ.get("FAZ_MASKING_KEY") == KEY


### PR DESCRIPTION
Closes #61.

`MASKING_ENABLED` reads from `.env` via pydantic-settings, but `FPEEngine.from_env()` and the placeholder key read `FAZ_MASKING_KEY` straight from `os.environ`, which doesn't include `.env`. So enabling masking through `.env` alone — the README's documented path — turned masking on, failed the fail-closed key check, and crashed the server on startup (`-32000` to MCP clients). The deployed container dodged it only because docker-compose passes the key as a real env var.

**Fix:** `FAZ_MASKING_KEY` is now an optional `Settings` field (resolves from `.env` like the flag), and `install_masking` bridges it into the process environment when set there but not already exported. A real environment variable still wins, so container deployments are unchanged.

**Tests:** `test_key_resolves_from_settings_when_not_in_environment` pins the `.env`-only path; the existing fail-loud test is hardened to neutralize both key sources so a local `.env` can't mask the crash it guards. 911 pass, ruff/mypy clean. Verified live: the server that crashed with `-32000` now starts and serves a masked `faz_skill` call.

Affects released 2.9.0 → suggest cutting 2.9.1 after merge.
