### PR TITLE
fix(masking): the device keep set ignored list-valued keys

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,98 @@
+# Spec: the device-identity keep set ignores list-valued keys
+
+FROZEN SPEC. Implement exactly. If a step is impossible as written, implement the closest
+faithful version and report the deviation. Do not redesign. Do not widen scope.
+
+## Background you need
+
+`src/fortianalyzer_mcp/masking/wrapper.py` has `OutputMasker._device_identity_values(obj)`. It
+walks a tool response and collects every device-identity value into a frozenset called `keep`.
+It runs only when `FAZ_MASK_DEVICE_IDENTITY` is OFF, which is the default.
+
+Its own docstring states the invariant it exists to hold:
+
+    With FAZ_MASK_DEVICE_IDENTITY off these stay readable by design, so any handler that can
+    reach the same value under another key (live 8.0.0 alerts carry the reporting appliance's
+    serial in target[].value) must leave it clear too. Masking it in one place while devid
+    shows it two keys away is not privacy, it is a token-to-serial correlation gift.
+
+`keep` is consulted by `_burn_strings` and `_mask_target`, so a value in `keep` stays clear
+inside a `target` entry instead of being masked or burned.
+
+## The defect
+
+The collector only handles STRING values:
+
+    if key.lower() in DEVICE_IDENTITY_TYPES and isinstance(value, str):
+        out.update(part.strip() for part in value.split(","))
+
+`devs` is a DEVICE_IDENTITY_TYPES key whose live value is a LIST of device names (it appears on
+an eventmgmt alert's `subject_details` as `{alertid, devs, epids, euids}`). A list fails the
+`isinstance(value, str)` test, falls through to the `else: walk(value)` branch, and its elements
+are then visited with no device key in scope, so nothing is collected.
+
+Result, with the flag OFF and a device named ONLY under `devs`: the name stays clear under
+`devs` itself, but the SAME name inside a `target` entry gets masked to a token. That is exactly
+the token-to-name inconsistency the keep set exists to prevent.
+
+Reproduced on current main (RFC placeholders, key `"0"*64`):
+
+    payload {"devs": ["fgt-branch-01"], "target": [{"name": "device", "value": "fgt-branch-01"}]}
+    _device_identity_values(payload)  ->  frozenset()          # empty; should hold the name
+    masked target value               ->  a host- token         # should stay clear
+
+Compare the string-valued sibling, which is correct today:
+
+    payload {"devname": "fgt-branch-01", "target": [{"name": "device", "value": "fgt-branch-01"}]}
+    _device_identity_values(payload)  ->  {"fgt-branch-01"}
+    masked target value               ->  fgt-branch-01         # clear, correct
+
+## What to implement
+
+In `_device_identity_values`, make a DEVICE_IDENTITY_TYPES key whose value is a list or tuple
+contribute each of its STRING elements to the keep set, applying the same comma-splitting and
+`.strip()` already applied to a string value.
+
+Constraints:
+- Change ONLY `_device_identity_values`. Do not touch fields.py, do not touch `_burn_strings`,
+  `_mask_target`, or any other method.
+- Non-string, non-list values under a device key must keep behaving as they do now.
+- Nested containers under a device key (a list of lists, a dict) must not crash. Collect string
+  elements where the shape is a flat list or tuple; anything else may be ignored, but must not
+  raise.
+- The existing COMPOSITE_DEVICE_VDOM branch must keep working unchanged.
+- Match the surrounding style. The file uses `isinstance(x, list | tuple)` elsewhere.
+- Keep the docstring accurate: add one sentence noting that a device key may be list-valued.
+
+## Tests to add
+
+In `tests/test_masking_leak.py`, next to the existing device-identity tests. Use the module's
+existing constants (`DEV_NAME`, `DEV_PEER`, `KEY`) and the existing `masker` fixture, which has
+the device flag OFF.
+
+1. A device named only under `devs` stays clear inside a `target` entry with `name: "device"`.
+2. The same, for a `target` entry under an UNKNOWN name (the burn path): it stays clear rather
+   than becoming a `masked-unrepresentable-` placeholder.
+3. `devs` carrying TWO device names keeps both clear.
+4. A device name under `devs` that does NOT appear in `target` is unaffected (no behaviour
+   change for the ordinary case).
+5. A regression guard: a NON-device string in the same response is still masked normally, so the
+   change did not widen the keep set beyond device keys.
+6. With the device flag ON (`full_masker` fixture), `devs` still masks as before. The keep set is
+   not built at all in that mode, so this must be unchanged.
+
+## Proof
+
+Run and include full output:
+
+    cd /tmp/wtkeep && FORTIANALYZER_HOST=faz.example.test PYTHONPATH=/tmp/wtkeep/src \
+      UV_PROJECT_ENVIRONMENT=/tmp/venv75 uv run --no-sync -p 3.12 \
+      pytest tests/ --ignore=tests/integration -q -p no:cacheprovider
+
+Also run `ruff check src/ tests/` and `ruff format --check src/ tests/` with the same prefix and
+report both. The suite must be green and lint clean. Baseline before your change is 1123 passed.
+
+## Out of scope
+
+Do not add or retype any key in fields.py. Do not change masking behaviour when the flag is ON.
+Do not touch the unmask path. Do not commit anything; I will review the diff and commit.

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -441,14 +441,42 @@ class OutputMasker:
         ``target[].value``) must leave it clear too. Masking it in one
         place while ``devid`` shows it two keys away is not privacy, it is
         a token-to-serial correlation gift.
+
+        A device-identity key may carry a list of names rather than one
+        string: ``devs`` on an alert's ``subject_details`` is list-valued,
+        and until it was handled here a device named only there stayed
+        clear under ``devs`` while the same name masked inside ``target``,
+        which is the pairing this set exists to prevent.
+
+        The comma split applies to the string form ONLY. A string is split
+        because FAZ joins aggregated device names into one value
+        (``fortigate`` on a multi-device fortiview row), and every part is
+        then a device name. A list is already that split form, so
+        splitting its elements again would add nothing and would widen the
+        one hazard this set has: whatever lands in it is exempted from
+        masking inside ``target``, so a value carrying a comma exempts each
+        part independently of whether that part names a device.
         """
         out: set[str] = set()
 
         def walk(node: Any) -> None:
             if isinstance(node, dict):
                 for key, value in node.items():
-                    if key.lower() in DEVICE_IDENTITY_TYPES and isinstance(value, str):
-                        out.update(part.strip() for part in value.split(","))
+                    if key.lower() in DEVICE_IDENTITY_TYPES:
+                        if isinstance(value, str):
+                            out.update(part.strip() for part in value.split(","))
+                        elif isinstance(value, list | tuple):
+                            # String elements are taken whole; anything else
+                            # (a dict nesting devname deeper) is walked, as
+                            # every non-string value already was before the
+                            # list form was handled here.
+                            for item in value:
+                                if isinstance(item, str):
+                                    out.add(item.strip())
+                                else:
+                                    walk(item)
+                        else:
+                            walk(value)
                     elif key.lower() in COMPOSITE_DEVICE_VDOM and isinstance(value, str):
                         for part in value.split(","):
                             match = _DEVVDS_RE.match(part.strip())

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -625,6 +625,118 @@ class TestTargetDeviceIdentityConsistency:
     every other device-identity carrier: half-masked estate identity would
     pair each token with its clear serial two keys away."""
 
+    def test_list_valued_device_stays_clear_in_device_target(self, masker: OutputMasker):
+        masked = masker.mask_result(
+            {"devs": [DEV_NAME], "target": [{"name": "device", "value": DEV_NAME}]}
+        )
+
+        assert masked["target"][0]["value"] == DEV_NAME
+
+    def test_list_valued_device_stays_clear_in_unknown_target(self, masker: OutputMasker):
+        masked = masker.mask_result(
+            {"devs": [DEV_NAME], "target": [{"name": "unknown", "value": DEV_NAME}]}
+        )
+
+        assert masked["target"][0]["value"] == DEV_NAME
+        assert "masked-unrepresentable-" not in masked["target"][0]["value"]
+
+    def test_two_list_valued_devices_stay_clear_in_targets(self, masker: OutputMasker):
+        masked = masker.mask_result(
+            {
+                "devs": [DEV_NAME, DEV_PEER],
+                "target": [
+                    {"name": "device", "value": DEV_NAME},
+                    {"name": "device", "value": DEV_PEER},
+                ],
+            }
+        )
+
+        assert [entry["value"] for entry in masked["target"]] == [DEV_NAME, DEV_PEER]
+
+    def test_list_valued_device_absent_from_target_is_unchanged(self, masker: OutputMasker):
+        masked = masker.mask_result(
+            {"devs": [DEV_NAME], "target": [{"name": "device", "value": DEV_PEER}]}
+        )
+
+        assert masked["devs"] == [DEV_NAME]
+        assert masked["target"][0]["value"] != DEV_PEER
+
+    def test_non_device_value_alongside_device_list_still_masks(self, masker: OutputMasker):
+        masked = masker.mask_result({"devs": [DEV_NAME], "srcname": ENDPOINT_NAME})
+
+        assert masked["devs"] == [DEV_NAME]
+        assert masked["srcname"] != ENDPOINT_NAME
+
+    def test_list_valued_device_still_masks_when_flag_on(self, full_masker: OutputMasker):
+        masked = full_masker.mask_result({"devs": [DEV_NAME]})
+
+        assert masked["devs"][0] != DEV_NAME
+
+    def test_a_comma_inside_a_list_element_is_not_split(self, masker: OutputMasker):
+        """The split is for the string form only, and deliberately so.
+
+        Whatever lands in the keep set is exempted from masking inside
+        ``target``, so splitting exempts each part on its own. A string has
+        to be split because FAZ joins aggregated device names into one
+        value; a list is already that split form, so splitting its elements
+        would widen the exemption for nothing.
+        """
+        analyst = "analyst-example"
+        masked = masker.mask_result(
+            {
+                "devs": [f"{DEV_NAME},{analyst}"],
+                "target": [{"name": "user", "value": analyst}],
+            }
+        )
+
+        assert masked["target"][0]["value"] != analyst
+
+    def test_whitespace_around_a_list_element_is_stripped(self, masker: OutputMasker):
+        """The string branch strips; the list branch must agree.
+
+        Without it, a name padded by the appliance fails the exact-string
+        match and the same device masks in ``target`` while staying clear
+        under ``devs``, which is the inconsistency this set exists to close.
+        """
+        masked = masker.mask_result(
+            {
+                "devs": [f"  {DEV_NAME}  "],
+                "target": [{"name": "device", "value": DEV_NAME}],
+            }
+        )
+
+        assert masked["target"][0]["value"] == DEV_NAME
+
+    def test_a_non_string_list_element_is_not_admitted(self, masker: OutputMasker):
+        """Whatever enters the keep set is exempted from masking.
+
+        Stringifying arbitrary elements would let a bare id exempt any
+        ``target`` value that happens to render the same way, so only real
+        string names are collected.
+        """
+        masked = masker.mask_result(
+            {"devs": [1305], "target": [{"name": "device", "value": "1305"}]}
+        )
+
+        assert masked["target"][0]["value"] != "1305"
+
+    def test_a_dict_nested_in_a_list_element_is_still_walked(self, masker: OutputMasker):
+        """A non-string list element keeps its device-identity keys.
+
+        Before lists were handled here they fell through to the recursive
+        walk, so ``devs: [{"devname": ...}]`` contributed the nested name.
+        The list branch must not cut that path off: it takes string
+        elements whole and walks the rest.
+        """
+        masked = masker.mask_result(
+            {
+                "devs": [{"devname": DEV_NAME}],
+                "target": [{"name": "device", "value": DEV_NAME}],
+            }
+        )
+
+        assert masked["target"][0]["value"] == DEV_NAME
+
     def test_estate_serial_in_target_stays_clear_when_flag_off(self, masker: OutputMasker):
         masked = masker.mask_result(ALERT)
         entry = masked["target"][4]


### PR DESCRIPTION
Found during the review of #79, and it is in code I merged myself in #76.

## The bug

`_device_identity_values` pre-collects device-identity values so a name left readable under `devname` is not masked somewhere else in the same response. Its own docstring states why:

> Masking it in one place while `devid` shows it two keys away is not privacy, it is a token-to-serial correlation gift.

It only ever handled string values. `devs`, which #76 added to `DEVICE_IDENTITY_TYPES`, is **list-valued** on a live alert's `subject_details`, so it failed the `isinstance(value, str)` check, fell through to the generic walk, and contributed nothing to the keep set.

With the flag off, a device named only under `devs`:

```
subject_details.devs : ["fgt-branch-01"]                      (clear, correct)
target[].value       : "host-045f-qwphpgyzte6q.yrm"           (masked)
```

Clear under one key, a token under another, same record. That is exactly the pairing the keep set exists to prevent. CI could not have caught it and neither could my #76 mutation tests, because it is not a leak: it masks *more*, not less. It only shows up if you ask whether the two paths agree.

## The fix

Handle a list or tuple value: collect each string element into the keep set.

The comma split stays on the **string** form only, and that asymmetry is deliberate. A string is split because FAZ joins aggregated device names into one value (`fortigate` on a multi-device fortiview row), so every part is a device name. A list is already that split form, and splitting its elements again would widen the one hazard this set has: whatever lands in it is *exempted* from masking inside `target`, so a value carrying a comma would exempt each part whether or not it names a device. A test pins that a comma inside a list element is not split.

## Verification

- **1132 pass on 3.12 and 3.13**, ruff clean.
- Nine tests, including both sides of the flag and a regression guard that a non-device string is still masked.
- **Five of five mutants killed**: reverting the list branch (the original defect), dropping tuple support, restoring the comma split on list elements, dropping `.strip()`, and admitting non-string elements into the exemption set.

Independent of the other open PRs; touches only `_device_identity_values`.
