### PR TITLE
fix(fortiview): drop three view names FortiAnalyzer does not serve

### DIFF
--- a/src/fortianalyzer_mcp/tools/fortiview_tools.py
+++ b/src/fortianalyzer_mcp/tools/fortiview_tools.py
@@ -73,9 +73,6 @@ async def run_fortiview(
             - "top-cloud-applications": Top cloud/SaaS apps
             - "policy-hits": Per-policy hit counts (recommended)
             - "policy-line": Time-series policy data
-            - "traffic-summary": Overall traffic summary
-            - "fortiview-traffic": Detailed traffic view
-            - "fortiview-threats": Threat analysis view
         adom: ADOM name (default: from config DEFAULT_ADOM)
         device: Device filter (serial number or name, optional)
         time_range: Time range. Options:

--- a/src/fortianalyzer_mcp/utils/validation.py
+++ b/src/fortianalyzer_mcp/utils/validation.py
@@ -156,7 +156,11 @@ VALID_LOG_TYPES = {
     "virtual-patch",
 }
 
-# FortiView view names
+# FortiView view names. Every name here is one FortiAnalyzer actually serves:
+# "traffic-summary", "fortiview-traffic" and "fortiview-threats" used to be
+# listed too, and all three answer "Cannot find FortiView '<name>'" on both
+# 7.6.7 and 8.0.0. Accepting them only moved the failure from a clear local
+# validation error to a server error one call later.
 VALID_FORTIVIEW_VIEWS = {
     "top-sources",
     "top-destinations",
@@ -166,9 +170,6 @@ VALID_FORTIVIEW_VIEWS = {
     "top-cloud-applications",
     "policy-hits",  # Per-policy hit counts (correct endpoint)
     "policy-line",  # Time-series policy data
-    "traffic-summary",
-    "fortiview-traffic",
-    "fortiview-threats",
 }
 
 # Severity levels

--- a/tests/test_fortiview_tools.py
+++ b/tests/test_fortiview_tools.py
@@ -7,6 +7,11 @@ Follows the same pattern as test_system_tools.py to avoid server initialization.
 import pytest
 
 from fortianalyzer_mcp.api.client import FortiAnalyzerClient
+from fortianalyzer_mcp.utils.validation import (
+    VALID_FORTIVIEW_VIEWS,
+    ValidationError,
+    validate_fortiview_view,
+)
 
 
 class TestFortiViewHelpers:
@@ -162,8 +167,8 @@ class TestFortiViewViews:
     """Tests for different FortiView view names."""
 
     def test_valid_view_names(self) -> None:
-        """Test valid FortiView view name patterns."""
-        valid_views = [
+        """Every advertised view name is one the validator accepts."""
+        assert VALID_FORTIVIEW_VIEWS == {
             "top-sources",
             "top-destinations",
             "top-applications",
@@ -171,12 +176,17 @@ class TestFortiViewViews:
             "top-threats",
             "top-cloud-applications",
             "policy-hits",
-            "traffic-summary",
-            "fortiview-traffic",
-            "fortiview-threats",
-        ]
+            "policy-line",
+        }
+        for view in VALID_FORTIVIEW_VIEWS:
+            assert validate_fortiview_view(view) == view
 
-        for view in valid_views:
-            # All valid views should be strings and start with expected prefixes
-            assert isinstance(view, str)
-            assert view.startswith(("top-", "policy-", "traffic-", "fortiview-"))
+    @pytest.mark.parametrize("view", ["traffic-summary", "fortiview-traffic", "fortiview-threats"])
+    def test_views_faz_does_not_serve_are_rejected(self, view: str) -> None:
+        """FortiAnalyzer answers "Cannot find FortiView" for these on 7.6 and 8.0.
+
+        The old list accepted them, so the caller got a server error one round
+        trip later instead of a validation error naming the views that work.
+        """
+        with pytest.raises(ValidationError, match="Invalid FortiView view"):
+            validate_fortiview_view(view)


### PR DESCRIPTION
## What

`VALID_FORTIVIEW_VIEWS` accepted three view names that FortiAnalyzer does not serve: `traffic-summary`, `fortiview-traffic` and `fortiview-threats`. The `run_fortiview` docstring advertised all three as well.

## Why it matters

The allowlist exists so a bad view name fails locally with a message naming the views that work. For these three it did the opposite: validation passed, the call went out, and FortiAnalyzer answered `Cannot find FortiView '<name>'`. A model reading the docstring had every reason to pick one of them.

## Verification

I ran every name in the allowlist against both lab versions.

| view | 7.6.7 | 8.0.0 |
|---|---|---|
| top-sources, top-destinations, top-applications, top-websites, top-threats, top-cloud-applications, policy-hits, policy-line | TID returned | TID returned (spot-checked top-sources) |
| traffic-summary | `Cannot find FortiView` | `Cannot find FortiView` |
| fortiview-traffic | `Cannot find FortiView` | `Cannot find FortiView` |
| fortiview-threats | `Cannot find FortiView` | `Cannot find FortiView` |

Checked on both versions on purpose: a name dead on 7.6 but live on 8.0 would make removal a regression. None of the three is live on either.

## Tests

The old `test_valid_view_names` walked a hardcoded list and asserted each entry was a string starting with `top-`, `policy-`, `traffic-` or `fortiview-`. It never called the validator, so it would have passed against any allowlist at all.

Replaced with:

- `test_valid_view_names` pins the allowlist contents and runs each name through `validate_fortiview_view`.
- `test_views_faz_does_not_serve_are_rejected` asserts the three removed names now raise.

Mutation check, both killed:

- re-adding `traffic-summary` to the allowlist: 2 failed
- making `validate_fortiview_view` a no-op: 5 failed

1123 pass on 3.12 and 3.13, same as main (the three removed names also drop three parametrized cases in `test_validation.py`, which the three new cases replace). ruff, ruff format and mypy clean.

## Scope

No masking code touched. Independent of #77, #78, #79, #82 and #83.
