### PR TITLE
fix(masking): mask the fortiview resolved-name twin and the incident workflow principals

### DIFF
--- a/src/fortianalyzer_mcp/masking/fields.py
+++ b/src/fortianalyzer_mcp/masking/fields.py
@@ -165,6 +165,12 @@ FIELD_TYPES: dict[str, str] = {
     "hostname": HOSTNAME,
     "epname": IP_OR_HOST,
     "dstepname": IP_OR_HOST,
+    # fortiview top-sources/top-destinations: the resolved name for the
+    # sibling srcip/dstip, or that same address again when nothing
+    # resolves. Untyped, it handed back the raw address sitting beside its
+    # own token, which discloses the pairing and not just the value.
+    "srcip_hostname": IP_OR_HOST,
+    "dstip_hostname": IP_OR_HOST,
     "fqdn": HOSTNAME,
     "host": HOSTNAME,
     "dst_host": HOSTNAME,
@@ -218,6 +224,17 @@ FIELD_TYPES: dict[str, str] = {
     "endpoint": IP_OR_HOST,  # incident: an address or an endpoint name
     "reporter": USERNAME,  # incident: who raised it
     "lastuser": USERNAME,  # incident: who last touched it
+    # The incident workflow slots. Same principals as reporter/lastuser,
+    # and empty on an estate that does not work incidents, which is why
+    # they were missed. EMAIL rather than USERNAME because it is a strict
+    # superset here: a value with no "@" falls back to username masking and
+    # produces the IDENTICAL token, so one analyst keeps one token across
+    # all five keys, while an "@"-shaped login still masks instead of
+    # burning. A domain-qualified login (DOMAIN\\user) is outside both
+    # alphabets and still fails closed to a placeholder.
+    "assigned_to": EMAIL,
+    "remedy_executor": EMAIL,
+    "remedy_approver": EMAIL,
     "dstendpoint": IP_OR_HOST,  # inside the incident grpby JSON blob
     "srcendpoint": IP_OR_HOST,
     # --- response echo keys: tool responses reflect caller inputs at the

--- a/src/fortianalyzer_mcp/masking/fields.py
+++ b/src/fortianalyzer_mcp/masking/fields.py
@@ -296,6 +296,11 @@ DEVICE_IDENTITY_TYPES: dict[str, str] = {
     # the sibling "devname" masked, handing over the token-to-name pairing
     # the flag exists to withhold.
     "devs": HOSTNAME,
+    # fortiview policy-hits nests the reporting appliance a second time,
+    # under device_info.dev_name, spelled with an underscore. Same class as
+    # devname and the same failure devs had: it defeated the flag instead
+    # of following it, keeping the name clear beside a masked devid.
+    "dev_name": HOSTNAME,
 }
 
 #: ``target[].name`` values, mapped to the type of the sibling ``value``.

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -1069,3 +1069,80 @@ class TestDeviceListAndSourceLink:
         masked = masker.mask_result({"link": link})["link"]
 
         assert ArgUnmasker(FPEEngine(KEY)).resolve_url(masked) == link
+
+
+class TestFortiViewResolvedName:
+    """``srcip_hostname``/``dstip_hostname``: the resolved twin of a masked address.
+
+    FortiView puts the reverse-resolved name for a row's address here, and
+    the address itself when nothing resolves. Untyped, the second case
+    handed the raw address back beside its own token, which gives away the
+    token-to-raw pairing and not just the one value.
+    """
+
+    def test_unresolved_row_no_longer_leaks_the_address(self, masker: OutputMasker):
+        row = {"dstip": PEER_IP, "dstip_hostname": PEER_IP, "sessions": 3}
+        out = masker.mask_result({"data": [row]})["data"][0]
+
+        assert PEER_IP not in str(out)
+
+    def test_the_pair_agrees_so_no_pairing_is_disclosed(self, masker: OutputMasker):
+        # The whole point: one raw value must not appear as a token under
+        # one key and in clear under its sibling in the same row.
+        row = {"srcip": PEER_IP, "srcip_hostname": PEER_IP}
+        out = masker.mask_result({"data": [row]})["data"][0]
+
+        assert out["srcip"] == out["srcip_hostname"]
+
+    def test_resolved_row_masks_the_name_and_reverses(self, masker: OutputMasker):
+        row = {"dstip": PEER_IP, "dstip_hostname": BAD_DOMAIN}
+        out = masker.mask_result({"data": [row]})["data"][0]
+
+        assert BAD_DOMAIN not in str(out)
+        assert FPEEngine(KEY).unmask_hostname(out["dstip_hostname"]) == BAD_DOMAIN
+
+    def test_address_form_stays_reversible(self, masker: OutputMasker):
+        out = masker.mask_result({"dstip_hostname": PEER_IP})["dstip_hostname"]
+
+        assert FPEEngine(KEY).unmask_ip(out) == PEER_IP
+
+
+class TestIncidentWorkflowPrincipals:
+    """``assigned_to``/``remedy_executor``/``remedy_approver``.
+
+    Empty on an estate that does not work incidents, which is how they
+    escaped the leak tests that were built from live records.
+    """
+
+    @pytest.mark.parametrize("key", ["assigned_to", "remedy_executor", "remedy_approver"])
+    def test_workflow_principal_is_masked(self, masker: OutputMasker, key: str):
+        masked = masker.mask_result({"incid": "IN00000001", key: ANALYST})
+
+        assert ANALYST not in str(masked)
+
+    def test_one_analyst_keeps_one_token_across_every_slot(self, masker: OutputMasker):
+        # EMAIL falls back to username masking with no "@", so these agree
+        # with the USERNAME siblings. If they did not, the same person would
+        # read as several different principals in one record.
+        masked = masker.mask_result(
+            {
+                "reporter": ANALYST,
+                "lastuser": ANALYST,
+                "assigned_to": ANALYST,
+                "remedy_executor": ANALYST,
+                "remedy_approver": ANALYST,
+            }
+        )
+
+        assert len(set(masked.values())) == 1
+
+    def test_at_shaped_login_masks_instead_of_burning(self, masker: OutputMasker):
+        # The reason these are EMAIL and not USERNAME.
+        masked = masker.mask_result({"assigned_to": SOC_EMAIL})["assigned_to"]
+
+        assert SOC_EMAIL not in masked
+        assert not masked.startswith("masked-unrepresentable-")
+
+    def test_empty_slot_is_untouched(self, masker: OutputMasker):
+        # The live shape on an estate that does not work incidents.
+        assert masker.mask_result({"assigned_to": ""})["assigned_to"] == ""

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -1106,6 +1106,17 @@ class TestFortiViewResolvedName:
 
         assert FPEEngine(KEY).unmask_ip(out) == PEER_IP
 
+    @pytest.mark.parametrize("key", ["srcip_hostname", "dstip_hostname"])
+    def test_both_columns_take_the_resolved_form_reversibly(self, masker: OutputMasker, key: str):
+        # Asserting the resolved form on one column only left the other free
+        # to be typed IP, which burns a hostname irreversibly, or TEXT, which
+        # ships it in clear. Both passed the address-only assertions above.
+        out = masker.mask_result({key: BAD_DOMAIN})[key]
+
+        assert BAD_DOMAIN not in out
+        assert not out.startswith("masked-unrepresentable-")
+        assert FPEEngine(KEY).unmask_hostname(out) == BAD_DOMAIN
+
 
 class TestIncidentWorkflowPrincipals:
     """``assigned_to``/``remedy_executor``/``remedy_approver``.
@@ -1136,9 +1147,12 @@ class TestIncidentWorkflowPrincipals:
 
         assert len(set(masked.values())) == 1
 
-    def test_at_shaped_login_masks_instead_of_burning(self, masker: OutputMasker):
-        # The reason these are EMAIL and not USERNAME.
-        masked = masker.mask_result({"assigned_to": SOC_EMAIL})["assigned_to"]
+    @pytest.mark.parametrize("key", ["assigned_to", "remedy_executor", "remedy_approver"])
+    def test_at_shaped_login_masks_instead_of_burning(self, masker: OutputMasker, key: str):
+        # The reason these are EMAIL and not USERNAME. Parametrised over all
+        # three, because asserting it on one leaves the other two free to be
+        # retyped back to USERNAME without any test noticing.
+        masked = masker.mask_result({key: SOC_EMAIL})[key]
 
         assert SOC_EMAIL not in masked
         assert not masked.startswith("masked-unrepresentable-")
@@ -1155,12 +1169,18 @@ class TestNestedDeviceName:
         # fortiview policy-hits spells the appliance dev_name inside a
         # device_info sub-object. Unlisted, it kept the name clear next to a
         # masked devid on the same row.
+        #
+        # devid holds the SERIAL and dev_name the hostname, as a live row
+        # does. Reusing one string for both would let this pass even if
+        # dev_name were typed TEXT, because pass 2 would substitute it from
+        # the sibling's mapping entry and the field would never be typed at
+        # all -- the original bug, shipping green.
         masked = full_masker.mask_result(
-            {"devid": DEV_NAME, "device_info": {"dev_name": DEV_NAME, "ha_dev": "no"}}
+            {"devid": DEV_SERIAL, "device_info": {"dev_name": DEV_NAME, "ha_dev": "no"}}
         )
 
         assert DEV_NAME not in str(masked)
-        assert masked["device_info"]["dev_name"] == masked["devid"]
+        assert DEV_SERIAL not in str(masked)
 
     def test_nested_dev_name_stays_clear_with_the_flag_off(self, masker: OutputMasker):
         masked = masker.mask_result({"device_info": {"dev_name": DEV_NAME}})

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -1146,3 +1146,23 @@ class TestIncidentWorkflowPrincipals:
     def test_empty_slot_is_untouched(self, masker: OutputMasker):
         # The live shape on an estate that does not work incidents.
         assert masker.mask_result({"assigned_to": ""})["assigned_to"] == ""
+
+
+class TestNestedDeviceName:
+    """``device_info.dev_name``: the appliance, spelled a second way."""
+
+    def test_nested_dev_name_follows_the_flag_too(self, full_masker: OutputMasker):
+        # fortiview policy-hits spells the appliance dev_name inside a
+        # device_info sub-object. Unlisted, it kept the name clear next to a
+        # masked devid on the same row.
+        masked = full_masker.mask_result(
+            {"devid": DEV_NAME, "device_info": {"dev_name": DEV_NAME, "ha_dev": "no"}}
+        )
+
+        assert DEV_NAME not in str(masked)
+        assert masked["device_info"]["dev_name"] == masked["devid"]
+
+    def test_nested_dev_name_stays_clear_with_the_flag_off(self, masker: OutputMasker):
+        masked = masker.mask_result({"device_info": {"dev_name": DEV_NAME}})
+
+        assert masked["device_info"]["dev_name"] == DEV_NAME


### PR DESCRIPTION
Two more allowlist gaps, both older than the Wave-2 work. Found by a different method than the last round, which is the interesting part: instead of reading schemas, I pulled real response payloads from a live 7.6.7 estate and diffed the key names against `FIELD_TYPES`. Two queries were enough to surface these.

The first one is the most serious masking gap I have found in this project so far, and it would have shipped in 2.10.0.

## 1. `srcip_hostname` / `dstip_hostname` hand back the plaintext beside its own token

FortiView `top-sources` and `top-destinations` put the reverse-resolved name for a row's address in these columns, and the address itself again when nothing resolves. Neither key was in either table, so neither was masked.

```
input:  {"dstip": "198.51.100.20", "dstip_hostname": "198.51.100.20"}
before: {"dstip": "<token>",       "dstip_hostname": "198.51.100.20"}
```

That is worse than leaking one value. The reader gets **the token and its plaintext side by side**, which unmasks every other appearance of that address anywhere in the response, and on any other response using the same key.

On the live estate the effect was unmistakable: `dstip_hostname` values sat in the exact provider ranges named by that row's `agg_app`, while `dstip` showed unrelated addresses. The unrelated ones were the tokens.

`IP_OR_HOST`, because the field genuinely holds either form, and it makes the pair agree so nothing is disclosed by the sibling. A test pins that `srcip == srcip_hostname` after masking.

## 2. `assigned_to` / `remedy_executor` / `remedy_approver`

The incidentmgmt workflow slots. They name the same analysts as `reporter` and `lastuser` two keys away, which are already masked as `USERNAME`.

They are **empty on an estate that does not work incidents**, which is precisely why every leak test built from live records missed them. Ours is such an estate; yours may not be.

`EMAIL` rather than `USERNAME`, and I checked this rather than guessing. `EMAIL` is a strict superset here:

```
mask as USERNAME: user-045f-jnhI
mask as EMAIL   : user-045f-jnhI      <- identical
```

With no `@` it falls back to username masking and yields the identical token, so **one analyst keeps one token across all five keys**. With an `@` it masks instead of burning, which `USERNAME` would not. A domain-qualified login (`DOMAIN\user`) is outside both alphabets and still fails closed to a placeholder, which is the right direction and is noted in the code.

## Verification

- **1133 pass on 3.12 and 3.13**, ruff and bandit clean.
- Nine new tests, including one pinning that the resolved-name pair agrees, and one pinning that a single analyst collapses to a single token across all five incident keys.
- **Seven of seven mutants killed.** Two of those are wrong-type mutants rather than missing-key mutants: typing the resolved name `HOSTNAME` instead of `IP_OR_HOST` (breaks the address form), and typing the workflow slots `USERNAME` instead of `EMAIL` (burns `@`-shaped logins). Both are caught.

## Method note

Both of these, and the six in #76, are the same failure: the allowlist was verified against `get_log_fields`, and every other API the tools call speaks a different vocabulary. Nobody has ever diffed live response keys against the table.

I ran that diff properly across FortiView, alerts, incidents and traffic logs, and put the full result in a separate issue rather than expanding this PR. Most of it is genuinely out of scope or a documented residual. These two were the ones worth fixing.
