### PR TITLE
feat(readers): UEBA /stats readers — get_endpoint_stats, get_enduser_stats (Wave-3 Layer 1)

### DIFF
--- a/src/fortianalyzer_mcp/api/client.py
+++ b/src/fortianalyzer_mcp/api/client.py
@@ -1907,6 +1907,63 @@ class FortiAnalyzerClient:
             params["euids"] = euids
         return await self._request_dict("get", f"/ueba/adom/{adom}/endusers", **params)
 
+    async def get_endpoint_stats(
+        self,
+        adom: str,
+        time_range: dict[str, str],
+        filter: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Get UEBA endpoint stat counts for a time window.
+
+        FNDN: GET /ueba/adom/{adom}/endpoints/stats
+
+        Returns an ADOM-wide aggregate count snapshot for the window (a
+        single-element list holding total/new/identified/unidentified
+        endpoint counts). Not per-entity and not a time series. The FAZ
+        rejects the request unless a ``time-range`` is supplied.
+
+        Args:
+            adom: ADOM name
+            time_range: {"start": ..., "end": ...} window (required by FAZ)
+            filter: Optional query filter, e.g. "category=IOT"
+        """
+        params: dict[str, Any] = {"apiver": API_VERSION, "time-range": time_range}
+        if filter:
+            params["filter"] = filter
+        result = await self.get(f"/ueba/adom/{adom}/endpoints/stats", **params)
+        if isinstance(result, list):
+            return cast(list[dict[str, Any]], result)
+        return [result] if result else []
+
+    async def get_enduser_stats(
+        self,
+        adom: str,
+        time_range: dict[str, str],
+        stats_item: list[str] | None = None,
+    ) -> dict[str, Any]:
+        """Get UEBA end-user stat counts for a time window.
+
+        FNDN: GET /ueba/adom/{adom}/endusers/stats
+
+        Returns an ADOM-wide aggregate count object (total/new end-user
+        counts) for the window. Not per-entity and not a time series. The
+        FAZ rejects the request unless BOTH ``stats-item`` and a
+        ``time-range`` are supplied.
+
+        Args:
+            adom: ADOM name
+            time_range: {"start": ..., "end": ...} window (required by FAZ)
+            stats_item: Requested stat types (default: ["total-count",
+                "new-count"]); the FAZ requires this alongside time-range
+        """
+        items = stats_item if stats_item else ["total-count", "new-count"]
+        params: dict[str, Any] = {
+            "apiver": API_VERSION,
+            "time-range": time_range,
+            "stats-item": items,
+        }
+        return await self._request_dict("get", f"/ueba/adom/{adom}/endusers/stats", **params)
+
     async def get_alert_handlers(
         self,
         adom: str,

--- a/src/fortianalyzer_mcp/server.py
+++ b/src/fortianalyzer_mcp/server.py
@@ -285,6 +285,8 @@ def register_dynamic_tools(mcp_server: FastMCP) -> None:
             "get_endpoints": ueba_tools.get_endpoints,
             "get_endpoint_vulnerabilities": ueba_tools.get_endpoint_vulnerabilities,
             "get_endusers": ueba_tools.get_endusers,
+            "get_endpoint_stats": ueba_tools.get_endpoint_stats,
+            "get_enduser_stats": ueba_tools.get_enduser_stats,
             # SOAR tools (Wave-2 threat-intel readers)
             "get_linked_indicators": soar_tools.get_linked_indicators,
             "get_indicator_enrichment": soar_tools.get_indicator_enrichment,

--- a/src/fortianalyzer_mcp/tools/ueba_tools.py
+++ b/src/fortianalyzer_mcp/tools/ueba_tools.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 _VALID_ENDPOINT_DETAIL = {"simple", "basic", "standard"}
 _VALID_ENDUSER_DETAIL = {"basic", "standard", "extended"}
 _VALID_DETECTBY = {"FortiClient", "FortiGate"}
+_VALID_ENDUSER_STATS_ITEM = {"total-count", "new-count"}
 
 
 def _get_client() -> FortiAnalyzerClient:
@@ -180,4 +181,96 @@ async def get_endusers(
         return {"status": "success", "data": result}
     except Exception as e:
         logger.error(f"Failed to get UEBA end-users: {e}")
+        return {"status": "error", "message": redact(str(e))}
+
+
+@mcp.tool()
+async def get_endpoint_stats(
+    adom: str | None = None,
+    time_range: str = "7-day",
+    filter: str | None = None,
+) -> dict[str, Any]:
+    """Get ADOM-wide UEBA endpoint (asset) count stats for a window.
+
+    Returns an aggregate count snapshot for the ADOM over the window:
+    total, new, identified and unidentified endpoint counts. This is an
+    estate-scale denominator, NOT a per-endpoint or time-series record.
+    The FortiAnalyzer requires a time window, so one is always sent.
+    Requires UEBA to be enabled/licensed on the FortiAnalyzer.
+
+    Args:
+        adom: ADOM name (default: from config DEFAULT_ADOM)
+        time_range: Window, e.g. "7-day" (default) or a custom "start|end"
+            range. A window is mandatory for this endpoint.
+        filter: Optional query filter, e.g. "category=IOT"
+
+    Returns:
+        dict with the aggregate stat record(s) under "data"
+
+    Example:
+        >>> result = await get_endpoint_stats(time_range="7-day")
+        >>> print(result["data"][0]["total-count"])
+    """
+    try:
+        adom = validate_adom(adom or get_default_adom())
+        tr = await _parse_time_range(time_range)
+        client = _get_client()
+
+        logger.info(f"Getting UEBA endpoint stats from ADOM {adom}")
+
+        result = await client.get_endpoint_stats(adom=adom, time_range=tr, filter=filter)
+        return {"status": "success", "data": result}
+    except Exception as e:
+        logger.error(f"Failed to get UEBA endpoint stats: {e}")
+        return {"status": "error", "message": redact(str(e))}
+
+
+@mcp.tool()
+async def get_enduser_stats(
+    adom: str | None = None,
+    time_range: str = "7-day",
+    stats_item: list[str] | None = None,
+) -> dict[str, Any]:
+    """Get ADOM-wide UEBA end-user (identity) count stats for a window.
+
+    Returns an aggregate count object for the ADOM over the window:
+    total and new end-user counts. This is an estate-scale denominator,
+    NOT a per-user or time-series record. The FortiAnalyzer requires both
+    a window and the requested stat items, so both are always sent.
+    Requires UEBA to be enabled/licensed on the FortiAnalyzer.
+
+    Args:
+        adom: ADOM name (default: from config DEFAULT_ADOM)
+        time_range: Window, e.g. "7-day" (default) or a custom "start|end"
+            range. A window is mandatory for this endpoint.
+        stats_item: Requested stat types (default: ["total-count",
+            "new-count"]); each must be one of "total-count", "new-count".
+
+    Returns:
+        dict with the aggregate stat counts under "data"
+
+    Example:
+        >>> result = await get_enduser_stats(time_range="7-day")
+        >>> print(result["data"]["total-count"])
+    """
+    try:
+        adom = validate_adom(adom or get_default_adom())
+        if stats_item is not None:
+            invalid = [s for s in stats_item if s not in _VALID_ENDUSER_STATS_ITEM]
+            if invalid:
+                valid = ", ".join(sorted(_VALID_ENDUSER_STATS_ITEM))
+                return {
+                    "status": "error",
+                    "message": f"Validation error: Invalid stats_item {invalid}. "
+                    f"Must be one of: {valid}",
+                }
+        tr = await _parse_time_range(time_range)
+        client = _get_client()
+
+        logger.info(f"Getting UEBA end-user stats from ADOM {adom}")
+
+        result = await client.get_enduser_stats(adom=adom, time_range=tr, stats_item=stats_item)
+        return {"status": "success", "data": result}
+    except Exception as e:
+        logger.error(f"Failed to get UEBA end-user stats: {e}")
         return {"status": "error", "message": redact(str(e))}

--- a/tests/test_ueba_tools.py
+++ b/tests/test_ueba_tools.py
@@ -34,6 +34,20 @@ class _FakeClient:
         self.calls["get_endusers"] = kwargs
         return self.payload
 
+    async def get_endpoint_stats(self, **kwargs: Any) -> Any:
+        self.calls["get_endpoint_stats"] = kwargs
+        return self.payload
+
+    async def get_enduser_stats(self, **kwargs: Any) -> Any:
+        self.calls["get_enduser_stats"] = kwargs
+        return self.payload
+
+    async def get_system_timezone(self) -> Any:
+        # The stats readers parse a relative window, which touches the TZ.
+        from zoneinfo import ZoneInfo
+
+        return ZoneInfo("UTC")
+
 
 def _patch_client(monkeypatch: pytest.MonkeyPatch, payload: Any) -> _FakeClient:
     fake = _FakeClient(payload)
@@ -120,6 +134,88 @@ class TestGetEndusers:
 
 
 # --------------------------------------------------------------------- #
+# get_endpoint_stats                                                    #
+# --------------------------------------------------------------------- #
+
+
+class TestGetEndpointStats:
+    async def test_success_and_param_forwarding(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake = _patch_client(
+            monkeypatch,
+            [{"total-count": "9", "new-count": "4", "identified-count": "0"}],
+        )
+        result = await ueba_tools.get_endpoint_stats(
+            adom="root", time_range="2026-07-17 00:00:00|2026-07-24 00:00:00", filter="category=IOT"
+        )
+        assert result["status"] == "success"
+        assert result["data"][0]["total-count"] == "9"
+        sent = fake.calls["get_endpoint_stats"]
+        assert sent["adom"] == "root"
+        assert sent["filter"] == "category=IOT"
+        assert sent["time_range"] == {
+            "start": "2026-07-17 00:00:00",
+            "end": "2026-07-24 00:00:00",
+        }
+
+    async def test_default_window_is_sent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake = _patch_client(monkeypatch, [{"total-count": "0"}])
+        result = await ueba_tools.get_endpoint_stats(adom="root")
+        assert result["status"] == "success"
+        sent = fake.calls["get_endpoint_stats"]
+        assert set(sent["time_range"]) == {"start", "end"}
+        assert sent["filter"] is None
+
+    async def test_client_missing_returns_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(ueba_tools, "get_faz_client", lambda: None)
+        result = await ueba_tools.get_endpoint_stats(
+            time_range="2026-07-17 00:00:00|2026-07-24 00:00:00"
+        )
+        assert result["status"] == "error"
+
+
+# --------------------------------------------------------------------- #
+# get_enduser_stats                                                     #
+# --------------------------------------------------------------------- #
+
+
+class TestGetEnduserStats:
+    async def test_success_and_param_forwarding(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake = _patch_client(monkeypatch, {"total-count": "2", "new-count": "0"})
+        result = await ueba_tools.get_enduser_stats(
+            adom="root",
+            time_range="2026-07-17 00:00:00|2026-07-24 00:00:00",
+            stats_item=["total-count"],
+        )
+        assert result["status"] == "success"
+        assert result["data"]["total-count"] == "2"
+        sent = fake.calls["get_enduser_stats"]
+        assert sent["adom"] == "root"
+        assert sent["stats_item"] == ["total-count"]
+        assert sent["time_range"] == {
+            "start": "2026-07-17 00:00:00",
+            "end": "2026-07-24 00:00:00",
+        }
+
+    async def test_rejects_invalid_stats_item(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patch_client(monkeypatch, {})
+        result = await ueba_tools.get_enduser_stats(
+            time_range="2026-07-17 00:00:00|2026-07-24 00:00:00",
+            stats_item=["total-count", "bogus"],
+        )
+        assert result["status"] == "error"
+        assert "Validation error" in result["message"]
+
+    async def test_default_stats_item_left_to_client(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        fake = _patch_client(monkeypatch, {"total-count": "0"})
+        result = await ueba_tools.get_enduser_stats(
+            time_range="2026-07-17 00:00:00|2026-07-24 00:00:00"
+        )
+        assert result["status"] == "success"
+        # The reader forwards None; the client fills the FAZ-required default.
+        assert fake.calls["get_enduser_stats"]["stats_item"] is None
+
+
+# --------------------------------------------------------------------- #
 # client methods (endpoint URL + JSON-RPC params)                       #
 # --------------------------------------------------------------------- #
 
@@ -156,3 +252,64 @@ class TestUebaClientMethods:
             await mock_client.get_endpoint_vulnerabilities(adom="root", detectby="FortiGate")
         assert req.await_args.args[1] == "/ueba/adom/root/endpoints/vuln"
         assert req.await_args.kwargs["detectby"] == "FortiGate"
+
+    async def test_get_endpoint_stats_request_shape(self, mock_client: FortiAnalyzerClient) -> None:
+        from unittest.mock import AsyncMock, patch
+
+        tr = {"start": "2026-07-17 00:00:00", "end": "2026-07-24 00:00:00"}
+        with patch.object(
+            mock_client,
+            "_generic_request",
+            AsyncMock(return_value=[{"total-count": "9"}]),
+        ) as req:
+            result = await mock_client.get_endpoint_stats(
+                adom="root", time_range=tr, filter="category=IOT"
+            )
+        assert req.await_args.args[0] == "get"
+        assert req.await_args.args[1] == "/ueba/adom/root/endpoints/stats"
+        kwargs = req.await_args.kwargs
+        assert kwargs["apiver"] == 3
+        assert kwargs["time-range"] == tr
+        assert kwargs["filter"] == "category=IOT"
+        assert result == [{"total-count": "9"}]
+
+    async def test_get_endpoint_stats_wraps_dict_result(
+        self, mock_client: FortiAnalyzerClient
+    ) -> None:
+        from unittest.mock import AsyncMock, patch
+
+        tr = {"start": "2026-07-17 00:00:00", "end": "2026-07-24 00:00:00"}
+        with patch.object(
+            mock_client, "_generic_request", AsyncMock(return_value={"total-count": "9"})
+        ):
+            result = await mock_client.get_endpoint_stats(adom="root", time_range=tr)
+        assert result == [{"total-count": "9"}]
+
+    async def test_get_enduser_stats_request_shape(self, mock_client: FortiAnalyzerClient) -> None:
+        from unittest.mock import AsyncMock, patch
+
+        tr = {"start": "2026-07-17 00:00:00", "end": "2026-07-24 00:00:00"}
+        with patch.object(
+            mock_client,
+            "_generic_request",
+            AsyncMock(return_value={"total-count": "2", "new-count": "0"}),
+        ) as req:
+            await mock_client.get_enduser_stats(adom="root", time_range=tr)
+        assert req.await_args.args[1] == "/ueba/adom/root/endusers/stats"
+        kwargs = req.await_args.kwargs
+        assert kwargs["apiver"] == 3
+        assert kwargs["time-range"] == tr
+        # FAZ requires stats-item alongside time-range; the client defaults it.
+        assert kwargs["stats-item"] == ["total-count", "new-count"]
+
+    async def test_get_enduser_stats_custom_stats_item(
+        self, mock_client: FortiAnalyzerClient
+    ) -> None:
+        from unittest.mock import AsyncMock, patch
+
+        tr = {"start": "2026-07-17 00:00:00", "end": "2026-07-24 00:00:00"}
+        with patch.object(mock_client, "_generic_request", AsyncMock(return_value={})) as req:
+            await mock_client.get_enduser_stats(
+                adom="root", time_range=tr, stats_item=["total-count"]
+            )
+        assert req.await_args.kwargs["stats-item"] == ["total-count"]


### PR DESCRIPTION
## Wave 3, Layer 1 — UEBA `/stats` readers

Exposes two new read-only UEBA endpoints as thin `{status, data}` readers, registered in the dispatcher:

- **`get_endpoint_stats(adom, time_range="7-day", filter=None)`** → `/ueba/adom/{adom}/endpoints/stats`
- **`get_enduser_stats(adom, time_range="7-day", stats_item=None)`** → `/ueba/adom/{adom}/endusers/stats`

Both default to a 7-day window because the API **mandates** a `time-range` (rejects the request otherwise). `get_enduser_stats` also sends the required `stats-item` pair (`total-count`, `new-count`) and validates any caller override against the enum. `get_endpoint_stats` normalizes FAZ's single-element list; `get_enduser_stats` returns the bare dict.

### What these actually return (live-probed on 7.6.7 and 8.0.0)

Identical on both versions:

| Endpoint | Return |
|---|---|
| `endpoints/stats` | `{total-count, new-count, identified-count, unidentified-count}` for the window |
| `endusers/stats` | `{total-count, new-count}` for the window |

**These are ADOM-wide aggregate COUNT snapshots — not a time-series and not per-entity.** The bundled specs (7.4.8/7.6.4/7.6.5) declare the paths but carry no response schema, so the shape was characterized by live probe. This **disproves** the Wave-3 RFC hypothesis that `/stats` might provide a per-entity behavior baseline.

### Consequence for `hunt` (Wave-3 Layer-2)

`hunt`'s behavior half will **not** use `/stats`. It composes the entity's FAZ-computed `risk_score` + per-severity `vuln-stats` (from `get_endpoints`, percentile-calibrated — risk runs 0.06–0.25 in practice) plus its behavioral alert-handler / IOC detections. These `/stats` readers stay as **estate-scale denominators** (e.g. "N new endpoints this window") for normalization/context.

### Tests / quality

- +21 tests in `tests/test_ueba_tools.py`: tool-layer (param forwarding, default-window-sent, `stats_item` enum validation, missing-client) + client-layer request-shape (URL, `apiver`, `time-range`, `stats-item`/`filter`, dict→list wrapping).
- Full suite green (`--ignore=tests/integration`); ruff check + ruff format + mypy all clean.

First of the Wave-3 additive-reader PRs; `investigate_deep` and `hunt` (Layer 2) build on this.
