### PR TITLE
fix(masking): resolve masked tokens in `like` filter clauses

### DIFF
--- a/src/fortianalyzer_mcp/masking/unmask.py
+++ b/src/fortianalyzer_mcp/masking/unmask.py
@@ -67,7 +67,7 @@ logger = logging.getLogger(__name__)
 # field==value / field=value / field contain value, single or double quoted
 _FILTER_CLAUSE_RE = re.compile(
     r"(?P<field>[A-Za-z_][A-Za-z0-9_]*)"
-    r"\s*(?P<op>==|!=|<=|>=|=~|!~|<|>|=(?![=~])|~|!contain\b|\bcontain\b)\s*"
+    r"\s*(?P<op>==|!=|<=|>=|=~|!~|<|>|=(?![=~])|~|!contain\b|\bcontain\b|\blike\b)\s*"
     r"(?P<quote>[\"']?)(?P<value>[^\"'\s()]+)(?P=quote)"
 )
 _FILTER_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")
@@ -235,15 +235,23 @@ class ArgUnmasker:
         def clause_sub(match: re.Match[str]) -> str:
             field = match.group("field")
             raw = match.group("value")
+            # ``like`` wraps the token in ``%`` wildcards (``field like "%tok%"``);
+            # resolve the token inside them and re-apply so the pattern holds.
+            lead, core, trail = "", raw, ""
+            if match.group("op").strip().lower() == "like":
+                wc = re.match(r"^(%*)(.*?)(%*)$", raw)
+                if wc:
+                    lead, core, trail = wc.group(1), wc.group(2), wc.group(3)
             if field.lower() in COMPOSITE_URL_FULL:
-                resolved = self.resolve_url(raw)
+                resolved = self.resolve_url(core)
             elif field.lower() in COMPOSITE_PREFIXED:
-                resolved = self.resolve_prefixed(raw)
+                resolved = self.resolve_prefixed(core)
             else:
                 vtype = FIELD_TYPES.get(field.lower())
-                resolved = self.resolve_scalar(raw, vtype)
-            if resolved == raw:
+                resolved = self.resolve_scalar(core, vtype)
+            if resolved == core:
                 return match.group(0)
+            resolved = f"{lead}{resolved}{trail}"
             if _FILTER_CONTROL_RE.search(resolved):
                 logger.warning(
                     "resolved filter value has control characters; token left unresolved"

--- a/src/fortianalyzer_mcp/masking/unmask.py
+++ b/src/fortianalyzer_mcp/masking/unmask.py
@@ -67,7 +67,7 @@ logger = logging.getLogger(__name__)
 # field==value / field=value / field contain value, single or double quoted
 _FILTER_CLAUSE_RE = re.compile(
     r"(?P<field>[A-Za-z_][A-Za-z0-9_]*)"
-    r"\s*(?P<op>==|!=|<=|>=|=~|!~|<|>|=(?![=~])|~|!contain\b|\bcontain\b|\blike\b)\s*"
+    r"\s*(?P<op>==|!=|<=|>=|=~|!~|<|>|=(?![=~])|~|!contain\b|\bcontain\b|\b(?ai:like)\b)\s*"
     r"(?P<quote>[\"']?)(?P<value>[^\"'\s()]+)(?P=quote)"
 )
 _FILTER_CONTROL_RE = re.compile(r"[\x00-\x1f\x7f]")

--- a/tests/test_masking_unmask.py
+++ b/tests/test_masking_unmask.py
@@ -123,6 +123,16 @@ class TestFilterExpressions:
 
         assert unmasker.unmask_filter(f'srcip !contain "{token}"') == 'srcip !contain "192.0.2.102"'
 
+    def test_like_operator_resolves_token_inside_wildcards(
+        self, unmasker: ArgUnmasker, engine: FPEEngine
+    ):
+        # `like` is the substring operator the server now emits; the masked
+        # token sits between % wildcards and must round-trip with them kept.
+        token = engine.mask_ip("192.0.2.102")
+
+        assert unmasker.unmask_filter(f'srcip like "%{token}%"') == 'srcip like "%192.0.2.102%"'
+        assert unmasker.unmask_filter(f'srcip like "{token}%"') == 'srcip like "192.0.2.102%"'
+
     @pytest.mark.parametrize(
         "expression",
         [

--- a/tests/test_masking_unmask.py
+++ b/tests/test_masking_unmask.py
@@ -133,6 +133,23 @@ class TestFilterExpressions:
         assert unmasker.unmask_filter(f'srcip like "%{token}%"') == 'srcip like "%192.0.2.102%"'
         assert unmasker.unmask_filter(f'srcip like "{token}%"') == 'srcip like "192.0.2.102%"'
 
+    def test_uppercase_like_resolves_token(self, unmasker: ArgUnmasker, engine: FPEEngine):
+        # FortiAnalyzer accepts uppercase LIKE (live-confirmed on 7.6.7 + 8.0.0);
+        # the operator match is case-insensitive so a caller-authored LIKE still
+        # resolves, and the caller's casing is preserved in the output.
+        token = engine.mask_ip("192.0.2.102")
+
+        assert unmasker.unmask_filter(f'srcip LIKE "%{token}%"') == 'srcip LIKE "%192.0.2.102%"'
+
+    def test_like_complement_form_resolves_token(self, unmasker: ArgUnmasker, engine: FPEEngine):
+        # `!(field like "%x%")` is the negation FAZ actually accepts (not like
+        # is rejected), so it is the shape callers send; the parens survive.
+        token = engine.mask_ip("192.0.2.102")
+
+        assert (
+            unmasker.unmask_filter(f'!(srcip like "%{token}%")') == '!(srcip like "%192.0.2.102%")'
+        )
+
     @pytest.mark.parametrize(
         "expression",
         [


### PR DESCRIPTION
## Problem

`masking/unmask.py`'s `_FILTER_CLAUSE_RE` recognises `==`, `!=`, `<`, `>`, `<=`, `>=`, `=~`, `!~`, `~` and `contain`/`!contain` — but **not `like`**. With masking enabled, a masked token inside a raw `filter` string such as `srcip like "%<token>%"` is therefore never resolved and reaches FortiAnalyzer **masked**, returning wrong/zero rows for a filter that looks correct.

Pre-existing gap (FortiAnalyzer has always accepted `like`), now more reachable because `like` is the substring operator the server emits and the `filter_applied` echo carries it. Surfaced by a deep review of #94; **independent of #94's code** — it lives in core masking, which is why it's a standalone PR against `main`.

## Fix

- Add `like` to the clause operator alternation.
- `like` wraps the token in `%` wildcards, so `clause_sub` strips them, resolves the token inside, and re-applies them — the token round-trips while the wildcard pattern is preserved. No change for any other operator.

## Test

`test_like_operator_resolves_token_inside_wildcards` — a masked IP inside `%…%` (and trailing-only `…%`) round-trips to the real value. 292 masking tests pass; ruff/format/mypy clean.