### PR TITLE
fix(fortiview): cloud-apps default sort was a non-existent column

### DIFF
--- a/src/fortianalyzer_mcp/tools/fortiview_tools.py
+++ b/src/fortianalyzer_mcp/tools/fortiview_tools.py
@@ -556,18 +556,27 @@ async def get_top_cloud_applications(
     device: str | None = None,
     time_range: str = "1-hour",
     limit: int = 10,
-    sort_by: str = "bandwidth",
+    sort_by: str = "sessions",
 ) -> dict[str, Any]:
-    """Get top cloud/SaaS applications.
+    """Get top cloud/SaaS applications (Shadow IT view).
 
     Returns the most used cloud and SaaS applications.
+
+    Note: this view has no ``bandwidth`` column — its byte columns are
+    ``total_size``/``upload_size``/``download_size``, and those are
+    **always 0** because FortiGate app-ctrl logs carry no byte counts (a
+    known FortiOS logging limitation). So the default sort is ``sessions``
+    (usage), not bytes; ``d_risk`` (risk score) is the other useful sort.
+    Sorting by a non-existent column (e.g. ``bandwidth``) raises a
+    FortiAnalyzer DB error, so stick to columns this view actually has:
+    ``sessions``, ``d_risk``, ``num_loginids``, ``total_size`` (0).
 
     Args:
         adom: ADOM name (default: from config DEFAULT_ADOM)
         device: Device filter (serial number or name, optional)
         time_range: Time range (default: "1-hour")
         limit: Number of top cloud apps to return (default: 10)
-        sort_by: Sort field (default: "bandwidth")
+        sort_by: Sort field (default: "sessions"; "d_risk" also useful)
 
     Returns:
         dict with top cloud applications data

--- a/tests/test_fortiview_tools.py
+++ b/tests/test_fortiview_tools.py
@@ -193,3 +193,25 @@ class TestFortiViewViews:
         """
         with pytest.raises(ValidationError, match="Invalid FortiView view"):
             validate_fortiview_view(view)
+
+
+class TestCloudApplicationsSortDefault:
+    """The Shadow-IT cloud-apps view has no ``bandwidth`` column (its byte
+    columns are ``total_size``/... and always 0 — FGT app-ctrl logs carry no
+    bytes). Sorting by ``bandwidth`` raised a FAZ ``Missing columns`` DB
+    error, so the default must be a real, populated column."""
+
+    async def test_default_sort_is_sessions_not_bandwidth(self) -> None:
+        from unittest.mock import patch
+
+        from fortianalyzer_mcp.tools.fortiview_tools import get_top_cloud_applications
+
+        with patch(
+            "fortianalyzer_mcp.tools.fortiview_tools.get_fortiview_data",
+            autospec=True,
+            return_value={"status": "success", "data": []},
+        ) as gfd:
+            await get_top_cloud_applications()
+        assert gfd.call_args.kwargs["view_name"] == "top-cloud-applications"
+        assert gfd.call_args.kwargs["sort_by"] == "sessions"
+        assert gfd.call_args.kwargs["sort_by"] != "bandwidth"


### PR DESCRIPTION
`get_top_cloud_applications` defaulted `sort_by='bandwidth'`, but that view has no `bandwidth` column, so FAZ returned `Missing columns: 'bandwidth'` and `app_usage`'s cloud section broke.

Root cause is layered:
- **FGT-side (known, unfixed):** app-ctrl logs carry no byte counts, so the cloud-app byte columns (`total_size`/`upload_size`/`download_size`) are always 0. Bandwidth for cloud apps is unavailable at the source.
- **Ours:** we sorted by `bandwidth`, which isn't even a column on this view (the GUI sorts by `d_risk`). Sorting by a non-existent column is a hard DB error.

Fix: default `sort_by` → `sessions` (real, populated column). Docstring documents the byte gap. Live-verified on 7.6.7 and 8.0.0 (returns Github/SSL/iCloud... ranked by sessions). Also un-breaks `app_usage`'s cloud section.