### PR TITLE
fix(masking): mask filter_applied when it echoes compiled filter entries

### DIFF
--- a/src/fortianalyzer_mcp/masking/fields.py
+++ b/src/fortianalyzer_mcp/masking/fields.py
@@ -305,6 +305,23 @@ COMPOSITE_PREFIXED = ("groupby1", "groupby2")
 COMPOSITE_JSON = ("grpby",)
 COMPOSITE_TARGET = ("target",)
 
+#: ``filter_applied`` when a tool echoes a *compiled* filter as
+#: ``[[field, op, value], ...]`` rather than as one string. Argument
+#: unmasking runs at the wrapper boundary, so a tool that compiles a
+#: caller's structured filter is holding the RESOLVED identifier by the time
+#: it builds these entries; echoing them untyped hands the raw value back to
+#: the model, unlocked by the model's own token.
+#:
+#: TEXT is not enough on its own. Pass 2 substitutes values this response
+#: mapped and scans for IPv4/MAC/email shapes, so an entry survives in clear
+#: exactly when the query matched nothing and the mapping is therefore empty:
+#: a hostname, a username or an IPv6 address rides straight back out. Each
+#: entry names its own field, so ``wrapper._mask_filter_entries`` masks the
+#: value by that field's type instead, the inverse of the way a structured
+#: condition is resolved on the way in. The string form of the key keeps its
+#: ordinary TEXT treatment.
+COMPOSITE_FILTER_ENTRIES = ("filter_applied",)
+
 #: fortiview ``top-threats`` pair, masked together by
 #: ``wrapper._mask_threat_pair``: a non-empty ``obf_url`` marks the row as
 #: a browsed-domain threat; ``obf_url`` itself is the ``[dot]``-escaped

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -58,6 +58,7 @@ from typing import Any
 
 from fortianalyzer_mcp.masking.fields import (
     COMPOSITE_DEVICE_VDOM,
+    COMPOSITE_FILTER_ENTRIES,
     COMPOSITE_JSON,
     COMPOSITE_PREFIXED,
     COMPOSITE_TARGET,
@@ -773,7 +774,9 @@ class OutputMasker:
         if isinstance(obj, dict):
             out: dict[str, Any] = {}
             for key, value in obj.items():
-                if self._field_types.get(key.lower()) == TEXT:
+                if key.lower() in COMPOSITE_FILTER_ENTRIES and isinstance(value, list):
+                    out[key] = self._mask_filter_entries(value, mapping)
+                elif self._field_types.get(key.lower()) == TEXT:
                     out[key] = self._mask_text_tree(value, mapping)
                 else:
                     out[key] = self._mask_free_text(value, mapping)
@@ -781,6 +784,47 @@ class OutputMasker:
         if isinstance(obj, list):
             return [self._mask_free_text(item, mapping) for item in obj]
         return obj
+
+    def _mask_filter_entries(self, value: Any, mapping: dict[str, str]) -> Any:
+        """``filter_applied`` as compiled ``[field, op, value]`` entries.
+
+        A tool that compiles a structured filter echoes what it actually sent,
+        which is the resolved value: argument unmasking runs at the wrapper
+        boundary, so by the time the tool body builds its entries the token the
+        caller passed is already the real identifier. Echoed untyped, that
+        hands the raw value straight back to the model, and it is the caller's
+        own token that unlocked it.
+
+        TEXT alone cannot close it. Pass 2 substitutes values this response
+        mapped and scans for IPv4/MAC/email shapes, so an entry survives in
+        clear whenever the query matched nothing, which is exactly when the
+        mapping is empty. A hostname, a username or an IPv6 address then rides
+        back out untouched.
+
+        The entry states its own type, so use it: mask the value by the type of
+        the field named beside it, the inverse of the way arguments are
+        resolved on the way in. This runs in pass 2 rather than pass 1
+        deliberately: pass 2 is the only pass that touches a TEXT key, and a
+        masked IPv4 is itself a valid IPv4, so masking in pass 1 and then
+        letting the free-text scan walk the same entries would mask it twice.
+
+        Anything that is not a three-part entry, or whose field carries no
+        type, falls back to the ordinary free-text treatment rather than being
+        guessed at.
+        """
+        out: list[Any] = []
+        for entry in value:
+            if not isinstance(entry, list | tuple) or len(entry) != 3:
+                out.append(self._mask_text_tree(entry, mapping))
+                continue
+            field, op, raw = entry
+            vtype = self._field_types.get(field.lower()) if isinstance(field, str) else None
+            if vtype is None or vtype == TEXT or not isinstance(raw, str):
+                out.append(self._mask_text_tree(list(entry), mapping))
+                continue
+            masked = self._mask_scalar(vtype, raw, mapping)
+            out.append([field, op, masked] if isinstance(entry, list) else (field, op, masked))
+        return out
 
     def _mask_text_tree(self, value: Any, mapping: dict[str, str]) -> Any:
         if isinstance(value, str):

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -1375,3 +1375,67 @@ class TestWave3SkillAssemblyKeys:
         assert PEER_IP not in str(masked)
         token = masked["rows"][0]["srcip"]
         assert masked["sweep"]["pivot_filter"] == f'srcip=="{token}"'
+
+
+class TestCompiledFilterEntries:
+    """``filter_applied`` echoed as compiled ``[field, op, value]`` entries.
+
+    Argument unmasking runs at the wrapper boundary, so a tool that compiles a
+    caller's structured filter holds the RESOLVED identifier by the time it
+    builds its entries. Echoing them untyped hands the raw value back to the
+    model, unlocked by the model's own token, and TEXT alone cannot stop it:
+    pass 2 can only substitute values this response mapped or match an
+    IPv4/MAC/email shape, so an entry survives in clear exactly when the query
+    matched nothing.
+    """
+
+    def test_a_hostname_entry_carries_the_typed_token(self, masker: OutputMasker):
+        expected = masker.mask_result({"hostname": SRC_NAME})["hostname"]
+        masked = masker.mask_result(
+            {"count": 0, "devices": [], "filter_applied": [["hostname", "==", SRC_NAME]]}
+        )
+
+        assert SRC_NAME not in str(masked)
+        assert masked["filter_applied"] == [["hostname", "==", expected]]
+
+    def test_a_username_entry_carries_the_typed_token(self, masker: OutputMasker):
+        expected = masker.mask_result({"user": ANALYST})["user"]
+        masked = masker.mask_result({"count": 0, "filter_applied": [["user", "==", ANALYST]]})
+
+        assert masked["filter_applied"] == [["user", "==", expected]]
+
+    def test_an_ipv6_entry_masks_where_the_text_scan_cannot(self, masker: OutputMasker):
+        # The pass-2 IOC scan is IPv4 only, so this one is invisible to it.
+        ipv6 = "2001:db8::7"
+        expected = masker.mask_result({"srcip": ipv6})["srcip"]
+        masked = masker.mask_result({"count": 0, "filter_applied": [["srcip", "==", ipv6]]})
+
+        assert ipv6 not in str(masked)
+        assert masked["filter_applied"] == [["srcip", "==", expected]]
+
+    def test_an_ipv4_entry_is_masked_exactly_once(self, masker: OutputMasker):
+        # A masked IPv4 is still a valid IPv4, so an entry masked in pass 1 and
+        # then walked again by the free-text scan would come back double
+        # masked. Equality with the typed token is what pins single masking.
+        expected = masker.mask_result({"srcip": PEER_IP})["srcip"]
+        masked = masker.mask_result({"count": 0, "filter_applied": [["srcip", "==", PEER_IP]]})
+
+        assert masked["filter_applied"] == [["srcip", "==", expected]]
+
+    def test_the_string_form_keeps_its_text_treatment(self, masker: OutputMasker):
+        expected = masker.mask_result({"srcip": PEER_IP})["srcip"]
+        masked = masker.mask_result({"filter_applied": f"srcip=={PEER_IP}"})
+
+        assert masked["filter_applied"] == f"srcip=={expected}"
+
+    def test_an_untypeable_field_falls_back_to_the_text_scan(self, masker: OutputMasker):
+        # No type to mask by, so the entry is not guessed at; the IOC scan
+        # still catches an address shape rather than passing it through.
+        masked = masker.mask_result({"filter_applied": [["mystery", "==", PEER_IP]]})
+
+        assert PEER_IP not in str(masked)
+
+    def test_shapes_that_are_not_entries_are_left_alone(self, masker: OutputMasker):
+        masked = masker.mask_result({"filter_applied": ["a note", ["only", "two"]]})
+
+        assert masked["filter_applied"] == ["a note", ["only", "two"]]


### PR DESCRIPTION
The masking half of the #94 review, kept separate from that PR so it can be judged on its own.

## The leak

Argument unmasking runs at the wrapper boundary, so a tool that compiles a caller's structured filter is holding the resolved identifier by the time it builds its entries. Echoing them back as `[field, op, value]` hands the raw value to the model, and it is the model's own token that unlocked it: send `host-<kid>-...`, read `host.example.com` out of the echo.

TEXT does not close it. Pass 2 substitutes values this response mapped and scans for IPv4/MAC/email shapes, so an entry survives in clear exactly when the query matched nothing, which is precisely when the mapping is empty. Measured on the #94 branch through the real `ArgUnmasker` and `OutputMasker`:

| value | echoed back | leak |
|---|---|---|
| hostname | `host.example.com` | yes |
| username | `jdoe` | yes |
| IPv6 | `2001:db8::7` | yes |
| IPv4 | re-masked by the IOC scan | no |
| control: same query returning one row | re-masked from the mapping | no |

That control row is the tell. Whether the value is disclosed depends on whether the response happened to carry it somewhere else, which is not a property anyone should be relying on.

## The fix

Each entry names its own field, so mask the value by that field's type: the exact inverse of the way a structured condition is resolved on the way in.

It sits in pass 2 rather than pass 1 deliberately. Pass 2 is the only pass that touches a TEXT key, and a masked IPv4 is itself a valid IPv4, so masking in pass 1 and then letting the free-text scan walk the same entries would mask it twice. One of the tests pins that by asserting an IPv4 entry comes out equal to the token the typed path mints, which a double-masked value would not.

Entries that carry no typeable field, or that are not three-part entries, fall back to the ordinary free-text treatment rather than being guessed at. The string form of `filter_applied`, which is what every tool on main emits today, is untouched.

## Scope

No tool on main echoes the list shape yet, so this is forward-compatible groundwork rather than a fix to current output. The shape arrives with the structured-filter work in #94, where `search_devices` and `list_tasks` both echo compiled entries. Landing it here keeps the masking change reviewable on its own, and it covers any tool that echoes compiled conditions later rather than just those two.

Same pattern as #92: the masking layer learns the vocabulary before the surface that produces it merges.

## Verification

1346 pass on 3.12 and 3.13, ruff, format and mypy clean. Red without the fix: 3 fail. Two mutants killed: re-scanning an entry after masking it (the double-mask case), and returning an untypeable entry raw instead of text-scanning it.
