### PR TITLE
feat(tools): UEBA + alert-handler reader tools (Wave-2 skills readers, #44)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to FortiAnalyzer MCP Server will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **UEBA + alert-handler reader tools (Wave-2 skills building blocks — [#44](https://github.com/rstierli/fortianalyzer-mcp/issues/44)).** Four additive read-only tools: `get_endpoints` and `get_endpoint_vulnerabilities` (UEBA endpoint/asset profiles + CVEs), `get_endusers` (UEBA identity records; `extended` detail adds email/department/title/phone), and `get_alert_handlers` (basic/correlation detection-rule config). Feature-gated on UEBA being licensed/enabled; API paths identical on 7.6.7 and 8.0.0. These are the readers the Wave-2 skills (`asset_lookup`, `identity_lookup`, `alert_rules`, `risk_assessment`, ...) will compose; useful on their own in the meantime. Live-verified against a real appliance. Brings the base tool count to 81 (82 with the skills dispatcher).
+
 ## [2.9.1] - 2026-07-12
 
 Patch release: fixes a startup crash when masking is configured through `.env` alone.

--- a/src/fortianalyzer_mcp/api/client.py
+++ b/src/fortianalyzer_mcp/api/client.py
@@ -1833,3 +1833,101 @@ class FortiAnalyzerClient:
         return await self._raw_request_dict(
             "get", f"/ioc/adom/{adom}/rescan/history", apiver=API_VERSION
         )
+
+    # =========================================================================
+    # UEBA - Endpoints & End-users (from ueba.json) — Wave 2 skills readers
+    # Read-only. Feature-gated: requires UEBA licensed/enabled on the FAZ.
+    # Endpoints identical on 7.6.7 and 8.0.0 (verified).
+    # =========================================================================
+
+    async def get_endpoints(
+        self,
+        adom: str,
+        epids: list[int] | None = None,
+        detail_level: str = "standard",
+        time_range: dict[str, str] | None = None,
+    ) -> dict[str, Any]:
+        """Get UEBA endpoint (asset) records.
+
+        FNDN: GET /ueba/adom/{adom}/endpoints
+
+        Args:
+            adom: ADOM name
+            epids: Optional endpoint IDs to scope the query
+            detail_level: "simple", "basic" or "standard"
+            time_range: {"start": ..., "end": ...} first-seen window
+        """
+        params: dict[str, Any] = {"apiver": API_VERSION, "detail-level": detail_level}
+        if epids:
+            params["epids"] = epids
+        if time_range:
+            params["time-range"] = time_range
+        return await self._request_dict("get", f"/ueba/adom/{adom}/endpoints", **params)
+
+    async def get_endpoint_vulnerabilities(
+        self,
+        adom: str,
+        epids: list[int] | None = None,
+        detectby: str | None = None,
+    ) -> dict[str, Any]:
+        """Get CVE/vulnerability records for UEBA endpoints.
+
+        FNDN: GET /ueba/adom/{adom}/endpoints/vuln
+
+        Args:
+            adom: ADOM name
+            epids: Optional endpoint IDs to scope the query
+            detectby: Optional detector filter ("FortiClient" or "FortiGate")
+        """
+        params: dict[str, Any] = {"apiver": API_VERSION}
+        if epids:
+            params["epids"] = epids
+        if detectby:
+            params["detectby"] = detectby
+        return await self._request_dict("get", f"/ueba/adom/{adom}/endpoints/vuln", **params)
+
+    async def get_endusers(
+        self,
+        adom: str,
+        euids: list[int] | None = None,
+        detail_level: str = "standard",
+    ) -> dict[str, Any]:
+        """Get UEBA end-user (identity) records.
+
+        FNDN: GET /ueba/adom/{adom}/endusers
+
+        Args:
+            adom: ADOM name
+            euids: Optional end-user IDs to scope the query
+            detail_level: "basic", "standard" or "extended" (extended adds
+                email/department/title/phone)
+        """
+        params: dict[str, Any] = {"apiver": API_VERSION, "detail-level": detail_level}
+        if euids:
+            params["euids"] = euids
+        return await self._request_dict("get", f"/ueba/adom/{adom}/endusers", **params)
+
+    async def get_alert_handlers(
+        self,
+        adom: str,
+        handler_type: str = "both",
+    ) -> dict[str, Any]:
+        """Get event alert-handler (detection-rule) definitions.
+
+        FNDN: GET /eventmgmt/adom/{adom}/config/basic-handler
+              GET /eventmgmt/adom/{adom}/config/correlation-handler
+
+        Args:
+            adom: ADOM name
+            handler_type: "basic", "correlation" or "both"
+        """
+        result: dict[str, Any] = {}
+        if handler_type in ("basic", "both"):
+            result["basic"] = await self._raw_request_dict(
+                "get", f"/eventmgmt/adom/{adom}/config/basic-handler", apiver=API_VERSION
+            )
+        if handler_type in ("correlation", "both"):
+            result["correlation"] = await self._raw_request_dict(
+                "get", f"/eventmgmt/adom/{adom}/config/correlation-handler", apiver=API_VERSION
+            )
+        return result

--- a/src/fortianalyzer_mcp/server.py
+++ b/src/fortianalyzer_mcp/server.py
@@ -234,6 +234,7 @@ def register_dynamic_tools(mcp_server: FastMCP) -> None:
             report_tools,
             system_tools,
             traffic_tools,
+            ueba_tools,
         )
 
         # Map tool names to functions
@@ -278,6 +279,11 @@ def register_dynamic_tools(mcp_server: FastMCP) -> None:
             "get_alert_details": event_tools.get_alert_details,
             "add_alert_comment": event_tools.add_alert_comment,
             "get_alert_incident_stats": event_tools.get_alert_incident_stats,
+            "get_alert_handlers": event_tools.get_alert_handlers,
+            # UEBA tools (Wave-2 skills readers)
+            "get_endpoints": ueba_tools.get_endpoints,
+            "get_endpoint_vulnerabilities": ueba_tools.get_endpoint_vulnerabilities,
+            "get_endusers": ueba_tools.get_endusers,
             # FortiView tools
             "run_fortiview": fortiview_tools.run_fortiview,
             "fetch_fortiview": fortiview_tools.fetch_fortiview,
@@ -417,6 +423,7 @@ else:
         report_tools,
         system_tools,
         traffic_tools,
+        ueba_tools,
     )
 
     if settings.FAZ_SKILLS_ENABLED:

--- a/src/fortianalyzer_mcp/tools/event_tools.py
+++ b/src/fortianalyzer_mcp/tools/event_tools.py
@@ -400,3 +400,51 @@ async def get_alert_incident_stats(
     except Exception as e:
         logger.error(f"Failed to get alert-incident stats: {e}")
         return {"status": "error", "message": redact(str(e))}
+
+
+_VALID_HANDLER_TYPES = {"basic", "correlation", "both"}
+
+
+@mcp.tool()
+async def get_alert_handlers(
+    adom: str | None = None,
+    handler_type: str = "both",
+) -> dict[str, Any]:
+    """Get event alert-handler (detection-rule) definitions.
+
+    Reads the alert-handler configuration: each handler's name, id, and
+    its rules (severity, filter, groupby, tags). This is the catalogue of
+    detection rules the appliance runs — a read-only building block for
+    the Wave-2 ``alert_rules`` skill.
+
+    Args:
+        adom: ADOM name (default: from config DEFAULT_ADOM)
+        handler_type: Which handlers to return: "basic", "correlation" or
+            "both" (default: "both")
+
+    Returns:
+        dict with handler definitions under "data" (keyed by "basic" and/or
+        "correlation")
+
+    Example:
+        >>> result = await get_alert_handlers(handler_type="basic")
+        >>> print(result["data"]["basic"])
+    """
+    try:
+        adom = validate_adom(adom or get_default_adom())
+        if handler_type not in _VALID_HANDLER_TYPES:
+            valid = ", ".join(sorted(_VALID_HANDLER_TYPES))
+            return {
+                "status": "error",
+                "message": f"Validation error: Invalid handler_type '{handler_type}'. "
+                f"Must be one of: {valid}",
+            }
+        client = _get_client()
+
+        logger.info(f"Getting {handler_type} alert handlers from ADOM {adom}")
+
+        result = await client.get_alert_handlers(adom=adom, handler_type=handler_type)
+        return {"status": "success", "adom": adom, "handler_type": handler_type, "data": result}
+    except Exception as e:
+        logger.error(f"Failed to get alert handlers: {e}")
+        return {"status": "error", "message": redact(str(e))}

--- a/src/fortianalyzer_mcp/tools/ueba_tools.py
+++ b/src/fortianalyzer_mcp/tools/ueba_tools.py
@@ -1,0 +1,183 @@
+"""UEBA endpoint and end-user tools for FortiAnalyzer.
+
+Read-only readers over the UEBA (User and Entity Behavior Analytics) API,
+added as building blocks for the Wave-2 skills (asset/identity/risk).
+Feature-gated: these endpoints require UEBA to be licensed and enabled on
+the FortiAnalyzer. The API paths are identical on 7.6.7 and 8.0.0.
+
+Based on the FNDN FortiAnalyzer UEBA (ueba.json) API specifications.
+"""
+
+import logging
+from typing import Any
+
+from fortianalyzer_mcp.api.client import FortiAnalyzerClient
+from fortianalyzer_mcp.server import get_faz_client, mcp
+from fortianalyzer_mcp.utils.responses import redact
+from fortianalyzer_mcp.utils.time_range import parse_time_range
+from fortianalyzer_mcp.utils.validation import get_default_adom, validate_adom
+
+logger = logging.getLogger(__name__)
+
+_VALID_ENDPOINT_DETAIL = {"simple", "basic", "standard"}
+_VALID_ENDUSER_DETAIL = {"basic", "standard", "extended"}
+_VALID_DETECTBY = {"FortiClient", "FortiGate"}
+
+
+def _get_client() -> FortiAnalyzerClient:
+    """Get the FortiAnalyzer client instance."""
+    client = get_faz_client()
+    if not client:
+        raise RuntimeError("FortiAnalyzer client not initialized")
+    return client
+
+
+async def _parse_time_range(time_range: str) -> dict[str, str]:
+    """Parse a time-range string, aligning relative presets to FAZ's TZ."""
+    if "|" in time_range:
+        return parse_time_range(time_range)
+    client = _get_client()
+    faz_tz = await client.get_system_timezone()
+    return parse_time_range(time_range, faz_tz=faz_tz)
+
+
+@mcp.tool()
+async def get_endpoints(
+    adom: str | None = None,
+    epids: list[int] | None = None,
+    detail_level: str = "standard",
+    time_range: str | None = None,
+) -> dict[str, Any]:
+    """Get UEBA endpoint (asset) records from FortiAnalyzer.
+
+    Resolves endpoint/asset profiles: hostname, IP, MAC, OS, first/last
+    seen, department, associated users and vulnerability-stat counts.
+    Requires UEBA to be enabled/licensed on the FortiAnalyzer.
+
+    Args:
+        adom: ADOM name (default: from config DEFAULT_ADOM)
+        epids: Optional list of endpoint IDs to scope the query
+        detail_level: "simple", "basic" or "standard" (default: "standard")
+        time_range: Optional first-seen window, e.g. "7-day" or a custom
+            "start|end" range
+
+    Returns:
+        dict with endpoint records under "data"
+
+    Example:
+        >>> result = await get_endpoints(detail_level="standard")
+        >>> for ep in result["data"]:
+        ...     print(ep.get("epname"), ep.get("epip"))
+    """
+    try:
+        adom = validate_adom(adom or get_default_adom())
+        if detail_level not in _VALID_ENDPOINT_DETAIL:
+            valid = ", ".join(sorted(_VALID_ENDPOINT_DETAIL))
+            return {
+                "status": "error",
+                "message": f"Validation error: Invalid detail_level '{detail_level}'. "
+                f"Must be one of: {valid}",
+            }
+        tr = await _parse_time_range(time_range) if time_range else None
+        client = _get_client()
+
+        logger.info(f"Getting UEBA endpoints from ADOM {adom}")
+
+        result = await client.get_endpoints(
+            adom=adom, epids=epids, detail_level=detail_level, time_range=tr
+        )
+        return {"status": "success", "data": result}
+    except Exception as e:
+        logger.error(f"Failed to get UEBA endpoints: {e}")
+        return {"status": "error", "message": redact(str(e))}
+
+
+@mcp.tool()
+async def get_endpoint_vulnerabilities(
+    adom: str | None = None,
+    epids: list[int] | None = None,
+    detectby: str | None = None,
+) -> dict[str, Any]:
+    """Get CVE/vulnerability records for UEBA endpoints.
+
+    Returns the per-endpoint vulnerability list (CVE id, severity, type,
+    description, references) as detected by FortiClient or FortiGate.
+    Requires UEBA to be enabled/licensed on the FortiAnalyzer.
+
+    Args:
+        adom: ADOM name (default: from config DEFAULT_ADOM)
+        epids: Optional list of endpoint IDs to scope the query
+        detectby: Optional detector filter: "FortiClient" or "FortiGate"
+
+    Returns:
+        dict with vulnerability records under "data"
+
+    Example:
+        >>> result = await get_endpoint_vulnerabilities(epids=[1025])
+        >>> print(len(result["data"]))
+    """
+    try:
+        adom = validate_adom(adom or get_default_adom())
+        if detectby is not None and detectby not in _VALID_DETECTBY:
+            valid = ", ".join(sorted(_VALID_DETECTBY))
+            return {
+                "status": "error",
+                "message": f"Validation error: Invalid detectby '{detectby}'. "
+                f"Must be one of: {valid}",
+            }
+        client = _get_client()
+
+        logger.info(f"Getting UEBA endpoint vulnerabilities from ADOM {adom}")
+
+        result = await client.get_endpoint_vulnerabilities(
+            adom=adom, epids=epids, detectby=detectby
+        )
+        return {"status": "success", "data": result}
+    except Exception as e:
+        logger.error(f"Failed to get UEBA endpoint vulnerabilities: {e}")
+        return {"status": "error", "message": redact(str(e))}
+
+
+@mcp.tool()
+async def get_endusers(
+    adom: str | None = None,
+    euids: list[int] | None = None,
+    detail_level: str = "standard",
+) -> dict[str, Any]:
+    """Get UEBA end-user (identity) records from FortiAnalyzer.
+
+    Resolves user identity records: username, groups, VPN IP, first/last
+    seen. With detail_level "extended", also returns email, department,
+    title and phone. Requires UEBA to be enabled/licensed on the FAZ.
+
+    Args:
+        adom: ADOM name (default: from config DEFAULT_ADOM)
+        euids: Optional list of end-user IDs to scope the query
+        detail_level: "basic", "standard" or "extended" (default: "standard")
+
+    Returns:
+        dict with end-user records under "data"
+
+    Example:
+        >>> result = await get_endusers(detail_level="extended")
+        >>> for user in result["data"]:
+        ...     print(user.get("euname"), user.get("email"))
+    """
+    try:
+        adom = validate_adom(adom or get_default_adom())
+        if detail_level not in _VALID_ENDUSER_DETAIL:
+            valid = ", ".join(sorted(_VALID_ENDUSER_DETAIL))
+            return {
+                "status": "error",
+                "message": f"Validation error: Invalid detail_level '{detail_level}'. "
+                f"Must be one of: {valid}",
+            }
+        client = _get_client()
+
+        logger.info(f"Getting UEBA end-users from ADOM {adom}")
+
+        result = await client.get_endusers(adom=adom, euids=euids, detail_level=detail_level)
+        return {"status": "success", "data": result}
+    except Exception as e:
+        logger.error(f"Failed to get UEBA end-users: {e}")
+        return {"status": "error", "message": redact(str(e))}

--- a/tests/test_event_tools.py
+++ b/tests/test_event_tools.py
@@ -219,3 +219,52 @@ class TestAlertClient:
                 comment="Test comment",
                 user="admin",
             )
+
+
+class TestAlertHandlers:
+    """get_alert_handlers reader tool + client method (Wave-2 alert_rules)."""
+
+    async def test_tool_success_both(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from fortianalyzer_mcp.tools import event_tools
+
+        class _Fake:
+            async def get_alert_handlers(self, **kwargs: object) -> dict[str, object]:
+                self.seen = kwargs
+                return {"basic": [{"name": "H1"}], "correlation": [{"name": "C1"}]}
+
+        fake = _Fake()
+        monkeypatch.setattr(event_tools, "get_faz_client", lambda: fake)
+        result = await event_tools.get_alert_handlers(adom="root")
+        assert result["status"] == "success"
+        assert result["handler_type"] == "both"
+        assert result["data"]["basic"][0]["name"] == "H1"
+        assert fake.seen["handler_type"] == "both"
+
+    async def test_tool_rejects_invalid_type(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from fortianalyzer_mcp.tools import event_tools
+
+        monkeypatch.setattr(event_tools, "get_faz_client", lambda: object())
+        result = await event_tools.get_alert_handlers(handler_type="fancy")
+        assert result["status"] == "error"
+        assert "Validation error" in result["message"]
+
+    async def test_client_method_basic_only(self, mock_client: FortiAnalyzerClient) -> None:
+        from unittest.mock import AsyncMock, patch
+
+        with patch.object(
+            mock_client, "_raw_request", AsyncMock(return_value=[{"name": "H1"}])
+        ) as req:
+            result = await mock_client.get_alert_handlers(adom="root", handler_type="basic")
+        assert "basic" in result and "correlation" not in result
+        assert req.await_args.args[1] == "/eventmgmt/adom/root/config/basic-handler"
+
+    async def test_client_method_both_hits_two_paths(
+        self, mock_client: FortiAnalyzerClient
+    ) -> None:
+        from unittest.mock import AsyncMock, patch
+
+        with patch.object(mock_client, "_raw_request", AsyncMock(return_value=[])) as req:
+            await mock_client.get_alert_handlers(adom="root", handler_type="both")
+        paths = [c.args[1] for c in req.await_args_list]
+        assert "/eventmgmt/adom/root/config/basic-handler" in paths
+        assert "/eventmgmt/adom/root/config/correlation-handler" in paths

--- a/tests/test_ueba_tools.py
+++ b/tests/test_ueba_tools.py
@@ -1,0 +1,158 @@
+"""Tests for the UEBA reader tools (Wave-2 skills building blocks).
+
+Two layers, matching the rest of the suite:
+- tool-level: patch ``get_faz_client`` in ``ueba_tools`` with a fake client
+  and assert the envelope, validation, and parameter forwarding;
+- client-level: use the ``mock_client`` fixture and patch the request layer
+  to assert the endpoint URL and JSON-RPC params.
+"""
+
+from typing import Any
+
+import pytest
+
+from fortianalyzer_mcp.api.client import FortiAnalyzerClient
+from fortianalyzer_mcp.tools import ueba_tools
+
+
+class _FakeClient:
+    """Records the last call and returns a canned payload."""
+
+    def __init__(self, payload: Any) -> None:
+        self.payload = payload
+        self.calls: dict[str, dict[str, Any]] = {}
+
+    async def get_endpoints(self, **kwargs: Any) -> Any:
+        self.calls["get_endpoints"] = kwargs
+        return self.payload
+
+    async def get_endpoint_vulnerabilities(self, **kwargs: Any) -> Any:
+        self.calls["get_endpoint_vulnerabilities"] = kwargs
+        return self.payload
+
+    async def get_endusers(self, **kwargs: Any) -> Any:
+        self.calls["get_endusers"] = kwargs
+        return self.payload
+
+
+def _patch_client(monkeypatch: pytest.MonkeyPatch, payload: Any) -> _FakeClient:
+    fake = _FakeClient(payload)
+    monkeypatch.setattr(ueba_tools, "get_faz_client", lambda: fake)
+    return fake
+
+
+# --------------------------------------------------------------------- #
+# get_endpoints                                                         #
+# --------------------------------------------------------------------- #
+
+
+class TestGetEndpoints:
+    async def test_success_and_param_forwarding(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake = _patch_client(monkeypatch, [{"epname": "host-1", "epip": "10.0.0.5"}])
+        result = await ueba_tools.get_endpoints(adom="root", epids=[7], detail_level="basic")
+        assert result["status"] == "success"
+        assert result["data"][0]["epname"] == "host-1"
+        sent = fake.calls["get_endpoints"]
+        assert sent["adom"] == "root"
+        assert sent["epids"] == [7]
+        assert sent["detail_level"] == "basic"
+
+    async def test_rejects_invalid_detail_level(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_client(monkeypatch, [])
+        result = await ueba_tools.get_endpoints(detail_level="everything")
+        assert result["status"] == "error"
+        assert "Validation error" in result["message"]
+
+    async def test_client_missing_returns_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(ueba_tools, "get_faz_client", lambda: None)
+        result = await ueba_tools.get_endpoints()
+        assert result["status"] == "error"
+
+
+# --------------------------------------------------------------------- #
+# get_endpoint_vulnerabilities                                          #
+# --------------------------------------------------------------------- #
+
+
+class TestGetEndpointVulnerabilities:
+    async def test_success_and_param_forwarding(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake = _patch_client(monkeypatch, [{"vulnid": "CVE-2024-0001"}])
+        result = await ueba_tools.get_endpoint_vulnerabilities(epids=[1025], detectby="FortiClient")
+        assert result["status"] == "success"
+        assert result["data"][0]["vulnid"] == "CVE-2024-0001"
+        sent = fake.calls["get_endpoint_vulnerabilities"]
+        assert sent["epids"] == [1025]
+        assert sent["detectby"] == "FortiClient"
+
+    async def test_rejects_invalid_detectby(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_client(monkeypatch, [])
+        result = await ueba_tools.get_endpoint_vulnerabilities(detectby="FortiGuard")
+        assert result["status"] == "error"
+        assert "Validation error" in result["message"]
+
+    async def test_detectby_optional(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake = _patch_client(monkeypatch, [])
+        result = await ueba_tools.get_endpoint_vulnerabilities()
+        assert result["status"] == "success"
+        assert fake.calls["get_endpoint_vulnerabilities"]["detectby"] is None
+
+
+# --------------------------------------------------------------------- #
+# get_endusers                                                          #
+# --------------------------------------------------------------------- #
+
+
+class TestGetEndusers:
+    async def test_success_extended(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake = _patch_client(monkeypatch, [{"euname": "jdoe", "email": "jdoe@example.com"}])
+        result = await ueba_tools.get_endusers(detail_level="extended")
+        assert result["status"] == "success"
+        assert result["data"][0]["email"] == "jdoe@example.com"
+        assert fake.calls["get_endusers"]["detail_level"] == "extended"
+
+    async def test_rejects_invalid_detail_level(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_client(monkeypatch, [])
+        result = await ueba_tools.get_endusers(
+            detail_level="simple"
+        )  # valid for endpoints, not endusers
+        assert result["status"] == "error"
+        assert "Validation error" in result["message"]
+
+
+# --------------------------------------------------------------------- #
+# client methods (endpoint URL + JSON-RPC params)                       #
+# --------------------------------------------------------------------- #
+
+
+class TestUebaClientMethods:
+    async def test_get_endpoints_request_shape(self, mock_client: FortiAnalyzerClient) -> None:
+        from unittest.mock import AsyncMock, patch
+
+        with patch.object(
+            mock_client, "_generic_request", AsyncMock(return_value=[{"epid": 1}])
+        ) as req:
+            await mock_client.get_endpoints(adom="root", epids=[1], detail_level="standard")
+        assert req.await_args.args[0] == "get"
+        assert req.await_args.args[1] == "/ueba/adom/root/endpoints"
+        kwargs = req.await_args.kwargs
+        assert kwargs["detail-level"] == "standard"
+        assert kwargs["epids"] == [1]
+        assert kwargs["apiver"] == 3
+
+    async def test_get_endusers_request_shape(self, mock_client: FortiAnalyzerClient) -> None:
+        from unittest.mock import AsyncMock, patch
+
+        with patch.object(mock_client, "_generic_request", AsyncMock(return_value=[])) as req:
+            await mock_client.get_endusers(adom="root", detail_level="extended")
+        assert req.await_args.args[1] == "/ueba/adom/root/endusers"
+        assert req.await_args.kwargs["detail-level"] == "extended"
+
+    async def test_get_endpoint_vulnerabilities_request_shape(
+        self, mock_client: FortiAnalyzerClient
+    ) -> None:
+        from unittest.mock import AsyncMock, patch
+
+        with patch.object(mock_client, "_generic_request", AsyncMock(return_value=[])) as req:
+            await mock_client.get_endpoint_vulnerabilities(adom="root", detectby="FortiGate")
+        assert req.await_args.args[1] == "/ueba/adom/root/endpoints/vuln"
+        assert req.await_args.kwargs["detectby"] == "FortiGate"


### PR DESCRIPTION
First slice of **Wave 2** (RFC #44): the additive read-only **reader tools** the Wave-2 skills will compose. No skills in this PR — these are the building blocks (and useful getters on their own).

**Four new tools:**
- `get_endpoints` — UEBA endpoint/asset profiles (hostname, IP, MAC, OS, first/last seen, department, vuln-stat counts)
- `get_endpoint_vulnerabilities` — per-endpoint CVE list (id, severity, type, description), FortiClient/FortiGate detector filter
- `get_endusers` — UEBA identity records; `extended` detail adds email/department/title/phone
- `get_alert_handlers` — basic/correlation detection-rule config (one tool, `handler_type`-selected per the Wave-2 plan)

**Shape:** matches the existing tool architecture — typed client methods (`client.get_endpoints` etc.; UEBA via `_request_dict`, handler config via `_raw_request_dict` mirroring `get_alerts`) with `@mcp.tool()` wrappers, standard `{status, data}` envelope, input validation. Registered in both full mode and the dynamic-mode registry. Feature-gated on UEBA being licensed/enabled; API paths verified identical on 7.6.7 and 8.0.0.

**Verification:**
- 15 new tests (tool-level: envelope, validation, param forwarding; client-level: endpoint URL + JSON-RPC param shape). Full suite 926 pass CI-style, ruff/mypy clean.
- **Live-verified against a real appliance:** `get_endpoints` 2548 records, `get_endusers` 28 records (extended), `get_alert_handlers` both classes, `get_endpoint_vulnerabilities` clean call (0 CVEs in the estate currently). Base tool count 77 → 81.

**Scope note:** README/docs tool-count + a new "UEBA Tools" category land with the **2.10.0** release (when the full Wave-2 tool surface is stable), not per-reader-PR — noted so it isn't forgotten.

Next in Wave 2: **PR B** (SOAR indicator readers — `get_indicator_enrichment`, `get_linked_indicators`), then the skills PRs. Plan: `.claude/references/faz-skills-wave2-plan.md` (homelab repo).
