### PR TITLE
fix(skills): redact warnings at any depth, not just the top level

### DIFF
--- a/src/fortianalyzer_mcp/skills/dispatcher.py
+++ b/src/fortianalyzer_mcp/skills/dispatcher.py
@@ -25,6 +25,33 @@ logger = logging.getLogger(__name__)
 _SKILL_IDS = ", ".join(sorted(SKILLS))
 
 
+def _redact_warnings(node: Any) -> Any:
+    """Redact every ``warnings`` list of strings in ``node``, at any depth.
+
+    Reading the top-level key alone was enough while every skill returned a
+    flat result. A skill that composes other skills is not flat: each
+    composed section keeps its own ``warnings``, and the composing handler
+    copies them upward with a section prefix. Only the copies were reaching
+    the chokepoint, so each warning shipped twice, once scrubbed and once
+    verbatim. Whichever of the two an operator reads is a coin toss, which
+    is the same as not scrubbing at all.
+
+    Only ``warnings`` is rewritten, and only its string elements, so no
+    other field shape is touched. See issue #68 M4 for why this scrubbing
+    exists at all.
+    """
+    if isinstance(node, dict):
+        return {
+            key: [redact(item) if isinstance(item, str) else item for item in value]
+            if key == "warnings" and isinstance(value, list)
+            else _redact_warnings(value)
+            for key, value in node.items()
+        }
+    if isinstance(node, list):
+        return [_redact_warnings(item) for item in node]
+    return node
+
+
 @mcp.tool()
 async def faz_skill(skill: str, params: dict[str, Any] | None = None) -> dict[str, Any]:
     """Run a FortiAnalyzer skill: an opinionated multi-tool orchestration
@@ -97,15 +124,12 @@ async def faz_skill(skill: str, params: dict[str, Any] | None = None) -> dict[st
             skill=skill,
         )
 
-    dumped = result.model_dump()
     # The success path does not go through error_response, so scrub the
     # caller-facing warnings here too: a degraded sub-call can carry raw FAZ
     # exception text (internal hostnames, session/token material) into a
     # warning. Redacting at the source covers today's warnings; this is the
     # belt-and-suspenders chokepoint for any warning shape. See issue #68 M4.
-    warnings = dumped.get("warnings")
-    if isinstance(warnings, list):
-        dumped["warnings"] = [redact(w) if isinstance(w, str) else w for w in warnings]
+    dumped = _redact_warnings(result.model_dump())
     return {
         "status": "success",
         "skill": skill,

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -828,6 +828,36 @@ class TestNestedWarningRedaction:
 
         assert _redact_warnings(payload) == payload
 
+    def test_returns_a_new_structure_rather_than_mutating_in_place(self):
+        # The preservation tests below compare against the same object, so
+        # they would all pass an implementation that edited the caller's
+        # dict and handed it back. Pin purity explicitly.
+        payload = {"warnings": [self.SECRET]}
+        result = _redact_warnings(payload)
+
+        assert result is not payload
+        assert payload["warnings"] == [self.SECRET]
+
+    def test_warnings_nested_inside_a_list_of_lists(self):
+        # Recursion has to go through every list level, not just the first.
+        out = _redact_warnings({"a": [[{"warnings": [self.SECRET]}]]})
+
+        assert "SECRET123" not in str(out)
+
+    def test_a_warnings_suffixed_key_is_not_rewritten(self):
+        # The docstring promises only `warnings` is touched. A suffix match
+        # would silently start rewriting neighbouring fields.
+        payload = {"suppressed_warnings": [self.SECRET]}
+
+        assert _redact_warnings(payload) == payload
+
+    def test_a_warnings_key_holding_a_dict_is_still_recursed_into(self):
+        # Not a shape any model produces today, but the branch that skips a
+        # non-list `warnings` must recurse rather than return it untouched.
+        out = _redact_warnings({"warnings": {"nested": {"warnings": [self.SECRET]}}})
+
+        assert "SECRET123" not in str(out)
+
     def test_shape_is_otherwise_preserved(self):
         payload = {
             "subject_type": "alert",

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -19,7 +19,7 @@ from pydantic import ValidationError
 
 from fortianalyzer_mcp.skills import handlers
 from fortianalyzer_mcp.skills.catalog import SKILLS, catalogue
-from fortianalyzer_mcp.skills.dispatcher import faz_skill
+from fortianalyzer_mcp.skills.dispatcher import _redact_warnings, faz_skill
 from fortianalyzer_mcp.skills.models import (
     SCHEMA_VERSION,
     FeatureGap,
@@ -771,3 +771,113 @@ class TestSkillsFlag:
 
         monkeypatch.delenv("FAZ_SKILLS_ENABLED", raising=False)
         assert Settings(FORTIANALYZER_HOST="192.0.2.1").FAZ_SKILLS_ENABLED is False
+
+
+class TestNestedWarningRedaction:
+    """A composed skill keeps a copy of each section's warnings.
+
+    The dispatcher scrubs what it is handed. While it read one top-level
+    key, only the composing handler's prefixed copies were scrubbed and
+    every original shipped verbatim alongside them.
+    """
+
+    SECRET = "session=SECRET123 expired"
+
+    def test_top_level_warnings_still_redacted(self):
+        out = _redact_warnings({"warnings": [self.SECRET]})
+
+        assert "SECRET123" not in out["warnings"][0]
+        assert "REDACTED" in out["warnings"][0]
+
+    def test_nested_warnings_are_redacted(self):
+        out = _redact_warnings(
+            {
+                "warnings": [f"triage: {self.SECRET}"],
+                "triage": {"warnings": [self.SECRET]},
+                "threat_intel": {"warnings": [self.SECRET]},
+            }
+        )
+
+        assert "SECRET123" not in str(out)
+
+    def test_warnings_inside_a_list_of_sections_are_redacted(self):
+        out = _redact_warnings({"sections": [{"warnings": [self.SECRET]}]})
+
+        assert "SECRET123" not in str(out)
+
+    def test_deeply_nested_warnings_are_redacted(self):
+        out = _redact_warnings({"a": {"b": {"c": {"warnings": [self.SECRET]}}}})
+
+        assert "SECRET123" not in str(out)
+
+    def test_non_warning_fields_are_untouched(self):
+        # Redaction is deliberately narrow: it rewrites this one key and
+        # nothing else, so a field that happens to contain a key=value pair
+        # keeps its exact content.
+        payload = {"headline": self.SECRET, "reason": self.SECRET, "count": 3}
+
+        assert _redact_warnings(payload) == payload
+
+    def test_non_string_warning_elements_survive(self):
+        payload = {"warnings": [{"structured": "shape"}, 7, None]}
+
+        assert _redact_warnings(payload) == payload
+
+    def test_a_warnings_key_that_is_not_a_list_is_left_alone(self):
+        payload = {"warnings": "not a list"}
+
+        assert _redact_warnings(payload) == payload
+
+    def test_shape_is_otherwise_preserved(self):
+        payload = {
+            "subject_type": "alert",
+            "counts": {"endpoints": 2},
+            "rows": [{"a": 1}, {"b": [1, 2]}],
+        }
+
+        assert _redact_warnings(payload) == payload
+
+    async def test_dispatcher_scrubs_a_nested_section_end_to_end(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The helper is wired in, not just present.
+
+        Uses a stub skill whose output nests another section's warnings,
+        which is the shape a composing skill produces.
+        """
+        from pydantic import BaseModel
+
+        from fortianalyzer_mcp.skills import dispatcher as dispatcher_module
+
+        class Section(BaseModel):
+            warnings: list[str] = []
+
+        class Composed(BaseModel):
+            warnings: list[str] = []
+            section: Section
+
+        class StubParams(BaseModel):
+            pass
+
+        async def handler(_params: StubParams) -> Composed:
+            return Composed(
+                warnings=[f"section: {self.SECRET}"],
+                section=Section(warnings=[self.SECRET]),
+            )
+
+        from fortianalyzer_mcp.skills.catalog import SkillSpec
+
+        spec = SkillSpec(
+            id="stub_composed",
+            tier="analysis",
+            description="stub",
+            params_model=StubParams,
+            output_model=Composed,
+            handler=handler,
+        )
+        monkeypatch.setitem(dispatcher_module.SKILLS, "stub_composed", spec)
+
+        result = await faz_skill(skill="stub_composed", params={})
+
+        assert result["status"] == "success"
+        assert "SECRET123" not in str(result)


### PR DESCRIPTION
Taking this one as you asked. Separate PR, off `main`, so it is independent of the skills work and of the rebase.

## The bug

The dispatcher scrubs caller-facing warnings because a degraded sub-call can carry raw FAZ exception text into one (#68 M4). It reads a single top-level key:

```python
warnings = dumped.get("warnings")
```

That was enough while every skill returned a flat result. A skill that composes other skills is not flat: each composed section keeps its own `warnings`, and the composing handler copies them upward with a section prefix. **Only the copies reached the chokepoint, so every nested warning shipped twice, once scrubbed and once verbatim beside it:**

```
top-level : triage: session=***REDACTED*** expired
nested    : session=SECRET123 expired
```

Whichever of the two an operator reads is a coin toss, which is the same as not scrubbing at all. Worth noting `redact()` catches it perfectly well when it is reached, so nothing was wrong with the scrubber, only with what it was handed.

This is latent on `main` today, because nothing on `main` nests yet. It goes live the moment `investigate` lands, which is why it is worth having in before the tag rather than after.

## The change

Recurse. Only a `warnings` key is rewritten, and only its string elements, so no other field shape is touched. Non-string elements, a `warnings` key that is not a list, and every other field come through byte-identical.

I deliberately did not widen it into a general "scrub every string" pass. That would be easy to write and hard to reason about, and it would start rewriting fields like `headline` and `reason` that are supposed to be verbatim. There is a test pinning that narrowness.

## Verification

- **1132 pass on 3.12 and 3.13**, ruff and bandit clean.
- Nine tests: top level still works, nested, nested inside a list of sections, four levels deep, plus three pinning what must NOT change, plus an end-to-end run through `faz_skill` with a stub composed skill so the helper is proven wired in rather than merely present.
- **Four of four mutants killed**: reverting to the top-level read, recursing without redacting, dropping list recursion, and redacting every list instead of only `warnings`. That last one matters most, since over-reach here would be silent.

Independent of #75, which does not touch `dispatcher.py`, so it can land in any order.
