### PR TITLE
feat(skills): investigate_deep — reactive root-cause + impact (Wave-3 Layer 2)

### DIFF
--- a/src/fortianalyzer_mcp/skills/catalog.py
+++ b/src/fortianalyzer_mcp/skills/catalog.py
@@ -19,6 +19,8 @@ from fortianalyzer_mcp.skills.models import (
     AppUsageResult,
     AssetLookupParams,
     AssetLookupResult,
+    DeepInvestigateParams,
+    DeepInvestigation,
     IdentityLookupParams,
     IdentityLookupResult,
     IdentityProfileParams,
@@ -198,6 +200,19 @@ SKILLS: dict[str, SkillSpec] = {
             params_model=InvestigateParams,
             output_model=Investigation,
             handler=handlers.run_investigate,
+        ),
+        SkillSpec(
+            id="investigate_deep",
+            tier="analysis",
+            description="Deep reactive investigation of one alert/incident (or a "
+            "forward-only entity): the investigate bundle, plus a backward "
+            "root-cause chain time-ordered to the earliest signal (deterministic, "
+            "no attribution) and a forward blast-radius of lateral log activity + "
+            "affected assets per traced entity. The forward pass consumes one "
+            "logview search slot per entity×logtype, hard-capped and windowed.",
+            params_model=DeepInvestigateParams,
+            output_model=DeepInvestigation,
+            handler=handlers.run_investigate_deep,
         ),
     )
 }

--- a/src/fortianalyzer_mcp/skills/handlers.py
+++ b/src/fortianalyzer_mcp/skills/handlers.py
@@ -34,11 +34,15 @@ from fortianalyzer_mcp.skills.models import (
     AssetLookupParams,
     AssetLookupResult,
     AssetRecord,
+    DeepInvestigateParams,
+    DeepInvestigation,
+    EntityImpact,
     FeatureGap,
     IdentityLookupParams,
     IdentityLookupResult,
     IdentityProfileParams,
     IdentityProfileResult,
+    Impact,
     IncidentRecord,
     IncidentsParams,
     IncidentsResult,
@@ -56,6 +60,8 @@ from fortianalyzer_mcp.skills.models import (
     RiskAssessmentParams,
     RiskAssessmentResult,
     RiskDimension,
+    RootCause,
+    RootCauseEvent,
     ThreatIntelParams,
     ThreatIntelResult,
     TimelineEntry,
@@ -2082,5 +2088,459 @@ async def run_investigate(params: InvestigateParams) -> Investigation:
         assets=assets,
         identities=identities,
         time_range=params.time_range,
+        warnings=warnings,
+    )
+
+
+# --------------------------------------------------------------------- #
+# investigate_deep (Wave 3)                                             #
+# --------------------------------------------------------------------- #
+
+# Forward lateral searches consume logview slots and per
+# [[feedback_real_world_test_window]] must stay bounded; a window wider
+# than a week is capped here (custom start|end ranges are the caller's
+# explicit intent and pass through). Reuses _WINDOW_RANK above.
+_DEEP_MAX_WINDOW = "7-day"
+
+
+def _cap_window(time_range: str) -> tuple[str, bool]:
+    """Cap a preset window at ``_DEEP_MAX_WINDOW``; report whether it was capped.
+
+    Custom ``start|end`` ranges and unrecognized tokens pass through
+    unchanged (the caller owns them); a preset wider than the floor is
+    narrowed to the floor.
+    """
+    if "|" in time_range:
+        return time_range, False
+    requested = _WINDOW_RANK.get(time_range)
+    if requested is None or requested <= _WINDOW_RANK[_DEEP_MAX_WINDOW]:
+        return time_range, False
+    return _DEEP_MAX_WINDOW, True
+
+
+def _root_cause_chain(triage: TriageResult) -> RootCause | FeatureGap:
+    """Backward chain to the earliest signal, from timestamped records only.
+
+    Deterministic and verbatim-sourced: every event is the incident/alert
+    subject, a related alert, or a triggering-log row the subject already
+    carries. Ordering is by timestamp (via ``_sort_key``); there is no
+    attribution or inferred causality — only the time ordering. Records
+    without a usable timestamp are dropped (they cannot be placed on the
+    chain), never guessed at.
+    """
+    events: list[RootCauseEvent] = []
+
+    subject = triage.subject
+    subj_ts = subject.get("timestamp") or subject.get("createtime") or subject.get("alerttime")
+    if subj_ts is not None:
+        if triage.subject_type == "incident":
+            ref = str(subject.get("incid") or "?")
+            desc = (
+                f"incident {ref}: {subject.get('name') or subject.get('description') or 'created'}"
+            )
+            events.append(
+                RootCauseEvent(
+                    timestamp=subj_ts, source="incident", reference=ref, description=desc
+                )
+            )
+        else:
+            ref = str(subject.get("alertid") or "?")
+            desc = f"alert {ref}: {subject.get('name') or subject.get('description') or 'raised'}"
+            events.append(
+                RootCauseEvent(timestamp=subj_ts, source="alert", reference=ref, description=desc)
+            )
+
+    for rel in triage.related:
+        if not isinstance(rel, dict):
+            continue
+        rel_ts = rel.get("timestamp") or rel.get("alerttime") or rel.get("createtime")
+        if rel_ts is None:
+            continue
+        if rel.get("alertid") is not None:
+            ref = str(rel.get("alertid"))
+            src: Any = "alert"
+            desc = f"alert {ref}: {rel.get('name') or rel.get('description') or 'raised'}"
+        elif rel.get("incid") is not None:
+            ref = str(rel.get("incid"))
+            src = "incident"
+            desc = f"incident {ref}: {rel.get('name') or rel.get('description') or 'created'}"
+        else:
+            continue
+        events.append(RootCauseEvent(timestamp=rel_ts, source=src, reference=ref, description=desc))
+
+    for row in triage.triggering_logs:
+        row_ts = row.get("itime") or row.get("timestamp") or row.get("eventtime")
+        if row_ts is None:
+            continue
+        ref = str(row.get("logid") or row.get("id") or "?")
+        desc = f"log {ref}: {row.get('logdesc') or row.get('msg') or row.get('subtype') or 'event'}"
+        events.append(
+            RootCauseEvent(timestamp=row_ts, source="log", reference=ref, description=desc)
+        )
+
+    if not events:
+        return FeatureGap(
+            reason="subject carries no timestamped alert/incident/log records to order into a chain"
+        )
+
+    ordered = sorted(events, key=lambda e: _sort_key(e.timestamp))
+    return RootCause(chain=ordered, earliest_signal=ordered[0], event_count=len(ordered))
+
+
+def _deep_headline(
+    subject_type: str,
+    subject_id: str,
+    base: Investigation | FeatureGap,
+    root_cause: RootCause | FeatureGap,
+    impact: Impact | FeatureGap,
+) -> str:
+    """Deterministic one-line rollup for the deep investigation.
+
+    Built only from values already present in the composed sections — no
+    inference; gap sections contribute a compact 'no data' note.
+    """
+    parts = [f"{subject_type} {subject_id}"]
+    if isinstance(base, Investigation):
+        parts.append(f"priority {base.triage.assessment.priority}")
+    if isinstance(root_cause, RootCause):
+        first = root_cause.earliest_signal
+        origin = f"{first.source} {first.reference}" if first else "?"
+        parts.append(f"root cause: {root_cause.event_count} events (earliest {origin})")
+    else:
+        parts.append("root cause: none")
+    if isinstance(impact, Impact):
+        touched = sum(v for e in impact.entities for v in e.counts.values())
+        parts.append(
+            f"impact: {impact.entity_count} entities, {touched} lateral rows "
+            f"({impact.lateral_searches_run} searches)"
+        )
+    else:
+        parts.append("impact: none")
+    return "; ".join(parts)
+
+
+async def _entity_impact(
+    adom: str | None,
+    entity_type: str,
+    entity_ref: str,
+    pivot: str | None,
+    logtypes: list[str],
+    time_range: str,
+    lateral_limit: int,
+    budget: int,
+    warnings: list[str],
+    epids: list[int],
+) -> tuple[EntityImpact, int]:
+    """Forward blast-radius for one entity: lateral log searches + assets.
+
+    Runs at most ``budget`` lateral ``log_search`` calls (one per log type,
+    in order); anything beyond the budget is dropped and named in
+    ``warnings`` — no silent truncation. Returns the ``EntityImpact`` and
+    the number of slots consumed. The ``asset_lookup`` is a plain GET (no
+    slot).
+    """
+    from fortianalyzer_mcp.tools.log_tools import query_logs
+
+    lateral: dict[str, list[dict[str, Any]] | FeatureGap] = {}
+    counts: dict[str, int] = {}
+    consumed = 0
+
+    for logtype in logtypes:
+        if pivot is None:
+            lateral[logtype] = FeatureGap(
+                reason=f"{entity_type} {entity_ref} yields no srcip/user pivot; "
+                "lateral search would be a guess"
+            )
+            continue
+        if consumed >= budget:
+            lateral[logtype] = FeatureGap(
+                reason=f"dropped by max_lateral_searches cap (budget {budget} exhausted)"
+            )
+            warnings.append(
+                f"impact[{entity_ref}]: lateral '{logtype}' search dropped by the "
+                f"fan-out cap (budget {budget})"
+            )
+            continue
+        consumed += 1
+        logs_res, err = await _call(
+            query_logs,
+            adom=adom,
+            logtype=logtype,
+            time_range=time_range,
+            filter=pivot,
+            limit=lateral_limit,
+        )
+        if logs_res is None:
+            lateral[logtype] = FeatureGap(reason=f"lateral '{logtype}' search unavailable: {err}")
+            warnings.append(f"impact[{entity_ref}]: {logtype} search unavailable: {err}")
+        else:
+            rows = logs_res.get("logs") or []
+            lateral[logtype] = rows
+            counts[logtype] = len(rows)
+            warnings.extend(
+                f"impact[{entity_ref}] {logtype}: {w}" for w in logs_res.get("warnings") or []
+            )
+
+    assets: AssetLookupResult | FeatureGap
+    if not epids:
+        assets = FeatureGap(
+            reason=f"{entity_type} {entity_ref} carries no endpoint id; asset lookup skipped"
+        )
+    else:
+        try:
+            assets = await run_asset_lookup(AssetLookupParams(adom=adom, epids=epids))
+            warnings.extend(f"impact[{entity_ref}] assets: {w}" for w in assets.warnings)
+            counts["assets"] = assets.endpoint_count
+        except SkillExecutionError as exc:
+            assets = FeatureGap(reason=f"asset lookup unavailable: {exc}")
+            warnings.append(f"impact[{entity_ref}]: asset lookup unavailable: {exc}")
+
+    return (
+        EntityImpact(
+            entity_type=entity_type,  # type: ignore[arg-type]
+            entity_ref=entity_ref,
+            pivot=pivot,
+            lateral_activity=lateral,
+            assets=assets,
+            counts=counts,
+        ),
+        consumed,
+    )
+
+
+async def _resolve_impact_entities(
+    adom: str | None,
+    epids: list[int],
+    euids: list[int],
+    ip: str | None,
+    warnings: list[str],
+) -> list[dict[str, Any]]:
+    """Resolve traced entities to their (type, ref, pivot, epids) tuples.
+
+    An endpoint's pivot is ``srcip==<epip>``; an end-user's is
+    ``user==<euname>``; a bare IP pivots on itself. A UEBA record that
+    carries no epip/euname yields no pivot (its lateral search degrades to
+    a gap, never a guess). The UEBA reads are plain GETs.
+    """
+    from fortianalyzer_mcp.tools.ueba_tools import get_endpoints, get_endusers
+    from fortianalyzer_mcp.utils.validation import sanitize_filter_value
+
+    resolved: list[dict[str, Any]] = []
+
+    for epid in epids:
+        eps_res, err = await _call(get_endpoints, adom=adom, epids=[epid], detail_level="simple")
+        record = None
+        if eps_res is None:
+            warnings.append(f"impact: endpoint {epid} lookup unavailable: {err}")
+        else:
+            record = next(
+                (ep for ep in _records(eps_res.get("data")) if str(ep.get("epid")) == str(epid)),
+                None,
+            )
+        pivot = None
+        epip = record.get("epip") if record else None
+        if epip:
+            pivot = f"srcip=={sanitize_filter_value(str(epip), 'epip')}"
+        resolved.append({"type": "endpoint", "ref": str(epid), "pivot": pivot, "epids": [epid]})
+
+    for euid in euids:
+        users_res, err = await _call(get_endusers, adom=adom, euids=[euid])
+        record = None
+        if users_res is None:
+            warnings.append(f"impact: end-user {euid} lookup unavailable: {err}")
+        else:
+            record = next(
+                (u for u in _records(users_res.get("data")) if str(u.get("euid")) == str(euid)),
+                None,
+            )
+        pivot = None
+        user_epids: list[int] = []
+        if record is not None:
+            euname = record.get("euname")
+            if euname:
+                pivot = f"user=={sanitize_filter_value(str(euname), 'euname')}"
+            for key in _ENDUSER_EPID_KEYS:
+                value = record.get(key)
+                for candidate in value if isinstance(value, list) else [value]:
+                    if isinstance(candidate, bool):
+                        continue
+                    if isinstance(candidate, int):
+                        user_epids.append(candidate)
+                    elif isinstance(candidate, str) and candidate.isdigit():
+                        user_epids.append(int(candidate))
+                if user_epids:
+                    break
+        resolved.append({"type": "enduser", "ref": str(euid), "pivot": pivot, "epids": user_epids})
+
+    if ip is not None:
+        pivot = f"srcip=={sanitize_filter_value(ip, 'ip')}"
+        resolved.append({"type": "ip", "ref": ip, "pivot": pivot, "epids": []})
+
+    return resolved
+
+
+def _parse_entity_subject(entity: str) -> tuple[list[int], list[int], str | None, str | None]:
+    """Parse a bare ``entity`` subject into (epids, euids, ip, error).
+
+    Accepts ``epid:N`` / ``euid:N`` (digit id) or a bare IPv4/IPv6 address.
+    Returns an error string (and empty selectors) for anything else, so the
+    caller can fail cleanly rather than guess.
+    """
+    text = entity.strip()
+    lowered = text.lower()
+    if lowered.startswith("epid:"):
+        rest = text[5:].strip()
+        if rest.isdigit():
+            return [int(rest)], [], None, None
+        return [], [], None, "entity 'epid:' expects a numeric id"
+    if lowered.startswith("euid:"):
+        rest = text[5:].strip()
+        if rest.isdigit():
+            return [], [int(rest)], None, None
+        return [], [], None, "entity 'euid:' expects a numeric id"
+    # Bare IP: a dotted/coloned token with no letters other than hex.
+    if any(sep in text for sep in (".", ":")) and " " not in text:
+        return [], [], text, None
+    return (
+        [],
+        [],
+        None,
+        "entity must be 'epid:N', 'euid:N' or a bare IP address",
+    )
+
+
+async def run_investigate_deep(params: DeepInvestigateParams) -> DeepInvestigation:
+    """Deep, reactive investigation: backward to the earliest signal and
+    forward to the blast radius.
+
+    Composition over existing skills — it adds no new client methods:
+
+    - **Reactive subject (alert_id/incident_id):** runs ``run_investigate``
+      as the base bundle (triage + summary + threat_intel + asset/identity;
+      its only hard fail). ``root_cause`` orders the base triage's
+      subject/related-alerts/triggering-logs by timestamp to the earliest
+      signal — deterministic, no attribution. ``impact`` fans out from the
+      entity ids the subject carries.
+    - **Forward-only subject (entity = epid:N / euid:N / IP):** there is no
+      incident to trace, so ``base`` and ``root_cause`` are gaps; only the
+      forward ``impact`` pass runs on that single entity.
+
+    Slot cost: the forward pass runs **one logview search slot per traced
+    entity × swept log type**, hard-capped by ``max_lateral_searches``
+    (default 8); excess pairs are dropped and named in ``warnings``. Every
+    window is capped to ``_DEEP_MAX_WINDOW`` (7-day) unless a custom
+    ``start|end`` range is given. The base ``investigate`` composition and
+    the UEBA/asset reads consume no search slots.
+    """
+    warnings: list[str] = []
+    time_range, capped = _cap_window(params.time_range)
+    if capped:
+        warnings.append(
+            f"time_range {params.time_range!r} capped to {time_range!r} for the "
+            "slot-consuming forward searches"
+        )
+
+    if params.entity:
+        subject_type = "entity"
+        subject_id = params.entity
+    elif params.alert_id:
+        subject_type = "alert"
+        subject_id = params.alert_id
+    else:
+        subject_type = "incident"
+        subject_id = str(params.incident_id)
+
+    # --- Base investigate (reactive subjects only) ---------------------- #
+    base: Investigation | FeatureGap
+    root_cause: RootCause | FeatureGap
+    impact_epids: list[int] = []
+    impact_euids: list[int] = []
+    impact_ip: str | None = None
+
+    if subject_type == "entity":
+        base = FeatureGap(
+            reason="forward-only entity subject: no incident/alert to run the base investigation on"
+        )
+        root_cause = FeatureGap(
+            reason="forward-only entity subject: no incident timeline to trace backward"
+        )
+        epids, euids, ip, parse_err = _parse_entity_subject(params.entity or "")
+        if parse_err is not None:
+            raise SkillExecutionError(parse_err)
+        impact_epids, impact_euids, impact_ip = epids, euids, ip
+    else:
+        base = await run_investigate(
+            InvestigateParams(
+                adom=params.adom,
+                alert_id=params.alert_id,
+                incident_id=params.incident_id,
+                time_range=time_range,
+                detail_level=params.detail_level,
+                include_threat_landscape=params.include_threat_landscape,
+                include_entities=True,
+            )
+        )
+        warnings.extend(f"base: {w}" for w in base.warnings)
+        root_cause = _root_cause_chain(base.triage)
+        # Forward pass reuses the entity ids the base triage already resolved.
+        carriers = [base.triage.subject]
+        if base.triage.subject_details is not None:
+            carriers.append(base.triage.subject_details)
+        impact_epids = _subject_entity_ids(carriers, _SUBJECT_EPID_KEYS)
+        impact_euids = _subject_entity_ids(carriers, _SUBJECT_EUID_KEYS)
+
+    # --- Forward impact pass -------------------------------------------- #
+    impact: Impact | FeatureGap
+    if not params.include_impact:
+        impact = FeatureGap(reason="disabled by include_impact=false")
+    elif not (impact_epids or impact_euids or impact_ip):
+        impact = FeatureGap(
+            reason=f"{subject_type} {subject_id} carries no traceable entity "
+            "(epid/euid/ip); forward blast-radius would be a guess"
+        )
+    else:
+        entities = await _resolve_impact_entities(
+            params.adom, impact_epids, impact_euids, impact_ip, warnings
+        )
+        budget = params.max_lateral_searches
+        impacts: list[EntityImpact] = []
+        run_total = 0
+        for ent in entities:
+            entity_impact, consumed = await _entity_impact(
+                adom=params.adom,
+                entity_type=ent["type"],
+                entity_ref=ent["ref"],
+                pivot=ent["pivot"],
+                logtypes=params.impact_logtypes,
+                time_range=time_range,
+                lateral_limit=params.lateral_limit,
+                budget=budget - run_total,
+                warnings=warnings,
+                epids=ent["epids"],
+            )
+            impacts.append(entity_impact)
+            run_total += consumed
+        # A logtype dropped for lack of budget shows up as a gap whose reason
+        # names the cap; count those explicitly (never silently truncated).
+        dropped = sum(
+            1
+            for e in impacts
+            for section in e.lateral_activity.values()
+            if isinstance(section, FeatureGap) and "max_lateral_searches" in section.reason
+        )
+        impact = Impact(
+            entities=impacts,
+            entity_count=len(impacts),
+            lateral_searches_run=run_total,
+            lateral_searches_dropped=dropped,
+        )
+
+    return DeepInvestigation(
+        subject_type=subject_type,  # type: ignore[arg-type]
+        headline=_deep_headline(subject_type, subject_id, base, root_cause, impact),
+        base=base,
+        root_cause=root_cause,
+        impact=impact,
+        time_range=time_range,
         warnings=warnings,
     )

--- a/src/fortianalyzer_mcp/skills/models.py
+++ b/src/fortianalyzer_mcp/skills/models.py
@@ -910,3 +910,194 @@ class Investigation(BaseModel):
     )
     time_range: str
     warnings: list[str] = Field(default_factory=list)
+
+
+# --------------------------------------------------------------------- #
+# investigate_deep (Analysis)                                           #
+# --------------------------------------------------------------------- #
+
+
+class DeepInvestigateParams(BaseModel):
+    """Parameters for the ``investigate_deep`` skill.
+
+    Exactly one subject is required: a reactive ``incident_id`` XOR
+    ``alert_id`` (which runs the full backward+forward pass), or a bare
+    ``entity`` (an ``epid:N`` / ``euid:N`` / an IP) for the forward-only
+    blast-radius case (no incident to trace backward from).
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    adom: str | None = None
+    alert_id: str | None = None
+    incident_id: str | None = None
+    entity: str | None = Field(
+        default=None,
+        description="Forward-only subject when there is no incident: an "
+        "endpoint id ('epid:1001'), an end-user id ('euid:42'), or a bare "
+        "IPv4/IPv6 address. Mutually exclusive with alert_id/incident_id.",
+    )
+    time_range: str = Field(
+        default="7-day",
+        description="Window for the base investigation, the root-cause ordering "
+        "and every forward lateral search. Windows wider than 7 days are "
+        "capped to 7-day (the forward searches consume slots); the cap is "
+        "reported in warnings.",
+    )
+    detail_level: Literal["standard", "extended"] = Field(
+        default="standard",
+        description="Indicator-enrichment detail, passed through to the base "
+        "investigate composition (reactive subjects only)",
+    )
+    include_threat_landscape: bool = Field(
+        default=True,
+        description="Include the FortiView top-threats context in the base investigate",
+    )
+    impact_logtypes: list[str] = Field(
+        default_factory=lambda: ["traffic", "dns", "app-ctrl", "dlp"],
+        description="Log types swept per entity in the forward (impact) pass. "
+        "Each (entity, logtype) pair is one logview search slot; the total "
+        "fan-out is capped by max_lateral_searches.",
+    )
+    max_lateral_searches: int = Field(
+        default=8,
+        ge=1,
+        le=20,
+        description="Hard cap on forward lateral log_search calls (slots). When "
+        "the entity×logtype matrix exceeds it, the excess is dropped and named "
+        "in warnings — never silently truncated.",
+    )
+    lateral_limit: int = Field(
+        default=100, ge=1, le=1000, description="Max rows per forward lateral search"
+    )
+    include_impact: bool = Field(
+        default=True, description="Run the forward (blast-radius) pass at all"
+    )
+
+    @model_validator(mode="after")
+    def _exactly_one_subject(self) -> "DeepInvestigateParams":
+        subjects = [self.alert_id, self.incident_id, self.entity]
+        provided = [s for s in subjects if s]
+        if len(provided) != 1:
+            raise ValueError('provide exactly one of "alert_id", "incident_id" or "entity"')
+        return self
+
+
+class RootCauseEvent(BaseModel):
+    """One dated event on the backward root-cause chain, verbatim-sourced.
+
+    Deterministic: every event is an observation lifted from an alert or a
+    triggering-log row the subject already carries — its timestamp and a
+    reference to the source record. No attribution, no inferred causality;
+    the chain is only the time ordering to the earliest signal.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    timestamp: int | str
+    source: Literal["incident", "alert", "log"]
+    reference: str = Field(description="The source record's id (incid/alertid/logid), verbatim")
+    description: str = Field(description="Derived one-liner from fields present on the record")
+
+
+class RootCause(BaseModel):
+    """The backward (root-cause) section: a time-ordered chain to the
+    earliest observed signal. Degrades to a ``FeatureGap`` when the subject
+    carries no timestamped events to order."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    chain: list[RootCauseEvent] = Field(
+        description="Events ordered oldest-first; chain[0] is the earliest signal"
+    )
+    earliest_signal: RootCauseEvent | None = Field(
+        default=None, description="Convenience copy of chain[0] (None when the chain is empty)"
+    )
+    event_count: int
+
+
+class EntityImpact(BaseModel):
+    """The forward blast-radius for one traced entity.
+
+    ``lateral_activity`` maps each swept log type to its verbatim rows (or a
+    ``FeatureGap`` when that search failed or was dropped by the fan-out
+    cap). ``pivot`` names the exact filter clause the searches ran on, so
+    the fan-out is auditable and never a guess.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    entity_type: Literal["endpoint", "enduser", "ip"]
+    entity_ref: str = Field(description="epid/euid/ip that identifies this entity, verbatim")
+    pivot: str | None = Field(
+        default=None, description="The srcip/user filter clause the lateral searches ran on"
+    )
+    lateral_activity: dict[str, list[dict[str, Any]] | FeatureGap] = Field(
+        default_factory=dict,
+        description="Per-logtype verbatim rows the entity touched — or a gap marker per type",
+    )
+    assets: AssetLookupResult | FeatureGap = Field(
+        description="UEBA asset profile for the entity's endpoint(s) — or the gap marker"
+    )
+    counts: dict[str, int] = Field(
+        default_factory=dict, description="Row count per available lateral section"
+    )
+
+
+class Impact(BaseModel):
+    """The forward (impact) section: what the subject's entities touched.
+
+    Degrades to a ``FeatureGap`` when the subject carries no traceable
+    entity (no epid/euid/ip); otherwise one ``EntityImpact`` per entity,
+    each of whose sub-sections degrades independently.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    entities: list[EntityImpact]
+    entity_count: int
+    lateral_searches_run: int = Field(description="Forward log_search slots actually consumed")
+    lateral_searches_dropped: int = Field(
+        description="Entity×logtype pairs skipped by the max_lateral_searches cap"
+    )
+
+
+class DeepInvestigation(BaseModel):
+    """Output of the ``investigate_deep`` skill.
+
+    A reactive deep dive: the Wave-2 ``investigate`` result as the base
+    bundle, plus a backward ``root_cause`` chain (time-ordered to the
+    earliest signal, deterministic — no attribution) and a forward
+    ``impact`` blast-radius (lateral log activity + affected assets per
+    traced entity). Every section degrades independently to a
+    ``FeatureGap``; the top-level ``warnings`` aggregate the nested ones
+    with a section prefix.
+
+    For a bare ``entity`` subject there is no incident to trace, so
+    ``base`` and ``root_cause`` are gaps and only the forward ``impact``
+    pass runs.
+
+    Slot cost: the forward pass runs up to ``max_lateral_searches`` logview
+    searches (one per traced entity × swept log type, capped); the base
+    ``investigate`` composition consumes none. See the handler docstring.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    subject_type: Literal["alert", "incident", "entity"]
+    headline: str = Field(
+        description="Deterministic one-line rollup (base priority when reactive, "
+        "plus root-cause and impact counts) — derived, no inference"
+    )
+    base: Investigation | FeatureGap = Field(
+        description="The Wave-2 investigate bundle for a reactive subject — or the "
+        "gap marker for a forward-only entity subject"
+    )
+    root_cause: RootCause | FeatureGap = Field(
+        description="Backward chain to the earliest signal — or the gap marker"
+    )
+    impact: Impact | FeatureGap = Field(
+        description="Forward blast-radius across the subject's entities — or the gap marker"
+    )
+    time_range: str
+    warnings: list[str] = Field(default_factory=list)

--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -40,8 +40,13 @@ WAVE2_ENRICHMENT_IDS = {
     "risk_assessment",
 }
 WAVE2_ANALYSIS_IDS = {"investigate"}
+WAVE3_ANALYSIS_IDS = {"investigate_deep"}
 REGISTERED_SKILL_IDS = (
-    WAVE1_SKILL_IDS | WAVE2_DATA_ACCESS_IDS | WAVE2_ENRICHMENT_IDS | WAVE2_ANALYSIS_IDS
+    WAVE1_SKILL_IDS
+    | WAVE2_DATA_ACCESS_IDS
+    | WAVE2_ENRICHMENT_IDS
+    | WAVE2_ANALYSIS_IDS
+    | WAVE3_ANALYSIS_IDS
 )
 
 GET_INCIDENTS = "fortianalyzer_mcp.tools.incident_tools.get_incidents"

--- a/tests/test_skills_investigate_deep.py
+++ b/tests/test_skills_investigate_deep.py
@@ -1,0 +1,361 @@
+"""Wave-3 analysis skill: investigate_deep.
+
+Same conventions as ``test_skills_investigate.py``: composed handlers
+import their tool functions lazily, so they are patched at their defining
+modules with ``autospec=True``; the dispatcher path is exercised through
+``faz_skill``. investigate_deep composes the whole ``investigate`` bundle
+(reused as the base) plus a backward root-cause chain and a forward
+per-entity lateral log_search fan-out, so the mocks are the union of the
+base composition's readers plus ``query_logs`` for the forward pass.
+"""
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from pydantic import ValidationError
+
+from fortianalyzer_mcp.skills import handlers
+from fortianalyzer_mcp.skills.catalog import SKILLS
+from fortianalyzer_mcp.skills.dispatcher import faz_skill
+from fortianalyzer_mcp.skills.models import (
+    SCHEMA_VERSION,
+    DeepInvestigateParams,
+    FeatureGap,
+    Impact,
+    Investigation,
+    RootCause,
+)
+
+GET_INCIDENT = "fortianalyzer_mcp.tools.incident_tools.get_incident"
+GET_ALERTS = "fortianalyzer_mcp.tools.event_tools.get_alerts"
+GET_ALERT_DETAILS = "fortianalyzer_mcp.tools.event_tools.get_alert_details"
+GET_ALERT_LOGS = "fortianalyzer_mcp.tools.event_tools.get_alert_logs"
+GET_ALERT_INCIDENT_STATS = "fortianalyzer_mcp.tools.event_tools.get_alert_incident_stats"
+GET_TOP_THREATS = "fortianalyzer_mcp.tools.fortiview_tools.get_top_threats"
+GET_LINKED = "fortianalyzer_mcp.tools.soar_tools.get_linked_indicators"
+GET_ENRICH = "fortianalyzer_mcp.tools.soar_tools.get_indicator_enrichment"
+GET_ENDPOINTS = "fortianalyzer_mcp.tools.ueba_tools.get_endpoints"
+GET_VULNS = "fortianalyzer_mcp.tools.ueba_tools.get_endpoint_vulnerabilities"
+GET_ENDUSERS = "fortianalyzer_mcp.tools.ueba_tools.get_endusers"
+QUERY_LOGS = "fortianalyzer_mcp.tools.log_tools.query_logs"
+
+
+def t(target: str, **kwargs: Any) -> Any:
+    """``patch`` a tool function with autospec (signature-validating)."""
+    return patch(target, autospec=True, **kwargs)
+
+
+def ok(**fields: Any) -> dict[str, Any]:
+    """A successful tool envelope."""
+    return {"status": "success", **fields}
+
+
+def logs_ok(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """A successful query_logs envelope."""
+    return {"status": "success", "tid": 1, "logs": rows, "total": len(rows)}
+
+
+INCIDENT = {
+    "incid": "inc-001",
+    "name": "Malware Detection",
+    "severity": "high",
+    "status": "new",
+    "timestamp": 1704067200,
+    "epid": 1001,
+    "euid": 42,
+}
+ALERT = {
+    "alertid": "alert-001",
+    "name": "Malware C2 traffic",
+    "severity": "critical",
+    "timestamp": 1704067300,
+    "incids": ["inc-001"],
+    "acknowledged": False,
+}
+TRIG_LOG = {"logid": "l-1", "itime": 1704067100, "logdesc": "C2 beacon"}
+THREATS = [{"threat": "Backdoor.Agent", "threatweight": 500, "incidents": 3}]
+ENDPOINT = {"epid": 1001, "epname": "EU-EXAMPLE1", "epip": "192.0.2.7"}
+ENDUSER = {"euid": 42, "euname": "jdoe", "epid": [1001]}
+
+
+class TestDeepCatalog:
+    def test_registered_as_analysis_tier(self):
+        assert "investigate_deep" in SKILLS
+        assert SKILLS["investigate_deep"].tier == "analysis"
+
+    def test_params_forbid_unknown_keys(self):
+        with pytest.raises(ValidationError):
+            DeepInvestigateParams(incident_id="inc-001", no_such_parameter=True)
+
+    def test_requires_exactly_one_subject(self):
+        with pytest.raises(ValidationError, match="exactly one"):
+            DeepInvestigateParams()
+        with pytest.raises(ValidationError, match="exactly one"):
+            DeepInvestigateParams(alert_id="a", incident_id="i")
+        with pytest.raises(ValidationError, match="exactly one"):
+            DeepInvestigateParams(incident_id="i", entity="epid:1")
+
+
+class TestDeepReactive:
+    async def test_incident_subject_full_pass(self):
+        with (
+            t(GET_INCIDENT, return_value=ok(data=INCIDENT)),
+            t(GET_ALERTS, return_value=ok(data=[ALERT])),
+            t(GET_ALERT_LOGS, return_value=ok(data=[TRIG_LOG])),
+            t(GET_ALERT_INCIDENT_STATS, return_value=ok(data={"alerts": 5})),
+            t(GET_LINKED, return_value=ok(data=[])),
+            t(GET_TOP_THREATS, return_value=ok(data=THREATS)),
+            t(GET_ENDPOINTS, return_value=ok(data=[ENDPOINT])),
+            t(GET_VULNS, return_value=ok(data=[])),
+            t(GET_ENDUSERS, return_value=ok(data=[ENDUSER])),
+            t(QUERY_LOGS, return_value=logs_ok([{"srcip": "192.0.2.7", "dstip": "203.0.113.9"}])),
+        ):
+            result = await handlers.run_investigate_deep(
+                DeepInvestigateParams(incident_id="inc-001")
+            )
+        assert result.subject_type == "incident"
+        assert isinstance(result.base, Investigation)
+        assert result.base.triage.assessment.priority == "high"
+
+        # Backward: root cause chain, ordered oldest-first to the earliest signal.
+        assert isinstance(result.root_cause, RootCause)
+        assert result.root_cause.event_count >= 1
+        first = result.root_cause.earliest_signal
+        assert first is not None
+        assert result.root_cause.chain[0] is first
+        # Incident subject (ts 1704067200) is earlier than its related alert
+        # (ts 1704067300); triggering logs are attached to alert subjects, not
+        # incidents, so the chain here is incident-then-alert.
+        assert first.source == "incident"
+        assert result.root_cause.chain[-1].source == "alert"
+
+        # Forward: impact over the entity ids the subject carries (epid+euid).
+        assert isinstance(result.impact, Impact)
+        assert result.impact.entity_count == 2
+        assert result.impact.lateral_searches_run > 0
+        refs = {e.entity_ref for e in result.impact.entities}
+        assert refs == {"1001", "42"}
+        assert "priority high" in result.headline
+        assert "root cause:" in result.headline
+        assert "impact:" in result.headline
+
+    async def test_alert_subject_root_cause_includes_triggering_log(self):
+        # Alert subjects carry triggering logs; the log (itime 1704067100)
+        # predates the alert (1704067300), so it is the earliest signal.
+        with (
+            t(GET_ALERTS, return_value=ok(data=[ALERT])),
+            t(GET_ALERT_DETAILS, return_value=ok(data={"data": [{"alertid": "alert-001"}]})),
+            t(GET_ALERT_LOGS, return_value=ok(data=[TRIG_LOG])),
+            t(GET_INCIDENT, return_value=ok(data=INCIDENT)),
+            t(GET_ALERT_INCIDENT_STATS, return_value=ok(data={})),
+            t(GET_LINKED, return_value=ok(data=[])),
+            t(GET_TOP_THREATS, return_value=ok(data=THREATS)),
+            t(GET_ENDPOINTS, return_value=ok(data=[])),
+            t(GET_ENDUSERS, return_value=ok(data=[])),
+            t(QUERY_LOGS, return_value=logs_ok([])),
+        ):
+            result = await handlers.run_investigate_deep(
+                DeepInvestigateParams(alert_id="alert-001", impact_logtypes=["traffic"])
+            )
+        assert result.subject_type == "alert"
+        assert isinstance(result.root_cause, RootCause)
+        first = result.root_cause.earliest_signal
+        assert first is not None
+        assert first.source == "log"
+        assert first.reference == "l-1"
+
+    async def test_lateral_pivots_on_epip_and_username(self):
+        with (
+            t(GET_INCIDENT, return_value=ok(data=INCIDENT)),
+            t(GET_ALERTS, return_value=ok(data=[])),
+            t(GET_ALERT_INCIDENT_STATS, return_value=ok(data={})),
+            t(GET_LINKED, return_value=ok(data=[])),
+            t(GET_TOP_THREATS, return_value=ok(data=THREATS)),
+            t(GET_ENDPOINTS, return_value=ok(data=[ENDPOINT])),
+            t(GET_VULNS, return_value=ok(data=[])),
+            t(GET_ENDUSERS, return_value=ok(data=[ENDUSER])),
+            t(QUERY_LOGS, return_value=logs_ok([])) as ql,
+        ):
+            await handlers.run_investigate_deep(
+                DeepInvestigateParams(
+                    incident_id="inc-001", impact_logtypes=["traffic"], max_lateral_searches=8
+                )
+            )
+        pivots = {c.kwargs["filter"] for c in ql.call_args_list}
+        assert "srcip==192.0.2.7" in pivots
+        assert "user==jdoe" in pivots
+
+
+class TestDeepForwardOnly:
+    async def test_entity_epid_forward_only(self):
+        with (
+            t(GET_ENDPOINTS, return_value=ok(data=[ENDPOINT])),
+            t(GET_VULNS, return_value=ok(data=[])),
+            t(QUERY_LOGS, return_value=logs_ok([{"srcip": "192.0.2.7"}])) as ql,
+        ):
+            result = await handlers.run_investigate_deep(
+                DeepInvestigateParams(entity="epid:1001", impact_logtypes=["traffic", "dns"])
+            )
+        assert result.subject_type == "entity"
+        # No incident to trace: base + root_cause are gaps.
+        assert isinstance(result.base, FeatureGap)
+        assert isinstance(result.root_cause, FeatureGap)
+        # Only the forward pass runs, on the single endpoint.
+        assert isinstance(result.impact, Impact)
+        assert result.impact.entity_count == 1
+        ent = result.impact.entities[0]
+        assert ent.entity_type == "endpoint"
+        assert ent.pivot == "srcip==192.0.2.7"
+        assert ql.call_count == 2  # traffic + dns
+
+    async def test_entity_bare_ip_forward_only(self):
+        with t(QUERY_LOGS, return_value=logs_ok([])) as ql:
+            result = await handlers.run_investigate_deep(
+                DeepInvestigateParams(entity="203.0.113.9", impact_logtypes=["traffic"])
+            )
+        assert result.subject_type == "entity"
+        assert isinstance(result.impact, Impact)
+        ent = result.impact.entities[0]
+        assert ent.entity_type == "ip"
+        assert ent.pivot == "srcip==203.0.113.9"
+        assert ql.call_args.kwargs["filter"] == "srcip==203.0.113.9"
+
+    async def test_unrecognized_entity_raises(self):
+        with pytest.raises(handlers.SkillExecutionError, match="entity must be"):
+            await handlers.run_investigate_deep(DeepInvestigateParams(entity="not-an-entity"))
+
+
+class TestDeepBounds:
+    async def test_fanout_cap_drops_and_warns(self):
+        # 1 entity × 4 logtypes but a cap of 2 → 2 run, 2 dropped, no silent loss.
+        with (
+            t(GET_ENDPOINTS, return_value=ok(data=[ENDPOINT])),
+            t(GET_VULNS, return_value=ok(data=[])),
+            t(QUERY_LOGS, return_value=logs_ok([])) as ql,
+        ):
+            result = await handlers.run_investigate_deep(
+                DeepInvestigateParams(
+                    entity="epid:1001",
+                    impact_logtypes=["traffic", "dns", "app-ctrl", "dlp"],
+                    max_lateral_searches=2,
+                )
+            )
+        assert ql.call_count == 2
+        assert isinstance(result.impact, Impact)
+        assert result.impact.lateral_searches_run == 2
+        assert result.impact.lateral_searches_dropped == 2
+        assert any("dropped by the fan-out cap" in w for w in result.warnings)
+        ent = result.impact.entities[0]
+        dropped = [k for k, v in ent.lateral_activity.items() if isinstance(v, FeatureGap)]
+        assert set(dropped) == {"app-ctrl", "dlp"}
+
+    async def test_window_capped_to_seven_day(self):
+        with (
+            t(GET_ENDPOINTS, return_value=ok(data=[ENDPOINT])),
+            t(GET_VULNS, return_value=ok(data=[])),
+            t(QUERY_LOGS, return_value=logs_ok([])) as ql,
+        ):
+            result = await handlers.run_investigate_deep(
+                DeepInvestigateParams(
+                    entity="epid:1001", impact_logtypes=["traffic"], time_range="30-day"
+                )
+            )
+        assert result.time_range == "7-day"
+        assert ql.call_args.kwargs["time_range"] == "7-day"
+        assert any("capped to '7-day'" in w for w in result.warnings)
+
+    async def test_impact_disabled(self):
+        with (
+            t(GET_ENDPOINTS) as endpoints_mock,
+            t(QUERY_LOGS) as ql,
+        ):
+            result = await handlers.run_investigate_deep(
+                DeepInvestigateParams(entity="epid:1001", include_impact=False)
+            )
+        ql.assert_not_called()
+        endpoints_mock.assert_not_called()
+        assert isinstance(result.impact, FeatureGap)
+        assert "include_impact" in result.impact.reason
+
+
+class TestDeepDegradation:
+    async def test_subject_without_entities_gaps_impact(self):
+        no_entities = {k: v for k, v in INCIDENT.items() if k not in ("epid", "euid")}
+        with (
+            t(GET_INCIDENT, return_value=ok(data=no_entities)),
+            t(GET_ALERTS, return_value=ok(data=[])),
+            t(GET_ALERT_INCIDENT_STATS, return_value=ok(data={})),
+            t(GET_LINKED, return_value=ok(data=[])),
+            t(GET_TOP_THREATS, return_value=ok(data=THREATS)),
+            t(QUERY_LOGS) as ql,
+        ):
+            result = await handlers.run_investigate_deep(
+                DeepInvestigateParams(incident_id="inc-001")
+            )
+        ql.assert_not_called()
+        assert isinstance(result.impact, FeatureGap)
+        assert "would be a guess" in result.impact.reason
+        # The base + root_cause survive: a subject with no entities still has a timeline.
+        assert isinstance(result.base, Investigation)
+        assert isinstance(result.root_cause, RootCause)
+
+    async def test_base_subject_failure_raises(self):
+        with t(GET_INCIDENT, return_value={"status": "error", "error": "not_found"}):
+            with pytest.raises(handlers.SkillExecutionError, match="inc-404"):
+                await handlers.run_investigate_deep(DeepInvestigateParams(incident_id="inc-404"))
+
+    async def test_lateral_search_failure_degrades_to_gap(self):
+        with (
+            t(GET_ENDPOINTS, return_value=ok(data=[ENDPOINT])),
+            t(GET_VULNS, return_value=ok(data=[])),
+            t(QUERY_LOGS, return_value={"status": "error", "message": "logview unavailable"}),
+        ):
+            result = await handlers.run_investigate_deep(
+                DeepInvestigateParams(entity="epid:1001", impact_logtypes=["traffic"])
+            )
+        assert isinstance(result.impact, Impact)
+        section = result.impact.entities[0].lateral_activity["traffic"]
+        assert isinstance(section, FeatureGap)
+        assert any("traffic search unavailable" in w for w in result.warnings)
+
+    async def test_endpoint_without_epip_pivot_gaps(self):
+        no_epip = {"epid": 1001, "epname": "EU-EXAMPLE1"}  # no epip
+        with (
+            t(GET_ENDPOINTS, return_value=ok(data=[no_epip])),
+            t(GET_VULNS, return_value=ok(data=[])),
+            t(QUERY_LOGS) as ql,
+        ):
+            result = await handlers.run_investigate_deep(
+                DeepInvestigateParams(entity="epid:1001", impact_logtypes=["traffic"])
+            )
+        ql.assert_not_called()
+        assert isinstance(result.impact, Impact)
+        ent = result.impact.entities[0]
+        assert ent.pivot is None
+        section = ent.lateral_activity["traffic"]
+        assert isinstance(section, FeatureGap)
+        assert "would be a guess" in section.reason
+
+
+class TestDeepDispatch:
+    async def test_success_envelope(self):
+        with (
+            t(GET_ENDPOINTS, return_value=ok(data=[ENDPOINT])),
+            t(GET_VULNS, return_value=ok(data=[])),
+            t(QUERY_LOGS, return_value=logs_ok([])),
+        ):
+            result = await faz_skill(
+                skill="investigate_deep",
+                params={"entity": "epid:1001", "impact_logtypes": ["traffic"]},
+            )
+        assert result["status"] == "success"
+        assert result["skill"] == "investigate_deep"
+        assert result["schema_version"] == SCHEMA_VERSION
+        assert result["result"]["subject_type"] == "entity"
+        assert result["result"]["impact"]["entity_count"] == 1
+
+    async def test_missing_subject_rejected(self):
+        result = await faz_skill(skill="investigate_deep", params={})
+        assert result["status"] == "error"
+        assert result["error"] == "invalid_skill_params"


### PR DESCRIPTION
## Wave 3, Layer 2 — `investigate_deep` (reactive: root-cause + impact)

Analysis-tier skill. Given a known incident/alert/entity, trace **backward to the earliest signal** and **forward to the blast radius** in one pass. Pure composition over existing skills/tools — no new readers.

### Subject
`incident_id` XOR `alert_id` XOR a bare `entity` (`epid:N` / `euid:N` / IP for the forward-only case). Enforced by a `model_validator`.

### What it does
- **Base** = the Wave-2 `investigate` bundle (triage + summary + threat_intel + asset/identity), nested verbatim. The only hard-fail on a reactive subject.
- **Backward — `root_cause`:** orders the base triage's subject + correlated alerts + triggering logs by timestamp to the earliest signal. Verbatim-sourced references, **no attribution guessing** (matches `triage`'s posture). `FeatureGap` when nothing is timestamped.
- **Forward — `impact`:** per entity the subject carries, resolves an `srcip==<epip>` / `user==<euname>` pivot (same pattern as `risk_assessment`, via `sanitize_filter_value`), fans out `log_search` across `impact_logtypes` (default traffic/dns/app-ctrl/dlp) + `asset_lookup`. Each section degrades independently.
- **Output `DeepInvestigation`** (`extra="forbid"`, versioned `SCHEMA_VERSION`): `base` + `root_cause` + `impact`, per-section `FeatureGap`, top-level `warnings`.

### Slot discipline (no silent truncation)
Each lateral query = 1 logview search slot. **Shared per-invocation cap** (`max_lateral_searches`, default 8) consumed in entity order; windows capped to 7-day; drops are counted (`lateral_searches_dropped`) and surfaced as BOTH the section gap and a warning, naming the exact `[entity][logtype]` pair. Documented in the handler docstring.

### Live validation (both versions, windows ≤7-day)
- **7.6.7 (faz-prod-02, `test-demo-01`):** forward-only `epid:6676` (EU-83LP4Y2) → resolved epip `192.168.5.11`, lateral traffic+dns searches, base/root_cause correctly gapped. Reactive `IN00000026` → root_cause chain of 7 events to earliest alert; enduser with no `euname` → pivot gap (no guess). Cap test: 4 logtypes / cap 2 → exactly 2 ran, 2 dropped, each in gap + warning.
- **8.0.0 (faz-prod-ai, root):** reactive `IN00000004` → base + 5-event root_cause + impact; forward-only `euid:1039` → pivots `user==demo`, runs cleanly.

### Tests / quality
- New `tests/test_skills_investigate_deep.py` (18 autospec tests) + registered-skills set updated. All five FeatureGap fallbacks exercised.
- Full non-integration suite: **1298 passed** (+18). ruff check + ruff format + mypy all clean.

Second Wave-3 Layer-2 PR; `hunt` (proactive) is the last skill, then the wave's roadmap/README bump.
