### PR TITLE
test(hunt): drive both estate paths explicitly, not by merge order

### DIFF
--- a/tests/test_skills_hunt.py
+++ b/tests/test_skills_hunt.py
@@ -7,7 +7,9 @@ modules with ``autospec=True``; the dispatcher path is exercised through
 and a percentile-calibrated UEBA behaviour profile — so the mocks are
 ``query_logs`` (sweep), the SOAR readers (threat_intel), and the UEBA
 endpoint/end-user + alert readers (behaviour). The estate-stats readers are
-optional and absent on this branch, so that section degrades to a gap.
+optional, so both estate paths are driven explicitly: their absence and
+their presence are simulated on the module rather than inferred from
+whether this branch happens to carry them.
 """
 
 from typing import Any
@@ -22,11 +24,13 @@ from fortianalyzer_mcp.skills.dispatcher import faz_skill
 from fortianalyzer_mcp.skills.models import (
     SCHEMA_VERSION,
     EntityBehavior,
+    EstateContext,
     FeatureGap,
     HuntParams,
     HuntSweep,
     IndicatorSubject,
 )
+from fortianalyzer_mcp.tools import ueba_tools
 
 GET_ALERTS = "fortianalyzer_mcp.tools.event_tools.get_alerts"
 GET_TOP_THREATS = "fortianalyzer_mcp.tools.fortiview_tools.get_top_threats"
@@ -69,6 +73,9 @@ CROWD = [
     for i in range(1, 40)
 ]
 ESTATE = CROWD + [HOT_ENDPOINT]
+
+# The ADOM-wide count snapshot the Layer-1 estate reader returns.
+ENDPOINT_STATS = {"total-count": "40", "new-count": "2", "identified-count": "37"}
 
 ENDUSER = {"euid": 42, "euname": "chutter", "importance": "high"}
 BOTNET_ALERT = {
@@ -345,9 +352,16 @@ class TestHuntBehaviorPercentile:
 
 
 class TestHuntEstateContext:
-    async def test_estate_stats_absent_reader_degrades_to_gap(self):
-        # The estate-stats readers ship on a separate branch; absent here, the
-        # estate section is a gap (never a hard fail).
+    async def test_estate_stats_absent_reader_degrades_to_gap(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        # The estate-stats readers are optional: _hunt_estate imports them
+        # inside a try/except ImportError and the whole section degrades to a
+        # gap when they are missing (never a hard fail). Their absence is
+        # simulated here rather than inferred from the branch not carrying
+        # them, so this path keeps its coverage once the Layer-1 readers land.
+        monkeypatch.delattr(ueba_tools, "get_endpoint_stats", raising=False)
+        monkeypatch.delattr(ueba_tools, "get_enduser_stats", raising=False)
         with (
             t(GET_ENDPOINTS, return_value=ok(data=ESTATE)),
             t(GET_ALERTS, return_value=ok(data=[])),
@@ -355,6 +369,31 @@ class TestHuntEstateContext:
         ):
             result = await handlers.run_hunt(HuntParams(entity="epid:6676"))
         assert isinstance(result.estate, FeatureGap)
+        assert "not available in this build" in result.estate.reason
+
+    async def test_estate_stats_present_composes_context(self, monkeypatch: pytest.MonkeyPatch):
+        # With the readers importable the section is an EstateContext whose
+        # halves degrade one at a time, not a single gap. Injected for the
+        # same reason the absence is: the assertion then holds whether or not
+        # this branch carries Layer 1.
+        async def endpoint_stats(**_: Any) -> dict[str, Any]:
+            return ok(data=[ENDPOINT_STATS])
+
+        monkeypatch.setattr(ueba_tools, "get_endpoint_stats", endpoint_stats, raising=False)
+        monkeypatch.setattr(ueba_tools, "get_enduser_stats", endpoint_stats, raising=False)
+        with (
+            t(GET_ENDPOINTS, return_value=ok(data=ESTATE)),
+            t(GET_ALERTS, return_value=ok(data=[])),
+            t(QUERY_LOGS, return_value=logs_ok([])),
+        ):
+            result = await handlers.run_hunt(HuntParams(entity="epid:6676"))
+        assert isinstance(result.estate, EstateContext)
+        assert result.estate.endpoints == ENDPOINT_STATS
+        # An endpoint subject asks for no end-user denominator, so that half
+        # is a gap for want, not for failure.
+        assert isinstance(result.estate.endusers, FeatureGap)
+        assert "not requested" in result.estate.endusers.reason
+        assert result.estate.ranked_endpoint_total == len(ESTATE)
 
     async def test_estate_disabled(self):
         with (


### PR DESCRIPTION
Targets `feat/wave3-hunt` rather than `main`, so it lands inside #90 if you want it. Tests only, no behaviour change. Follow-up to https://github.com/rstierli/fortianalyzer-mcp/pull/90#issuecomment-5080212275

## The problem

`test_estate_stats_absent_reader_degrades_to_gap` asserts the whole estate section is a `FeatureGap`. That is true today only because this branch does not carry the Layer-1 readers: `_hunt_estate` returns the bare gap from its `except ImportError` arm alone. Merge #88 and the import succeeds, the section composes an `EstateContext` whose halves degrade one at a time, and the assertion fails:

```
EstateContext(endpoints=FeatureGap(reason='endpoint stats unavailable: ...'),
              endusers=FeatureGap(reason='not requested for this subject'),
              ranked_endpoint_total=40)
```

Neither branch is wrong. The test just reads the world it was written in, and the intended Layer-1 then Layer-2 order is the order that breaks it. Per-PR CI cannot see it because each PR is green against `main` alone.

## The fix

Drive both worlds explicitly on the module rather than inferring one from the tree:

- The absence test removes the two attributes with `monkeypatch.delattr(..., raising=False)`, so the `ImportError` arm keeps its coverage once the readers land instead of losing it silently. Deleting the test would have dropped that arm entirely.
- A companion test injects the readers and pins the composed shape: an `EstateContext` carrying the snapshot, the end-user half a gap for want rather than for failure, and `ranked_endpoint_total` counting the scored estate.

Both hold whether or not the readers are present, so neither depends on merge order again.

## Verification

- This branch alone: 1305 pass on 3.12 and 3.13, ruff and format clean.
- With #88 merged in: same suite passes, where it previously failed.
- Three mutants killed: dropping the absence simulation reproduces the original failure; breaking the composition fails the companion test; removing the `ImportError` arm fails the absence test.

Also worth knowing for merge planning, unrelated to this change: #89 and #90 conflict with each other in `skills/catalog.py`, `skills/handlers.py`, `skills/models.py` and `tests/test_skills.py`, so the second to merge needs a rebase.
