### PR TITLE
fix(masking): resolve masked groupby1/groupby2 values on the way back in (#81)

### DIFF
--- a/src/fortianalyzer_mcp/masking/unmask.py
+++ b/src/fortianalyzer_mcp/masking/unmask.py
@@ -51,6 +51,7 @@ import re
 from typing import Any
 
 from fortianalyzer_mcp.masking.fields import (
+    COMPOSITE_PREFIXED,
     COMPOSITE_URL_FULL,
     FIELD_TYPES,
     IP,
@@ -196,6 +197,31 @@ class ArgUnmasker:
         prefix = f"{parts.scheme}://" if parts.scheme else "//"
         return f"{prefix}{netloc}{resolved_tail}"
 
+    # -- prefixed group-by values (alert groupby1/groupby2) ---------------- #
+
+    def resolve_prefixed(self, value: str) -> str:
+        """Inverse of ``wrapper._mask_prefixed``.
+
+        The output side masks the inner value of a ``"<fieldname>:<value>"``
+        group-by string by the INNER field's type, so the inverse must too:
+        the outer key (``groupby1``) has no type, so resolving the string as
+        a whole leaves the token untouched and a filter built from it matches
+        zero rows. Split on the first colon only, so an IPv6 inner value
+        keeps its own colons, resolve the value by the inner field's type,
+        and reassemble. Mirrors the mask side's per-element comma handling.
+        """
+        field, sep, raw = value.partition(":")
+        if not sep or not raw:
+            return value
+        vtype = FIELD_TYPES.get(field.lower())
+        if "," in raw:
+            resolved = ",".join(self.resolve_scalar(part, vtype) for part in raw.split(","))
+        else:
+            resolved = self.resolve_scalar(raw, vtype)
+        if resolved == raw:
+            return value
+        return f"{field}{sep}{resolved}"
+
     # -- filter expressions ------------------------------------------------ #
 
     def unmask_filter(self, expression: str) -> str:
@@ -211,6 +237,8 @@ class ArgUnmasker:
             raw = match.group("value")
             if field.lower() in COMPOSITE_URL_FULL:
                 resolved = self.resolve_url(raw)
+            elif field.lower() in COMPOSITE_PREFIXED:
+                resolved = self.resolve_prefixed(raw)
             else:
                 vtype = FIELD_TYPES.get(field.lower())
                 resolved = self.resolve_scalar(raw, vtype)
@@ -246,6 +274,8 @@ class ArgUnmasker:
                 return self.unmask_filter(value)
             if lowered in COMPOSITE_URL_FULL:
                 return self.resolve_url(value)
+            if lowered in COMPOSITE_PREFIXED:
+                return self.resolve_prefixed(value)
             vtype = FIELD_TYPES.get(lowered)
             if vtype in (IP, MAC, IP_OR_HOST):
                 # comma-joined multi-values, same convention as the output side

--- a/tests/test_masking_unmask.py
+++ b/tests/test_masking_unmask.py
@@ -60,6 +60,54 @@ class TestScalarResolution:
         assert unmasker.resolve_scalar("host-###") == "host-###"
 
 
+class TestPrefixedGroupBy:
+    """``groupby1``/``groupby2`` are ``"<field>:<value>"``; the output side
+    masks the inner value by the inner field's type, so the inverse must
+    resolve by that type too, not by the untyped outer key."""
+
+    @pytest.mark.parametrize("outer", ["groupby1", "groupby2"])
+    @pytest.mark.parametrize(
+        ("inner", "raw"),
+        [
+            ("srcip", "192.0.2.102"),  # IP: unmarked token, needs the inner type
+            ("srcip", "2001:db8::1"),  # IPv6: value keeps its own colons
+            ("dstip", "203.0.113.9"),
+            ("qname", "bad.example.com"),  # DOMAIN: marked token
+            ("endpoint", "workstation-14"),  # IP_OR_HOST: hostname form
+        ],
+    )
+    def test_round_trips_through_filter_and_arg(
+        self,
+        masker: OutputMasker,
+        unmasker: ArgUnmasker,
+        outer: str,
+        inner: str,
+        raw: str,
+    ):
+        masked = masker.mask_result({outer: f"{inner}:{raw}"})[outer]
+        assert raw not in masked  # the value half really was masked on output
+
+        assert unmasker.unmask_filter(f'{outer}=="{masked}"') == f'{outer}=="{inner}:{raw}"'
+        assert unmasker.unmask_args({outer: masked})[outer] == f"{inner}:{raw}"
+
+    def test_comma_joined_inner_values_each_resolve(
+        self, masker: OutputMasker, unmasker: ArgUnmasker
+    ):
+        original = "srcip:192.0.2.102,192.0.2.103"
+        masked = masker.mask_result({"groupby1": original})["groupby1"]
+
+        assert unmasker.unmask_args({"groupby1": masked})["groupby1"] == original
+
+    def test_untyped_inner_field_is_left_alone(self, unmasker: ArgUnmasker):
+        # The output side does not mask an untyped inner field, so the
+        # inverse must not transform it either.
+        assert unmasker.resolve_prefixed("action:deny") == "action:deny"
+        assert unmasker.unmask_args({"groupby1": "action:deny"})["groupby1"] == "action:deny"
+
+    def test_a_string_with_no_colon_passes_through(self, unmasker: ArgUnmasker):
+        assert unmasker.resolve_prefixed("no-colon-here") == "no-colon-here"
+
+
 class TestFilterExpressions:
     @pytest.mark.parametrize("op", ["==", "!=", "<=", ">=", "=~", "!~", "~", "="])
     def test_all_operators_resolve_masked_ip(


### PR DESCRIPTION
Closes #81. Off `main`, independent of the open masking PR, so it can land in any order.

## The bug

The output side masks the inner value of a `"<fieldname>:<value>"` group-by string by the **inner** field's type (`wrapper._mask_prefixed`). `ArgUnmasker` had no inverse: it looked up the **outer** key, `groupby1`, which carries no type, so the token reached FAZ unchanged and a filter built from it silently matched zero rows. Same class as the `url` issue #65 closed.

Pre-existing and not specific to any one field. On `main`:

```
srcip   -> masked on output, NOT reversible
dstip   -> masked on output, NOT reversible
qname   -> masked on output, NOT reversible
```

and a live 7.6.7 accepts `groupby1` as a filter field, so the round trip is reachable:

```
get_alerts(filter='groupby1=="dstip:192.0.2.1"')   ->   status success, count 0
```

## The fix

`resolve_prefixed`, the inverse of `_mask_prefixed`:

- `partition(":")` on the first colon only, so an IPv6 inner value keeps its own colons
- resolve the value by the **inner** field's type through the existing `resolve_scalar`
- mirror the mask side's per-element comma handling
- reassemble `field:resolved`

Wired into both the filter path and the direct-argument path, next to the existing `url` composite. An untyped inner field is left untouched, matching the output side which does not mask it either. No new type table, no engine change.

## Independent of the `srcip_hostname` work

The mechanism resolves whatever typed inner field it finds, so the two `*_hostname` keys the open masking PR adds are covered automatically once they land, with no further change here. That PR's note about those two fields "landing in the non-reversible set" is closed by this.

## Verification

- **1136 pass on 3.12 and 3.13**, ruff and bandit clean.
- Ten parametrised round trips (`groupby1` and `groupby2` × IP, IPv6, DOMAIN marked token, `IP_OR_HOST` hostname) plus comma-joined, untyped-inner, and no-colon cases, each asserting the value really was masked on output first.
- **Five of five mutants killed**, including the two that matter: resolving by the outer type (the original bug), and truncating an IPv6 value at its second colon.
