### PR TITLE
fix(ueba): get_endpoint_vulnerabilities unions all detectors when detectby omitted (#87)

### DIFF
--- a/src/fortianalyzer_mcp/tools/ueba_tools.py
+++ b/src/fortianalyzer_mcp/tools/ueba_tools.py
@@ -23,6 +23,18 @@ logger = logging.getLogger(__name__)
 _VALID_ENDPOINT_DETAIL = {"simple", "basic", "standard"}
 _VALID_ENDUSER_DETAIL = {"basic", "standard", "extended"}
 _VALID_DETECTBY = {"FortiClient", "FortiGate"}
+
+
+def _vuln_records(payload: Any) -> list[Any]:
+    """Normalize a vulnerability response to a list of per-endpoint records."""
+    if isinstance(payload, list):
+        return payload
+    if isinstance(payload, dict):
+        data = payload.get("data")
+        return data if isinstance(data, list) else ([payload] if payload else [])
+    return []
+
+
 _VALID_ENDUSER_STATS_ITEM = {"total-count", "new-count"}
 
 
@@ -109,7 +121,10 @@ async def get_endpoint_vulnerabilities(
     Args:
         adom: ADOM name (default: from config DEFAULT_ADOM)
         epids: Optional list of endpoint IDs to scope the query
-        detectby: Optional detector filter: "FortiClient" or "FortiGate"
+        detectby: Detector filter ("FortiClient" or "FortiGate"). Omitted
+            (the default) queries every detector and returns the combined
+            records, because the appliance returns nothing when the filter
+            is absent.
 
     Returns:
         dict with vulnerability records under "data"
@@ -131,9 +146,22 @@ async def get_endpoint_vulnerabilities(
 
         logger.info(f"Getting UEBA endpoint vulnerabilities from ADOM {adom}")
 
-        result = await client.get_endpoint_vulnerabilities(
-            adom=adom, epids=epids, detectby=detectby
-        )
+        if detectby is None:
+            # The appliance returns nothing when the detector filter is
+            # absent, so an omitted detectby silently read as "no
+            # vulnerabilities" (#87). Query every detector and combine the
+            # per-endpoint records so an omitted filter means "all", not "none".
+            combined: list[Any] = []
+            for det in sorted(_VALID_DETECTBY):
+                recs = await client.get_endpoint_vulnerabilities(
+                    adom=adom, epids=epids, detectby=det
+                )
+                combined.extend(_vuln_records(recs))
+            result: Any = combined
+        else:
+            result = await client.get_endpoint_vulnerabilities(
+                adom=adom, epids=epids, detectby=detectby
+            )
         return {"status": "success", "data": result}
     except Exception as e:
         logger.error(f"Failed to get UEBA endpoint vulnerabilities: {e}")

--- a/tests/test_ueba_tools.py
+++ b/tests/test_ueba_tools.py
@@ -21,6 +21,7 @@ class _FakeClient:
     def __init__(self, payload: Any) -> None:
         self.payload = payload
         self.calls: dict[str, dict[str, Any]] = {}
+        self.vuln_detectby_seen: list[Any] = []
 
     async def get_endpoints(self, **kwargs: Any) -> Any:
         self.calls["get_endpoints"] = kwargs
@@ -28,6 +29,7 @@ class _FakeClient:
 
     async def get_endpoint_vulnerabilities(self, **kwargs: Any) -> Any:
         self.calls["get_endpoint_vulnerabilities"] = kwargs
+        self.vuln_detectby_seen.append(kwargs.get("detectby"))
         return self.payload
 
     async def get_endusers(self, **kwargs: Any) -> Any:
@@ -104,11 +106,18 @@ class TestGetEndpointVulnerabilities:
         assert result["status"] == "error"
         assert "Validation error" in result["message"]
 
-    async def test_detectby_optional(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        fake = _patch_client(monkeypatch, [])
+    async def test_detectby_omitted_unions_all_detectors(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The appliance returns nothing without a detector filter, so an
+        # omitted detectby must query every detector and combine (#87), not
+        # forward a single None that reads as "no vulnerabilities".
+        fake = _patch_client(monkeypatch, [{"epid": "1", "vuln-group": {"vulnerabilities": []}}])
         result = await ueba_tools.get_endpoint_vulnerabilities()
         assert result["status"] == "success"
-        assert fake.calls["get_endpoint_vulnerabilities"]["detectby"] is None
+        assert sorted(fake.vuln_detectby_seen) == ["FortiClient", "FortiGate"]
+        # one record per detector call is combined into the result
+        assert len(result["data"]) == 2
 
 
 # --------------------------------------------------------------------- #


### PR DESCRIPTION
Closes #87.

## Problem
The FortiAnalyzer UEBA vuln endpoint (`GET /ueba/adom/{adom}/endpoints/vuln`) returns **nothing** when the `detectby` filter is absent. The tool documented `detectby` as optional, so omitting it silently read as "no vulnerabilities."

**Reproduced live on 7.6.7** (ADOM staged fixture): `detectby="FortiClient"` returns the full CVE list; omitting it returns `data: []`.

## Fix
When `detectby` is `None`, query **every** detector (`FortiClient`, `FortiGate`) and return the combined per-endpoint records, so an omitted filter means "all", not "none". An explicit `detectby` is unchanged; internal callers (the skills handlers) that pass a specific detector are unaffected.

## Test
`test_detectby_omitted_unions_all_detectors` asserts both detectors are queried and the records combined. 21 `test_ueba_tools` pass; ruff/format/mypy clean.