### PR TITLE
ci: pin mcp<2 (upstream 2.0 dropped mcp.server.fastmcp)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "mcp>=1.0.0",
+    "mcp>=1.0.0,<2",  # 2.0 removed mcp.server.fastmcp (our whole API); pin to 1.x until a deliberate migration
     "pydantic>=2.0.0",
     "pydantic-settings>=2.3.0",
     "httpx>=0.27.0",


### PR DESCRIPTION
## Problem

`mcp==2.0.0` (upstream MCP Python SDK) released **2026-07-28** and **removed `mcp.server.fastmcp`** — the module the entire server is built on (`server.py:9 from mcp.server.fastmcp import FastMCP`, all `@mcp.tool` registration). Verified in a clean install: the `fastmcp` submodule is gone and there is no `FastMCP` class anywhere in 2.0.0 (it's replaced by a new `mcp.server.mcpserver.MCPServer` API).

The repo floats dependencies (`uv.lock` is gitignored), so CI's `mcp>=1.0.0` resolved to 2.0.0 the moment it landed — every push/PR now fails at **collection time** with `ModuleNotFoundError: No module named 'mcp.server.fastmcp'` across 29 test modules. `main`'s last CI passed at 12:52; the next run at 14:02 failed. Nothing in our code changed.

## Fix

Cap `mcp>=1.0.0,<2`. 1.x still has the FastMCP API we use; `uv lock` refreshes to 1.26.0. This unblocks the whole repo (and PR #101).

Note: `--frozen` in CI was considered but the lockfile is intentionally gitignored, so a cap in `pyproject.toml` is the right guard here.

## Follow-up

Migrating to the mcp 2.0 `MCPServer` API is tracked separately (see the linked issue). No urgency — 1.x is current and supported.