### PR TITLE
docs(masking): note the report-artifact residual (#80)

### DIFF
--- a/src/fortianalyzer_mcp/masking/fields.py
+++ b/src/fortianalyzer_mcp/masking/fields.py
@@ -56,6 +56,14 @@ Out of scope here, by design:
   wrong trade. Closing it properly needs the ``devvds`` treatment, a
   composite handler that lifts the maskable part out first, and that is
   a GA decision rather than a beta patch.
+- Report artifacts (``get_report_data`` / ``fetch_report`` output) are
+  out of masking scope: the flag masks live query surfaces, not rendered
+  documents. Those tools return the report base64-encoded (PDF, HTML,
+  CSV, XML), the masker walks the JSON envelope and cannot see inside an
+  encoded blob, so identifiers inside report tables reach the caller
+  raw, and PDF is inherently out of scope. Decoding and masking the
+  text formats is a GA backlog item (#80); a partial cover would read
+  as coverage while PDF still leaks.
 - ``incident_reporter`` is polymorphic: a username on a manually created
   incident, an alert id on an auto-raised one, so it carries no type
   here. The username case is decided per record instead: when the value


### PR DESCRIPTION
The one-liner you asked for in https://github.com/rstierli/fortianalyzer-mcp/issues/80#issuecomment-5067421812, in the residuals section of the fields.py module docstring, same place as the vpntunnel note from #78.

Slightly more than one line so the doc says why, matching the other residual entries: the base64 envelope is invisible to the masker, PDF is inherently out of scope, and the CSV/XML/HTML decode-and-mask option is a GA backlog item per your call (a partial cover reads as coverage while PDF still leaks).

Docstring only, no behavior change. 1280 pass on 3.12, ruff and format clean.