### PR TITLE
fix(soar): send time-range on indicator reads; resolve enrichment via list filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **SOAR indicator readers returned empty against real data (missing `time-range`).** `get_indicator_enrichment` and `get_linked_indicators` omitted the `time-range` parameter, so the FortiAnalyzer SOAR API applied its documented **7-day default window** and silently dropped older indicators — the readers returned `[]` even when the appliance held enriched indicators. Both now send an unbounded `time-range` by default (matching the GUI's "show all") and accept an optional `time_range` argument to narrow it. This shipped un-noticed because the reference estate had no populated indicators when the readers landed (#64); the first real enriched indicator exposed it. Live-validated end-to-end (a real Malicious URL now returns `enrichment-reputation`/`enrichment-confidence`/`enrichment-status`).
+- **`get_indicator_enrichment` queried the wrong endpoint.** The reputation is served inline on the indicator **list** endpoint, not `/indicator/enrichment/{nil-uuid}` (which returns nothing without a real enrichment UUID). The reader now resolves the indicator by a `value`/`type` filter on the list endpoint and, for `detail_level="extended"`, follows the row's real `enrichment-uuid` to `/indicator/enrichment/{uuid}` for the raw source detail. The single-quoted filter value rejects an embedded quote up front (no IP/URL/domain legitimately contains one), closing a filter-injection vector.
+
 ### Security
 
 - **Masking closes the remaining boundary leaks tracked in [#71](https://github.com/rstierli/fortianalyzer-mcp/issues/71).** Malformed `target` shapes and map keys now fail closed while preserving device-identity keep values, mixed-case composite siblings receive the same masking treatment as lowercase keys, and a URL with a marked host token that cannot decrypt now passes through whole instead of exposing a resolved tail beside the stale token.

--- a/src/fortianalyzer_mcp/api/client.py
+++ b/src/fortianalyzer_mcp/api/client.py
@@ -1941,21 +1941,33 @@ class FortiAnalyzerClient:
 
     _NIL_UUID = "00000000-0000-0000-0000-000000000000"
 
+    # SOAR indicator reads apply a default 7-day time-range when the request
+    # omits one (documented in the FNDN soar.indicator.get spec), which hides
+    # older indicators. This unbounded window matches the GUI's "show all"
+    # behaviour; callers narrow it via the ``time_range`` argument.
+    _WIDE_TIME_RANGE = {"start": "1970-01-01 00:00:00", "end": "2099-12-31 23:59:59"}
+
     async def get_linked_indicators(
         self,
         adom: str,
         alert_id: str | None = None,
         incident_id: str | None = None,
         filter: str | None = None,
+        time_range: dict[str, str] | None = None,
     ) -> Any:
         """Get IOC indicators linked to an alert or an incident.
 
         FNDN: GET /soar/adom/{adom}/alert/indicator     (alert-id)
               GET /soar/adom/{adom}/incident/indicator  (incident-id)
 
-        Exactly one of ``alert_id`` / ``incident_id`` must be given.
+        Exactly one of ``alert_id`` / ``incident_id`` must be given. A
+        ``time-range`` is always sent (default: unbounded) because the SOAR
+        API otherwise filters to the last 7 days and drops older indicators.
         """
-        params: dict[str, Any] = {"apiver": API_VERSION}
+        params: dict[str, Any] = {
+            "apiver": API_VERSION,
+            "time-range": time_range or self._WIDE_TIME_RANGE,
+        }
         if filter:
             params["filter"] = filter
         if alert_id:
@@ -1973,24 +1985,62 @@ class FortiAnalyzerClient:
         indicator_type: str,
         enrichment_uuid: str | None = None,
         detail_level: str = "standard",
+        time_range: dict[str, str] | None = None,
     ) -> Any:
         """Get IOC reputation/enrichment for an indicator.
 
-        FNDN: GET /soar/adom/{adom}/indicator/enrichment/{enrichment_uuid}
+        The reputation lives on the indicator list endpoint
+        (``/soar/adom/{adom}/indicator``): each row carries
+        ``enrichment-reputation`` (Good/Suspicious/Malicious/
+        NoReputationAvailable), ``enrichment-confidence`` (0-100),
+        ``enrichment-status`` and an ``enrichment-uuid``. The reader resolves
+        the indicator by a ``value``/``type`` filter and, for
+        ``detail_level="extended"``, follows the row's real ``enrichment-uuid``
+        to ``/indicator/enrichment/{uuid}`` for the raw source detail.
 
-        Addressable by ``indicator-type`` + ``indicator-value`` (verified
-        live) — the enrichment UUID path segment defaults to a nil UUID
-        when not supplied, since FAZ resolves by type+value. Returns
-        reputation (Good/Suspicious/Malicious/NoReputationAvailable),
-        confidence 0-100 and (extended) enrichment-detail.
+        A ``time-range`` is always sent (default: unbounded) — the SOAR API
+        otherwise applies a 7-day default and returns nothing for an indicator
+        seen earlier. ``enrichment_uuid``, when supplied, addresses the detail
+        endpoint directly and skips the value lookup.
         """
-        uuid = enrichment_uuid or self._NIL_UUID
-        return await self.get(
-            f"/soar/adom/{adom}/indicator/enrichment/{uuid}",
+        tr = time_range or self._WIDE_TIME_RANGE
+
+        # Direct-by-uuid path (caller already has the enrichment uuid).
+        if enrichment_uuid and enrichment_uuid != self._NIL_UUID:
+            return await self.get(
+                f"/soar/adom/{adom}/indicator/enrichment/{enrichment_uuid}",
+                apiver=API_VERSION,
+                **{"detail-level": detail_level, "time-range": tr},
+            )
+
+        # Resolve the indicator by value+type on the list endpoint, where the
+        # enrichment fields are returned inline. The value is single-quoted in
+        # the filter expression, so reject an embedded quote up front (an IP /
+        # URL / domain never legitimately contains one).
+        if "'" in indicator_value:
+            raise ValueError("indicator_value must not contain a single quote")
+        filter_expr = f"value=='{indicator_value}' and type=='{indicator_type}'"
+        result = await self.get(
+            f"/soar/adom/{adom}/indicator",
             apiver=API_VERSION,
-            **{
-                "indicator-type": indicator_type,
-                "indicator-value": indicator_value,
-                "detail-level": detail_level,
-            },
+            limit=100,
+            filter=filter_expr,
+            **{"time-range": tr},
         )
+        rows = result if isinstance(result, list) else (result.get("data") or [])
+
+        if detail_level == "extended":
+            for row in rows:
+                if not isinstance(row, dict):
+                    continue
+                euid = row.get("enrichment-uuid")
+                if euid and euid != self._NIL_UUID:
+                    try:
+                        row["enrichment-detail"] = await self.get(
+                            f"/soar/adom/{adom}/indicator/enrichment/{euid}",
+                            apiver=API_VERSION,
+                            **{"detail-level": "extended", "time-range": tr},
+                        )
+                    except Exception as exc:  # detail is best-effort enrichment
+                        logger.warning("enrichment detail fetch failed for %s: %s", euid, exc)
+        return rows

--- a/src/fortianalyzer_mcp/tools/soar_tools.py
+++ b/src/fortianalyzer_mcp/tools/soar_tools.py
@@ -2,17 +2,20 @@
 
 Read-only readers over the SOAR indicator API, added as building blocks
 for the Wave-2 ``threat_intel`` / ``investigate`` skills. Feature-gated:
-these require SOAR to be licensed on the FortiAnalyzer (and enrichment
-requires a reputation source, e.g. a VirusTotal/FortiGuard connector,
-to have populated indicator data).
+these require SOAR to be licensed on the FortiAnalyzer, and enrichment
+requires a reputation source (e.g. a VirusTotal/FortiGuard connector) to
+have populated the indicator's reputation.
 
-Only the GET reads are exposed. The bare ``/indicator/enrichment`` path
-is add-only; reputation is read by indicator type+value (or UUID) through
-``/indicator/enrichment/{uuid}``. Based on the FNDN SOAR (soar.json) spec.
+Reputation is read from the indicator list endpoint, where each row carries
+``enrichment-reputation`` / ``enrichment-confidence`` / ``enrichment-status``
+inline; ``detail_level="extended"`` follows the row's ``enrichment-uuid`` to
+``/indicator/enrichment/{uuid}`` for the raw source detail. Based on the FNDN
+SOAR (soar.json) spec.
 
-Note: the request shapes here are verified live against a real appliance;
-the enrichment *payload* shape is spec-derived and not yet live-validated,
-because the reference estate currently has no populated SOAR indicators.
+Every read sends an unbounded ``time-range`` by default: the SOAR API applies
+a 7-day default window when none is given (per the spec) and silently drops
+older indicators. Live-validated against a real appliance with populated,
+enriched indicators.
 """
 
 import logging
@@ -21,6 +24,7 @@ from typing import Any
 from fortianalyzer_mcp.api.client import FortiAnalyzerClient
 from fortianalyzer_mcp.server import get_faz_client, mcp
 from fortianalyzer_mcp.utils.responses import redact
+from fortianalyzer_mcp.utils.time_range import parse_time_range
 from fortianalyzer_mcp.utils.validation import get_default_adom, validate_adom
 
 logger = logging.getLogger(__name__)
@@ -37,12 +41,27 @@ def _get_client() -> FortiAnalyzerClient:
     return client
 
 
+async def _parse_time_range(time_range: str | None) -> dict[str, str] | None:
+    """Parse an optional time-range string into FAZ's ``{start,end}`` dict.
+
+    Returns ``None`` when no range is given, so the client applies its
+    unbounded default (SOAR otherwise filters to the last 7 days).
+    """
+    if not time_range:
+        return None
+    if "|" in time_range:
+        return parse_time_range(time_range)
+    faz_tz = await _get_client().get_system_timezone()
+    return parse_time_range(time_range, faz_tz=faz_tz)
+
+
 @mcp.tool()
 async def get_linked_indicators(
     adom: str | None = None,
     alert_id: str | None = None,
     incident_id: str | None = None,
     filter: str | None = None,
+    time_range: str | None = None,
 ) -> dict[str, Any]:
     """Get IOC indicators linked to an alert or an incident.
 
@@ -55,6 +74,9 @@ async def get_linked_indicators(
         alert_id: Alert ID to look up indicators for
         incident_id: Incident ID to look up indicators for
         filter: Optional filter expression (indicator-uuid/type/value/status)
+        time_range: Optional window ("7-day", "30-day" or "start|end").
+            Omit to search all time (SOAR otherwise defaults to the last 7
+            days and drops older indicators).
 
     Provide exactly one of ``alert_id`` or ``incident_id``.
 
@@ -73,13 +95,14 @@ async def get_linked_indicators(
                 "status": "error",
                 "message": "Validation error: provide exactly one of 'alert_id' or 'incident_id'",
             }
+        tr = await _parse_time_range(time_range)
         client = _get_client()
 
         subject = f"alert {alert_id}" if alert_id else f"incident {incident_id}"
         logger.info(f"Getting linked indicators for {subject} in ADOM {adom}")
 
         result = await client.get_linked_indicators(
-            adom=adom, alert_id=alert_id, incident_id=incident_id, filter=filter
+            adom=adom, alert_id=alert_id, incident_id=incident_id, filter=filter, time_range=tr
         )
         return {"status": "success", "data": result}
     except Exception as e:
@@ -94,30 +117,39 @@ async def get_indicator_enrichment(
     adom: str | None = None,
     enrichment_uuid: str | None = None,
     detail_level: str = "standard",
+    time_range: str | None = None,
 ) -> dict[str, Any]:
     """Get IOC reputation/enrichment for an indicator.
 
     Returns the stored reputation for an IP, URL or domain: verdict
-    (Good/Suspicious/Malicious/NoReputationAvailable), confidence (0-100)
-    and source. With detail_level "extended", also returns the raw
-    enrichment detail. Reads existing enrichment only — it does not trigger
-    a new lookup. Requires SOAR licensed with a reputation source.
+    (``enrichment-reputation`` = Good/Suspicious/Malicious/
+    NoReputationAvailable), ``enrichment-confidence`` (0-100), status and the
+    indicator/enrichment UUIDs. With detail_level "extended", also attaches
+    the raw ``enrichment-detail`` from the reputation source. Reads existing
+    enrichment only — it does not trigger a new lookup. Requires SOAR
+    licensed with a reputation source that has enriched the indicator.
 
     Args:
         indicator_value: The indicator value (e.g. an IP, URL or domain)
         indicator_type: "IP", "URL" or "Domain"
         adom: ADOM name (default: from config DEFAULT_ADOM)
-        enrichment_uuid: Optional enrichment UUID (resolves by type+value
-            when omitted)
+        enrichment_uuid: Optional enrichment UUID; addresses the enrichment
+            detail directly (skips the value lookup) when supplied
         detail_level: "standard" or "extended" (default: "standard")
+        time_range: Optional window ("7-day", "30-day" or "start|end").
+            Omit to search all time (SOAR otherwise defaults to the last 7
+            days and returns nothing for an indicator seen earlier).
 
     Returns:
-        dict with the enrichment record under "data"
+        dict with the matched indicator record(s) under "data" (empty list
+        when the indicator is unknown or not yet enriched)
 
     Example:
         >>> result = await get_indicator_enrichment(
         ...     indicator_value="8.8.8.8", indicator_type="IP"
         ... )
+        >>> for ind in result["data"]:
+        ...     print(ind.get("enrichment-reputation"), ind.get("enrichment-confidence"))
     """
     try:
         adom = validate_adom(adom or get_default_adom())
@@ -135,6 +167,7 @@ async def get_indicator_enrichment(
                 "message": f"Validation error: Invalid detail_level "
                 f"'{detail_level}'. Must be one of: {valid}",
             }
+        tr = await _parse_time_range(time_range)
         client = _get_client()
 
         logger.info(f"Getting indicator enrichment for a {indicator_type} in ADOM {adom}")
@@ -145,6 +178,7 @@ async def get_indicator_enrichment(
             indicator_type=indicator_type,
             enrichment_uuid=enrichment_uuid,
             detail_level=detail_level,
+            time_range=tr,
         )
         return {"status": "success", "data": result}
     except Exception as e:

--- a/tests/test_soar_tools.py
+++ b/tests/test_soar_tools.py
@@ -123,19 +123,61 @@ class TestSoarClientMethods:
         with pytest.raises(ValueError, match="exactly one"):
             await mock_client.get_linked_indicators(adom="root")
 
-    async def test_enrichment_url_and_params(self, mock_client: FortiAnalyzerClient) -> None:
+    async def test_enrichment_resolves_via_list_filter(
+        self, mock_client: FortiAnalyzerClient
+    ) -> None:
+        # Reputation lives on the indicator list endpoint (the enrichment/{uuid}
+        # path only works with a real uuid); resolve by a value+type filter and
+        # always send a time-range (SOAR defaults to 7 days otherwise).
         from unittest.mock import AsyncMock, patch
 
         with patch.object(mock_client, "get", AsyncMock(return_value=[])) as req:
             await mock_client.get_indicator_enrichment(
                 adom="root", indicator_value="8.8.8.8", indicator_type="IP"
             )
-        url = req.await_args.args[0]
-        assert url.startswith("/soar/adom/root/indicator/enrichment/")
+        assert req.await_args.args[0] == "/soar/adom/root/indicator"
         kwargs = req.await_args.kwargs
-        assert kwargs["indicator-type"] == "IP"
-        assert kwargs["indicator-value"] == "8.8.8.8"
-        assert kwargs["detail-level"] == "standard"
+        assert kwargs["filter"] == "value=='8.8.8.8' and type=='IP'"
+        assert kwargs["time-range"] == mock_client._WIDE_TIME_RANGE
+
+    async def test_enrichment_rejects_quote_in_value(
+        self, mock_client: FortiAnalyzerClient
+    ) -> None:
+        # A single quote would break out of the value=='...' filter clause.
+        with pytest.raises(ValueError, match="single quote"):
+            await mock_client.get_indicator_enrichment(
+                adom="root", indicator_value="x' or '1'=='1", indicator_type="URL"
+            )
+
+    async def test_enrichment_extended_follows_enrichment_uuid(
+        self, mock_client: FortiAnalyzerClient
+    ) -> None:
+        # extended attaches the raw detail by following the row's real
+        # enrichment-uuid to the enrichment/{uuid} endpoint.
+        from unittest.mock import AsyncMock, patch
+
+        async def fake_get(url: str, **_: object) -> object:
+            if url == "/soar/adom/root/indicator":
+                return [
+                    {"value": "8.8.8.8", "enrichment-uuid": "e-9", "enrichment-reputation": "Good"}
+                ]
+            return [{"enrichment-detail": [{"source": "vt"}]}]
+
+        with patch.object(mock_client, "get", AsyncMock(side_effect=fake_get)) as req:
+            rows = await mock_client.get_indicator_enrichment(
+                adom="root", indicator_value="8.8.8.8", indicator_type="IP", detail_level="extended"
+            )
+        assert rows[0]["enrichment-detail"] == [{"enrichment-detail": [{"source": "vt"}]}]
+        assert req.await_args_list[1].args[0] == "/soar/adom/root/indicator/enrichment/e-9"
+
+    async def test_linked_indicators_send_time_range(
+        self, mock_client: FortiAnalyzerClient
+    ) -> None:
+        from unittest.mock import AsyncMock, patch
+
+        with patch.object(mock_client, "get", AsyncMock(return_value=[])) as req:
+            await mock_client.get_linked_indicators(adom="root", incident_id="IN00000019")
+        assert req.await_args.kwargs["time-range"] == mock_client._WIDE_TIME_RANGE
 
     async def test_enrichment_uses_supplied_uuid(self, mock_client: FortiAnalyzerClient) -> None:
         from unittest.mock import AsyncMock, patch


### PR DESCRIPTION
Fixes the SOAR indicator readers, which returned empty against real data. Diagnosed live with the FAZ GUI's own `/jsonrpc` capture (thanks Roland).

## The bugs

1. **Missing `time-range`.** `get_indicator_enrichment` / `get_linked_indicators` omitted the `time-range` param. The FNDN `soar.indicator.get` spec states *"if not exist, default time-range is 7 days from current time"* — so FAZ silently applied a 7-day window and dropped older indicators, returning `[]` even when the appliance held enriched indicators. Both readers now send an **unbounded** `time-range` by default (matching the GUI's "show all"), with an optional `time_range` arg (`"7-day"`, `"30-day"`, `"start|end"`) to narrow.

2. **Wrong endpoint for enrichment.** `get_indicator_enrichment` hit `/indicator/enrichment/{nil-uuid}`, which returns nothing without a real enrichment UUID. Reputation is served **inline on the indicator list endpoint**. The reader now resolves the indicator by a `value`/`type` filter there, and for `detail_level="extended"` follows the row's **real** `enrichment-uuid` to `/indicator/enrichment/{uuid}` for the raw source detail. The single-quoted filter value rejects an embedded quote up front (filter-injection guard).

## Why it wasn't caught

The readers (#64) shipped with the honest caveat *"request shapes verified live; payload shape spec-derived, not live-validated — the estate has no populated SOAR indicators."* The first real enriched indicator (a live phishing URL, rated **Malicious** by the VirusTotal connector) exposed that the readers returned nothing. The caveat came true — exactly why we write them.

## Verification

- Live end-to-end through the MCP tools against the real appliance: the Malicious URL now returns `enrichment-reputation: Malicious`, `enrichment-confidence: 90`, `enrichment-status: Completed`; `extended` attaches the raw `enrichment-detail`; an unknown indicator returns a clean empty list; the quote-injection guard fires.
- Suite **1080 pass** (SOAR tests rewritten to the corrected contract: list-filter endpoint, wide time-range, extended-detail follow, quote guard), ruff + format + mypy clean.

## Why it matters now

This is the prerequisite for `threat_intel` and the enrichment skills in 2.10.0 — without it those skills read nothing. Contract change: `get_indicator_enrichment` now returns the matched indicator **row(s)** (with `enrichment-*` fields) rather than an enrichment-record dict.
