### PR TITLE
masking: cover srcuuid_name/dstuuid_name address-object labels (#80)

### DIFF
--- a/src/fortianalyzer_mcp/masking/fields.py
+++ b/src/fortianalyzer_mcp/masking/fields.py
@@ -239,6 +239,22 @@ FIELD_TYPES: dict[str, str] = {
     "ui": TEXT,  # event: frequently embeds the admin source IP, e.g. GUI(10.0.0.1)
     "prompt": TEXT,  # app-ctrl: GenAI prompt text
     "description": TEXT,  # eventmgmt handler config: operator-authored prose
+    # --- resolved address-object labels (traffic logs). srcuuid_name /
+    # dstuuid_name are the *names* of the firewall address objects that
+    # matched the session's src/dst — operator-authored labels populated on
+    # ~90% of live rows (230,092/256,483 on the reference estate, #80). The
+    # raw uuids (srcuuid/dstuuid) carry no human content and are left out;
+    # the resolved *name* is the leak. TEXT rather than HOSTNAME: an object
+    # label is free-form ("Printer Floor 3", "jdoe-laptop", "all"), so
+    # HOSTNAME masking would burn anything carrying a space or punctuation
+    # to an irreversible placeholder. TEXT never burns and masks any
+    # embedded IOC (bare IPv4/MAC/email) in place. Documented residual: a
+    # plain descriptive label with no embedded IOC rides through clear —
+    # accepted here as the conservative direction (a burned routing/label
+    # value is worse than a readable object name); revisit at GA if a
+    # burn-tolerant name type is added.
+    "srcuuid_name": TEXT,
+    "dstuuid_name": TEXT,
     # --- eventmgmt / incidentmgmt object keys (NOT log fields; found by
     # leak-testing verbatim alert and incident records)
     "endpoint": IP_OR_HOST,  # incident: an address or an endpoint name

--- a/src/fortianalyzer_mcp/masking/fields.py
+++ b/src/fortianalyzer_mcp/masking/fields.py
@@ -253,6 +253,16 @@ FIELD_TYPES: dict[str, str] = {
     # accepted here as the conservative direction (a burned routing/label
     # value is worse than a readable object name); revisit at GA if a
     # burn-tolerant name type is added.
+    # Round-trip residual: the traffic vocabulary is complete=False, so these
+    # names pass through as structured filter fields and the appliance does
+    # serve them (exact equality on a displayed label returns rows on 7.6.7
+    # and 8.0.0). A label carrying an embedded IOC masks outbound but does
+    # not resolve inbound: _unmask_entry passes a vtype to resolve_scalar
+    # only for IP/MAC/IP_OR_HOST, so a TEXT value falls through untyped and
+    # reverses only when the *whole* string is a marked token. An IP token
+    # sitting mid-string is neither, so re-using a displayed label as a
+    # filter value sends a plausible-but-wrong address to the appliance,
+    # silently. Pre-existing to every filterable TEXT field; tracked on #73.
     "srcuuid_name": TEXT,
     "dstuuid_name": TEXT,
     # --- eventmgmt / incidentmgmt object keys (NOT log fields; found by

--- a/tests/test_masking_wrapper.py
+++ b/tests/test_masking_wrapper.py
@@ -184,6 +184,24 @@ class TestTextScan:
         assert "bob@example.com" not in str(masked)
         assert masked["msg"][1] == "second line"
 
+    def test_uuid_name_labels_typed_text(self):
+        # srcuuid_name/dstuuid_name are resolved address-object labels, added
+        # as TEXT (#80): free-form, so HOSTNAME would burn on spaces.
+        assert FIELD_TYPES["srcuuid_name"] == TEXT
+        assert FIELD_TYPES["dstuuid_name"] == TEXT
+        # The raw uuids carry no human content and stay out of the table.
+        assert "srcuuid" not in FIELD_TYPES
+        assert "dstuuid" not in FIELD_TYPES
+
+    def test_uuid_name_masks_embedded_ioc_leaves_label_clear(self, masker: OutputMasker):
+        # TEXT masks an embedded IOC in place; a plain label rides through
+        # (the documented residual).
+        masked = masker.mask_result(
+            {"srcuuid_name": "host 192.0.2.51", "dstuuid_name": "Printer Floor 3"}
+        )
+        assert "192.0.2.51" not in masked["srcuuid_name"]
+        assert masked["dstuuid_name"] == "Printer Floor 3"
+
     def test_text_dict_typed_key_is_not_double_masked(self, masker: OutputMasker):
         nested = masker.mask_result({"msg": {"srcip": "192.0.2.9"}})["msg"]["srcip"]
         bare = masker.mask_result({"srcip": "192.0.2.9"})["srcip"]


### PR DESCRIPTION
Closes the one clear, evidence-backed leak from the #80 masking-coverage audit.

## What

`srcuuid_name` / `dstuuid_name` — the resolved *names* of the firewall address objects that matched a session's src/dst — leaked verbatim. They're populated on ~90% of live traffic rows (230,092/256,483 on the reference estate, per the #80 evidence).

Added both to `FIELD_TYPES` as **TEXT**.

## Why TEXT and not HOSTNAME

Object labels are free-form (`Printer Floor 3`, `jdoe-laptop`, `all`). `HOSTNAME` masking would burn anything with a space or punctuation to an irreversible placeholder. `TEXT` never burns and masks any embedded IOC (bare IPv4/MAC/email) in place.

**Documented residual:** a plain descriptive label with no embedded IOC rides through clear. Accepted as the conservative direction (a burned label is worse than a readable object name). If we'd rather burn-risk a stricter `HOSTNAME` type, that's a one-line change — open to Christian's call on the #80 thread.

The raw `srcuuid`/`dstuuid` carry no human content and stay out of the table (a test asserts this).

## Tests

- `test_uuid_name_labels_typed_text` — both typed TEXT; raw uuids absent
- `test_uuid_name_masks_embedded_ioc_leaves_label_clear` — embedded IP masks, plain label rides through (pins the residual)

Full masking suite: 327 passed.