### PR TITLE
fix(masking): type the Wave-3 skill assembly keys (#89, #90)

### DIFF
--- a/src/fortianalyzer_mcp/masking/fields.py
+++ b/src/fortianalyzer_mcp/masking/fields.py
@@ -264,6 +264,27 @@ FIELD_TYPES: dict[str, str] = {
     "warnings": TEXT,
     "message": TEXT,
     "reason": TEXT,
+    # --- Wave-3 skill assembly keys (#89 investigate_deep, #90 hunt). Each
+    # is a string the skill builds itself around an identifier the same
+    # response masks under the value's own key, so leaving them untyped
+    # handed over the token-to-raw pairing (the srcip_hostname class again):
+    # rows[].srcip a token, pivot "srcip==<raw>" beside it. TEXT gives them
+    # exactly the treatment filter/filter_applied already get: pass 2
+    # substitutes any value this response mapped (closing the pairing) and
+    # the IOC scan masks bare IPv4/MAC/email. They inherit filter's known
+    # residuals too, unchanged and not widened here: a value that appears
+    # nowhere else in the response and is not IPv4/MAC/email-shaped (a bare
+    # hostname, a cold username, a bare IPv6, a quoted clause value) rides
+    # through as written. Two of these keys are filter clauses, so the
+    # proper close for the whole family (filter, filter_applied, pivot,
+    # pivot_filter) is a clause composite that masks the RHS by the inner
+    # field's type, mirroring unmask_filter; that is a GA-grade change to a
+    # shipped surface and is tracked in #80, not bundled into this parity
+    # fix.
+    "pivot": TEXT,  # investigate_deep impact entities: 'srcip==<value>'
+    "pivot_filter": TEXT,  # hunt sweep: same clause shape
+    "entity_ref": TEXT,  # investigate_deep: caller's entity, may be a bare IP
+    "headline": TEXT,  # skill summaries; first interpolated an identifier in #89
 }
 
 #: Composite keys whose value is a single string holding one or more

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -1298,3 +1298,80 @@ class TestNestedDeviceName:
         masked = masker.mask_result({"device_info": {"dev_name": DEV_NAME}})
 
         assert masked["device_info"]["dev_name"] == DEV_NAME
+
+
+class TestWave3SkillAssemblyKeys:
+    """Keys the Wave-3 skills build themselves around an identifier.
+
+    ``investigate_deep`` writes ``srcip==<value>`` clauses under ``pivot``
+    and the caller's entity under ``entity_ref``; ``hunt`` writes the same
+    clause shape under ``sweep.pivot_filter``; both interpolate the subject
+    into ``headline``. The same response masks the value under its own key,
+    so an untyped assembly key handed over the token-to-raw pairing, the
+    srcip_hostname class. Typed TEXT they get exactly the ``filter``
+    treatment: a value this response mapped is substituted (closing the
+    pairing) and a bare IPv4 is caught by the IOC scan with the same token
+    the structured pass mints. The residual they share with ``filter`` (a
+    cold value that is neither mapped nor IPv4/MAC/email-shaped) is not
+    pinned here because it is unchanged shipped behaviour, tracked for the
+    whole filter family in #80.
+    """
+
+    def test_pivot_filter_tracks_the_row_token(self, masker: OutputMasker):
+        # The pairing case: rows mask srcip, the sweep echoes the raw value.
+        masked = masker.mask_result(
+            {
+                "rows": [{"srcip": PEER_IP}],
+                "sweep": {"pivot_filter": f'srcip=="{PEER_IP}"'},
+            }
+        )
+
+        assert PEER_IP not in str(masked)
+        token = masked["rows"][0]["srcip"]
+        assert masked["sweep"]["pivot_filter"] == f'srcip=="{token}"'
+
+    def test_pivot_tracks_the_enduser_token(self, masker: OutputMasker):
+        # investigate_deep: pivot built from the UEBA record's euname.
+        masked = masker.mask_result(
+            {
+                "record": {"euname": ANALYST},
+                "impact": {"entities": [{"pivot": f"user=={ANALYST}"}]},
+            }
+        )
+
+        assert ANALYST not in str(masked)
+        token = masked["record"]["euname"]
+        assert masked["impact"]["entities"][0]["pivot"] == f"user=={token}"
+
+    def test_entity_ref_ip_masks_and_numeric_ref_survives(self, masker: OutputMasker):
+        # A cold entity_ref must carry the SAME token the typed path would
+        # mint, or the model cannot pivot on it; a burn or a blank would
+        # also satisfy a mere != assertion.
+        expected = masker.mask_result({"srcip": PEER_IP})["srcip"]
+        masked = masker.mask_result(
+            {"impact": {"entities": [{"entity_ref": PEER_IP}, {"entity_ref": "12"}]}}
+        )
+
+        entities = masked["impact"]["entities"]
+        assert entities[0]["entity_ref"] == expected
+        # investigate_deep emits bare numeric refs for epid/euid subjects;
+        # they are selectors, not identifiers, and TEXT never burns.
+        assert entities[1]["entity_ref"] == "12"
+
+    def test_headline_carries_the_exact_ip_token(self, masker: OutputMasker):
+        expected = masker.mask_result({"srcip": PEER_IP})["srcip"]
+        masked = masker.mask_result({"headline": f"indicator IP {PEER_IP}; sweep: 0 hits"})
+
+        assert masked["headline"] == f"indicator IP {expected}; sweep: 0 hits"
+
+    def test_pivot_pairing_holds_with_device_masking_on(self, full_masker: OutputMasker):
+        masked = full_masker.mask_result(
+            {
+                "rows": [{"srcip": PEER_IP}],
+                "sweep": {"pivot_filter": f'srcip=="{PEER_IP}"'},
+            }
+        )
+
+        assert PEER_IP not in str(masked)
+        token = masked["rows"][0]["srcip"]
+        assert masked["sweep"]["pivot_filter"] == f'srcip=="{token}"'


### PR DESCRIPTION
Pre-merge masking-boundary review of the three open Wave-3 PRs (#88, #89, #90), plus the masking-side fix for what it found. Same method that caught the reader-vocabulary gaps before 2.10.0: run each PR's real handler against mocked readers with RFC 5737/2606 placeholders, mask the output through the real `OutputMasker`, grep for survivors, and assert every planted identifier is also searched.

## What this PR changes

Four keys the new skills assemble around identifiers were in neither `FIELD_TYPES` nor the composites, so they passed verbatim while the same response masked the value under its own key. `pivot` and `pivot_filter` carry `srcip==<value>` / `user==<value>` clauses; `entity_ref` carries the caller's entity; `headline` names the subject. Each handed back the token-to-raw pairing (`rows[].srcip` a token, `pivot "srcip==<raw>"` one key away) which is the `srcip_hostname` class again.

All four are typed `TEXT`, exactly the treatment `filter`/`filter_applied` already get: pass 2 substitutes any value this response mapped (closing the pairing on every reader-discovered entity), and the IOC scan masks a bare IPv4/MAC/email subject with the same token the structured pass mints.

Harness result, per PR (real handler + real masker):
- **#88** (UEBA `/stats` readers): CLEAN, no change needed. Aggregate counts only; both the full and dynamic-mode registration paths mask; error paths already route through `redact()`.
- **#89** (`investigate_deep`): the `pivot` pairing (fires on the normal reactive flow), `entity_ref` IP, and `headline` IP all close. One residual, handler-side (below).
- **#90** (`hunt`): entity/indicator/pairing cases close. Two residuals, both handler-side (below).

## Scope: this is a parity fix, not a filter-grammar rework

The four keys inherit `filter`'s known, shipped residual unchanged: a value that appears nowhere else in the response and is not IPv4/MAC/email-shaped (a cold username, a bare hostname or IPv6, a quoted clause value) rides through, because prose substitution cannot type it.

An earlier draft made the whole TEXT pass clause-aware to close that. An adversarial review showed a global clause parser corrupts ordinary prose and URLs (a `headline` containing `?user=jdoe&...` gets mangled), is order-dependent, and breaks the outbound/inbound round trip (`_mask_scalar` comma-splits, `unmask_filter` does not). The correct close is a clause composite for the whole `filter` family (`filter`, `filter_applied`, `pivot`, `pivot_filter`) that masks the RHS by the inner field's type and mirrors `unmask_filter` exactly. That is a GA-grade change to a shipped surface; I have written it up on #80 rather than bundle it here.

## Handler-side findings for the PR authors (not fixable in the masking layer)

These are in the skill handlers, so they are yours to take or wave off; masking cannot reach them cleanly:

1. **#89 / #90 error path** echoes the caller's `entity` value: `raise SkillExecutionError(f"unrecognized entity {entity!r}; ...")` (pr89 `handlers.py:2395/2400/2408`, pr90 `handlers.py:2302`). Because inbound `unmask_args` resolves a marked token in `entity` first, a caller who only ever held the token gets the raw identifier back through `$.message`. Same class you fixed on #75; the fix is the same, name the parameter not its content.
2. **#90 dict keys**: the masker never masks dict *keys*, only values (verified in `_mask_structured`). No current handler builds an identifier-keyed dict, but `impact_logtypes` / `vuln_stats` are one refactor away. Worth a convention note + a pinned test.
3. **#89 headline / entity_ref cold non-IPv4 subjects**: the clean fix is handler-side, name the subject *type* not the raw value (`entity <ip>` -> `endpoint entity`), which sidesteps the residual entirely.
4. Minor: `hunt`'s `ttp` and `SweepMatch.logtype` are caller/reader strings under unlisted keys; low-risk, technique/logtype labels, flagging for completeness.

## Verification

1285 pass on 3.12 and 3.13, `wrapper.py` untouched. Five pinning tests (pairing token-equality across keys, exact-token cold IPv4 in `headline` and `entity_ref`, numeric selector rides through, pairing with device masking on); red without the typings (5 fail), each key's removal fails at least one. Review harnesses are reproducible; happy to share them.
