### PR TITLE
fix(masking): cover the reader vocabularies the log allowlist never had

### DIFF
--- a/src/fortianalyzer_mcp/masking/fields.py
+++ b/src/fortianalyzer_mcp/masking/fields.py
@@ -4,9 +4,16 @@ The log field names were verified against live FAZ 7.6.7 and 8.0.0 schemas
 (``get_log_fields`` across traffic, event, attack, webfilter, dns, virus,
 emailfilter and app-ctrl) — see the field-verification discussion on issue
 #40. Names the RFC drafted that do not exist in any schema (src, srcaddr,
-dst, dstaddr, srchost, dsthost, srcuser, remotename, email, message,
-domain) are deliberately absent: masking a nonexistent field is a silent
-no-op.
+dst, dstaddr, srchost, dsthost, srcuser, remotename) are deliberately
+absent: masking a nonexistent field is a silent no-op.
+
+``email``, ``domain`` and ``message`` were dropped on those same grounds
+and have since stopped qualifying. The logview vocabulary is not the only
+one the tools read: UEBA returns ``email`` on an extended ``get_endusers``
+record, FortiView names a browsed site ``domain`` on a top-websites row,
+and every tool answers an error under ``message``. Absent from
+``get_log_fields`` does not mean absent from a tool response, so each is
+carried below with the type its real carrier uses.
 
 **Logs are not the only surface.** ``get_log_fields`` describes logview
 rows. Alerts come from eventmgmt and incidents from incidentmgmt, and they
@@ -188,6 +195,7 @@ FIELD_TYPES: dict[str, str] = {
     "botnetdomain": DOMAIN,
     "domainctrldomain": DOMAIN,
     "scertcname": DOMAIN,
+    "domain": DOMAIN,  # fortiview top-websites: the site that was browsed
     # --- email carriers (from/to fall back to username when no "@")
     "sender": EMAIL,
     "recipient": EMAIL,
@@ -196,6 +204,7 @@ FIELD_TYPES: dict[str, str] = {
     "cc": EMAIL,
     "collectedemail": EMAIL,
     "dstcollectedemail": EMAIL,
+    "email": EMAIL,  # ueba get_endusers, detail_level="extended"
     # --- free text: embedded IOCs masked in place
     "msg": TEXT,
     "logdesc": TEXT,
@@ -217,6 +226,15 @@ FIELD_TYPES: dict[str, str] = {
     "filter": TEXT,
     "filter_applied": TEXT,
     "device": HOSTNAME,
+    # --- caller-facing prose: the skills layer and every tool error build
+    # these strings themselves, and they name the record they are about
+    # ("2 end-users match username 'jdoe'"). Pass 1 masks the record's own
+    # keys, so without these the same identifier is a token under one key
+    # and clear two keys away. TEXT, so pass 2 masks in place and nothing
+    # here is ever burned.
+    "warnings": TEXT,
+    "message": TEXT,
+    "reason": TEXT,
 }
 
 #: Composite keys whose value is a single string holding one or more
@@ -255,6 +273,12 @@ DEVICE_IDENTITY_TYPES: dict[str, str] = {
     "snclosest": HOSTNAME,
     "fortigate": HOSTNAME,  # fortiview: reporting device, comma-joined when aggregated
     "detectkey": HOSTNAME,  # ueba endpoints: serial of the detecting appliance
+    # eventmgmt alert subject_details: {alertid, devs, epids, euids}. Same
+    # class as devname, and until it was listed here it defeated the flag
+    # rather than following it: the device stayed clear under "devs" while
+    # the sibling "devname" masked, handing over the token-to-name pairing
+    # the flag exists to withhold.
+    "devs": HOSTNAME,
 }
 
 #: ``target[].name`` values, mapped to the type of the sibling ``value``.
@@ -280,7 +304,11 @@ COMPOSITE_URL_HOST = ("http_url",)
 #: the host masks in place exactly like COMPOSITE_URL_HOST, and the whole
 #: tail (path+query+fragment) seals into one reversible ``url-`` token.
 #: Substring search inside the tail is an accepted, documented loss.
-COMPOSITE_URL_FULL = ("url", "referralurl")
+#: ``link`` is the SOAR reputation source's reference URL, and the source
+#: puts the indicator in its query string ("...?query=<indicator>"), so the
+#: sensitive part is the tail, not the public portal host. Same treatment
+#: as ``url``, which keeps it reversible for anyone who wants to follow it.
+COMPOSITE_URL_FULL = ("url", "referralurl", "link")
 
 # Values that carry no identifier and pass through unmasked.
 SKIP_VALUES = frozenset({"", "N/A", "n/a", "unknown", "none", "-"})

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -469,6 +469,7 @@ class OutputMasker:
         if isinstance(obj, dict):
             paired = self._mask_threat_pair(obj, mapping)
             paired.update(self._mask_incident_reporter(obj, mapping))
+            paired.update(self._mask_indicator_pair(obj, mapping))
             return {
                 key: paired[key] if key in paired else self._mask_entry(key, value, mapping, keep)
                 for key, value in obj.items()
@@ -506,6 +507,40 @@ class OutputMasker:
         if value not in siblings:
             return {}
         return {key: self._mask_scalar(USERNAME, value, mapping)}
+
+    def _mask_indicator_pair(self, obj: dict[str, Any], mapping: dict[str, str]) -> dict[str, str]:
+        """SOAR ``value``/``type``: the IOC itself, typed by its sibling.
+
+        ``get_indicator_enrichment`` and ``get_linked_indicators`` return
+        the indicator under the key ``value``, which is far too generic to
+        allowlist outright: the same name carries a severity band, a count
+        and a config setting elsewhere in the API, and typing it globally
+        would mask ``"high"`` as a hostname. The sibling ``type`` decides
+        instead, exactly as ``obf_url`` decides for ``threat`` -- SOAR
+        writes it on every indicator row and it names the value's class.
+
+        Only IP, Domain and URL are recognised, which is the set the reader
+        tools accept. Any other ``type`` (or none) leaves ``value`` alone,
+        so the generic use of the name is untouched.
+        """
+        key = _find_key(obj, "value")
+        type_key = _find_key(obj, "type")
+        if key is None or type_key is None:
+            return {}
+        value = obj[key]
+        if not isinstance(value, str) or not value.strip() or value.strip() in SKIP_VALUES:
+            return {}
+        kind = obj[type_key]
+        if not isinstance(kind, str):
+            return {}
+        lowered = kind.strip().lower()
+        if lowered == "ip":
+            return {key: self._mask_scalar(IP, value, mapping)}
+        if lowered == "domain":
+            return {key: self._mask_scalar(DOMAIN, value, mapping)}
+        if lowered == "url":
+            return {key: self._mask_url_full(value, mapping)}
+        return {}
 
     def _mask_threat_pair(self, obj: dict[str, Any], mapping: dict[str, str]) -> dict[str, str]:
         """fortiview ``threat``/``obf_url``: masked together, as domains (#40).

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -932,3 +932,140 @@ class TestUrlFullMasking:
         masked = masker.mask_result({"url": encoded})["url"]
         assert masked.startswith("masked-unrepresentable-")
         assert ANALYST not in masked and "secret" not in masked
+
+
+class TestNonLogviewVocabulary:
+    """Keys that no logview schema has, but a real tool response carries.
+
+    The allowlist was built from ``get_log_fields``, so ``email``, ``domain``
+    and ``message`` were dropped as names that mask nothing. The UEBA, SOAR
+    and FortiView readers answer under exactly those names, and each of
+    these records is the shape its reader returns.
+    """
+
+    def test_ueba_enduser_email_is_masked(self, masker: OutputMasker):
+        engine = FPEEngine(KEY)
+        record = {"euid": 5, "euname": ANALYST, "email": SOC_EMAIL, "department": "SOC"}
+        masked = masker.mask_result({"status": "success", "data": [record]})
+        out = masked["data"][0]
+
+        assert SOC_EMAIL not in str(masked)
+        assert engine.unmask_email(out["email"]) == SOC_EMAIL
+
+    def test_fortiview_top_website_domain_is_masked(self, masker: OutputMasker):
+        masked = masker.mask_result({"data": [{"domain": BAD_DOMAIN, "bandwidth": 2}]})
+
+        assert BAD_DOMAIN not in str(masked)
+
+    def test_error_message_embedded_ip_is_masked_in_place(self, masker: OutputMasker):
+        # ``message`` is TEXT, so pass 2 scans it. A username in the same
+        # prose is only substituted when the response masked it somewhere
+        # (see the mapping residual in #73); an embedded address always is.
+        masked = masker.mask_result({"status": "error", "message": f"could not reach {PEER_IP}"})
+
+        assert PEER_IP not in masked["message"]
+
+
+class TestSoarIndicatorPair:
+    """``value`` typed by its sibling ``type``, the way SOAR returns an IOC."""
+
+    def test_indicator_ip_is_masked(self, masker: OutputMasker):
+        engine = FPEEngine(KEY)
+        row = {"value": PEER_IP, "type": "IP", "enrichment-reputation": "Malicious"}
+        out = masker.mask_result({"data": [row]})["data"][0]
+
+        assert PEER_IP not in str(out)
+        assert engine.unmask_ip(out["value"]) == PEER_IP
+        assert out["enrichment-reputation"] == "Malicious"  # verdict stays readable
+
+    def test_indicator_domain_is_masked(self, masker: OutputMasker):
+        out = masker.mask_result({"data": [{"value": BAD_DOMAIN, "type": "Domain"}]})
+
+        assert BAD_DOMAIN not in str(out)
+
+    def test_indicator_url_is_masked(self, masker: OutputMasker):
+        url = f"https://{BAD_DOMAIN}/payload"
+        out = masker.mask_result({"data": [{"value": url, "type": "URL"}]})["data"][0]
+
+        assert BAD_DOMAIN not in str(out)
+        assert out["value"].startswith("https://host-")
+
+    def test_indicator_type_is_case_insensitive(self, masker: OutputMasker):
+        # SOAR spells them IP/URL/Domain; nothing guarantees the casing.
+        for spelling in ("ip", "IP", "Ip"):
+            out = masker.mask_result({"data": [{"value": PEER_IP, "type": spelling}]})
+            assert PEER_IP not in str(out), spelling
+
+    def test_generic_value_type_pair_is_left_alone(self, masker: OutputMasker):
+        # The whole reason "value" is not allowlisted outright: the same key
+        # names a severity band, a count and a setting elsewhere in the API.
+        # An unrecognised type must leave it exactly as it was.
+        for kind in ("string", "severity", "int", ""):
+            out = masker.mask_result({"value": "high", "type": kind})
+            assert out["value"] == "high", kind
+
+    def test_value_without_a_type_sibling_is_left_alone(self, masker: OutputMasker):
+        assert masker.mask_result({"value": "high"})["value"] == "high"
+
+    def test_indicator_echo_in_prose_carries_the_same_token(self, masker: OutputMasker):
+        # The skills layer names the indicator in its caller-facing warning.
+        # Masked under one key and clear two keys away is the exact failure
+        # the two-pass design exists to close.
+        masked = masker.mask_result(
+            {
+                "data": [{"value": BAD_DOMAIN, "type": "Domain"}],
+                "warnings": [f"no stored enrichment for Domain '{BAD_DOMAIN}'"],
+            }
+        )
+
+        assert BAD_DOMAIN not in str(masked)
+        assert masked["data"][0]["value"] in masked["warnings"][0]
+
+
+class TestDeviceListAndSourceLink:
+    """Two more names the log vocabulary never had.
+
+    ``devs`` is the device list on an eventmgmt alert's ``subject_details``,
+    and ``link`` is the reference URL a SOAR reputation source returns.
+    """
+
+    def test_devs_follows_the_device_identity_flag(self, masker: OutputMasker):
+        # Flag off is the default: the appliance stays clear, like devname.
+        subject = {"alertid": "A1", "devs": [DEV_NAME], "epids": [3]}
+        masked = masker.mask_result({"subject_details": subject})
+
+        assert masked["subject_details"]["devs"] == [DEV_NAME]
+
+    def test_devs_masks_when_the_flag_is_on(self, full_masker: OutputMasker):
+        subject = {"alertid": "A1", "devs": [DEV_NAME], "epids": [3]}
+        masked = full_masker.mask_result({"subject_details": subject})
+
+        assert DEV_NAME not in str(masked)
+
+    def test_devs_and_devname_agree_under_the_flag(self, full_masker: OutputMasker):
+        # The reason this matters: while devs was unlisted, the same device
+        # was a token under devname and clear under devs in one record,
+        # which hands over exactly the pairing the flag withholds.
+        masked = full_masker.mask_result(
+            {"devname": DEV_NAME, "subject_details": {"devs": [DEV_NAME]}}
+        )
+
+        assert DEV_NAME not in str(masked)
+        assert masked["subject_details"]["devs"] == [masked["devname"]]
+
+    def test_source_link_tail_is_sealed(self, masker: OutputMasker):
+        # The reputation source puts the indicator in the query string.
+        link = f"https://ioc.example.org/search?query={BAD_DOMAIN}"
+        masked = masker.mask_result({"sources": [{"source": "cts", "link": link}]})
+        out = masked["sources"][0]["link"]
+
+        assert BAD_DOMAIN not in str(masked)
+        assert "url-" in out  # sealed, not burned: it resolves back
+
+    def test_source_link_round_trips(self, masker: OutputMasker):
+        from fortianalyzer_mcp.masking.unmask import ArgUnmasker
+
+        link = f"https://ioc.example.org/search?query={BAD_DOMAIN}"
+        masked = masker.mask_result({"link": link})["link"]
+
+        assert ArgUnmasker(FPEEngine(KEY)).resolve_url(masked) == link

--- a/tests/test_masking_wrapper.py
+++ b/tests/test_masking_wrapper.py
@@ -10,7 +10,7 @@ import re
 
 import pytest
 
-from fortianalyzer_mcp.masking.fields import FIELD_TYPES
+from fortianalyzer_mcp.masking.fields import DOMAIN, EMAIL, FIELD_TYPES, TEXT
 from fortianalyzer_mcp.masking.fpe_engine import FPEEngine
 from fortianalyzer_mcp.masking.wrapper import OutputMasker, install_masking
 
@@ -55,11 +55,18 @@ class TestFieldTable:
             "dsthost",
             "srcuser",
             "remotename",
-            "email",
-            "message",
-            "domain",
         ):
             assert dead not in FIELD_TYPES
+
+    def test_names_dead_in_logview_but_live_on_another_reader(self):
+        # These three left the list above because a real tool response
+        # carries them: UEBA end-users answer under "email", a fortiview
+        # top-websites row names the browsed site "domain", and every tool
+        # error answers under "message". Absent from get_log_fields is not
+        # absent from a tool response.
+        assert FIELD_TYPES["email"] == EMAIL
+        assert FIELD_TYPES["domain"] == DOMAIN
+        assert FIELD_TYPES["message"] == TEXT
 
     def test_core_fields_present(self):
         for name in (


### PR DESCRIPTION
Five keys that carry an identifier in a real tool response and were not covered by the allowlist. Found while reviewing #67 and #75 for the 2.10.0 release; **every one of them reproduces on `main` today** through already-merged readers, so this is deliberately a branch off `main` rather than anything stacked on the skills work. It can land before or after the tag.

Only reachable with `MASKING_ENABLED` on, which is off by default and still beta. Not urgent, but it is the difference between the skills being a masking-safe surface and not.

## The pattern

`fields.py` says the allowlist was verified against `get_log_fields`, and lists `email`, `message` and `domain` as names that "do not exist in any schema" and so were deliberately dropped. That reasoning was correct for the logview vocabulary and stopped being correct when the UEBA, SOAR and FortiView readers landed. Those APIs use exactly those names, plus `value` for the indicator itself and `link` for the source reference.

**Absent from `get_log_fields` does not mean absent from a tool response.** Verified against raw tool payloads, not just skill output:

```
get_endusers (#63)                LEAKS  email
get_top_websites (long-standing)  LEAKS  domain
get_indicator_enrichment (#64)    LEAKS  value
get_endpoints (#63)               clean
```

## What changed

**`email` as EMAIL, `domain` as DOMAIN.** Their real carriers are an extended `get_endusers` record and a FortiView top-websites row. The module docstring now says why they stopped qualifying instead of listing them as dead, and `test_rfc_dead_names_absent` keeps guarding the names that genuinely are dead.

**`message`, `warnings` and `reason` as TEXT.** These are prose the skills layer builds itself, and it names the record it is about. `identity_profile` masks `euname` in the record and then quotes the raw username in `warnings` two keys away, which is the "masked under one key, cleartext next to it" failure the two-pass design exists to close. TEXT means pass 2 masks in place and nothing here is ever burned.

**The SOAR indicator gets a sibling handler, not an allowlist entry.** `value` is far too generic to type globally: the same key carries a severity band, a count and a config setting elsewhere in the API, and a blanket rule would mask `"high"` as a hostname. The sibling `type` decides instead, exactly the way `obf_url` decides for `threat`. Only IP, Domain and URL are recognised, which is the set the reader tools accept, so every other use of `value` is untouched and a test pins that.

**`devs` in `DEVICE_IDENTITY_TYPES`.** The device list on an alert's `subject_details`. It was in neither table, so it defeated `FAZ_MASK_DEVICE_IDENTITY` rather than following it: with the flag **on**, the same appliance came back as a token under `devname` and clear under `devs` in one record, handing over exactly the pairing the flag withholds. It goes in the device table, not `FIELD_TYPES`, so it stays clear when the flag is off like `devname` does, and there is a test for each side of that.

**`link` in `COMPOSITE_URL_FULL`.** The SOAR reputation source's reference URL, which carries the indicator in its query string, so the sensitive part is the tail rather than the public portal host. Same carry-and-reverse as `url`, so it stays followable after unmasking.

## Deliberately not included

**`vpntunnel`** leaks the same way and I have left it alone on purpose, because a blanket rule would do real damage:

```
'hq-to-branch-zurich'  ->  masks and round-trips
'site_a-site_b'        ->  masks and round-trips
'to-DC (primary)'      ->  MaskingError: characters outside the maskable alphabet  (burns)
'tunnel#1'             ->  MaskingError                                            (burns)
```

Tunnel names are free-form config labels, so typing them as HOSTNAME irreversibly destroys any name with a space or a parenthesis. This is the shape `devvds` already has, and it got a composite handler precisely so the brackets could be lifted out first. My suggestion is `DEVICE_IDENTITY_TYPES["vpntunnel"] = HOSTNAME`, since a tunnel name is estate topology rather than personal data and that keeps it behind the flag, but it wants your call rather than my patch. Details on #75.

Also not included, because it is the skills layer rather than masking: the dispatcher redacts only top-level `warnings`, so warnings nested inside `Investigation` ship raw alongside their redacted copies. Written up on #75.

## Verification

- **1096 pass on 3.12 and 3.13**, ruff, format and bandit clean.
- Every affected reader payload run through the masker before and after.
- Applied on top of #75 as a cross-check: **1218 pass**, and all ten of my skill probe cases come back clean where four leaked before.
- **Every new test is mutation-checked**: reverting its own fix turns it red, ten of ten mutants killed. That includes one mutant that moves `devs` into `FIELD_TYPES`, since making it ignore the flag would be just as wrong as leaving it out.

## One residual this does not close

`faz_skill`'s error path hands the caller's own parameter straight back:

```
{"status": "error", "message": "no UEBA end-user matches username 'example-user'"}
```

Making `message` TEXT does not help here. Pass 2 substitutes what pass 1 masked, and the failure path returns no record at all, so the mapping is empty and a bare username has no shape to detect. If masking is on, the model handed you a token, `unmask_args` resolved it, and the error returns the real name it never had. Same family as residual 4 in #73. The clean fix is handler-side, so it is yours to make: either do not quote the caller's value back in `SkillExecutionError`, or name the parameter rather than its content. Happy to file it separately.
