### PR TITLE
fix(masking): close the composite-shape and target-entry fail-open residuals (#73)

### DIFF
--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -263,9 +263,10 @@ class OutputMasker:
         there is no reliable type for reversible masking. So does a whole
         ``target`` that is not a list, an entry that is not a dict, and a
         map-shaped ``value`` whose key carries the identifier. An entry
-        that IS a dict but carries neither ``name`` nor ``value`` is still
-        walked by the allowlist, so an identifier parked in its own key
-        survives; that shape is unattested and tracked separately.
+        that IS a dict but carries neither ``name`` nor ``value`` burns
+        whole for the same reason: with no slot to type it by, the
+        identifier is parked in the entry's own key, which the allowlist
+        walk would copy through in clear (#73).
         """
         out: list[Any] = []
         for item in value:
@@ -277,12 +278,19 @@ class OutputMasker:
                 continue
             name: Any = ""
             raw: Any = None
+            has_name = False
+            has_value = False
             for key, item_value in item.items():
                 lowered = key.lower()
                 if lowered == "name":
                     name = item_value
+                    has_name = True
                 elif lowered == "value":
                     raw = item_value
+                    has_value = True
+            if not has_name and not has_value:
+                out.append(self._burn_strings(item, keep))
+                continue
             vtype = TARGET_NAME_TYPES.get(str(name).lower())
             if vtype is None:
                 masked_value = self._burn_strings(raw, keep)
@@ -318,9 +326,24 @@ class OutputMasker:
                     entry[key] = masked_value
                 elif lowered == "asset_value":
                     # asset_value repeats the identifier on some targets and
-                    # carries an internal numeric id on others; mask only the
-                    # former.
-                    entry[key] = masked_value if item_value == raw else item_value
+                    # carries an internal id on others. The id case is a bare
+                    # number; a differing non-numeric string is a second
+                    # identifier for the same asset, so it gets the entry's
+                    # own type, and with no type to mask by it burns like the
+                    # value did (#73). Differing containers burn whole.
+                    if item_value == raw:
+                        entry[key] = masked_value
+                    elif isinstance(item_value, str):
+                        if item_value in keep or item_value.isdigit():
+                            entry[key] = item_value
+                        elif vtype is None:
+                            entry[key] = self._burn_strings(item_value, keep)
+                        else:
+                            entry[key] = self._mask_scalar(vtype, item_value, mapping)
+                    elif isinstance(item_value, list | tuple | dict):
+                        entry[key] = self._burn_strings(item_value, keep)
+                    else:
+                        entry[key] = item_value
                 else:
                     entry[key] = self._mask_entry(key, item_value, mapping, keep)
             out.append(entry)
@@ -725,10 +748,29 @@ class OutputMasker:
         lowered = key.lower()
         if lowered in COMPOSITE_PREFIXED and isinstance(value, str):
             return self._mask_prefixed(value, mapping)
+        if lowered in COMPOSITE_PREFIXED and isinstance(value, list):
+            # list-valued group-bys are a normal FAZ variation (#73): each
+            # element gets the same prefixed treatment the string form gets.
+            # A dict-shaped groupby stays with the allowlist walk below,
+            # which types it by its inner keys.
+            return [
+                self._mask_prefixed(item, mapping)
+                if isinstance(item, str)
+                else self._mask_structured(item, mapping, keep)
+                for item in value
+            ]
         if lowered in COMPOSITE_JSON and isinstance(value, str):
             return self._mask_json_blob(value, mapping)
         if lowered in COMPOSITE_URL_HOST and isinstance(value, str):
             return self._mask_url_host(value, mapping)
+        if lowered in COMPOSITE_URL_HOST and isinstance(value, list):
+            # same list convention the typed fields handle below
+            return [
+                self._mask_url_host(item, mapping)
+                if isinstance(item, str)
+                else self._mask_structured(item, mapping, keep)
+                for item in value
+            ]
         if lowered in COMPOSITE_URL_FULL and isinstance(value, str):
             return self._mask_url_full(value, mapping)
         if lowered in COMPOSITE_URL_FULL and isinstance(value, list):
@@ -739,6 +781,16 @@ class OutputMasker:
                 else self._mask_structured(item, mapping, keep)
                 for item in value
             ]
+        if (lowered in COMPOSITE_URL_HOST or lowered in COMPOSITE_URL_FULL) and isinstance(
+            value, dict
+        ):
+            # A map under a URL key has no slot the URL handlers can type,
+            # and the allowlist walk knows none of its inner keys, so the
+            # destination would ride through in clear (#73). Fail closed on
+            # the whole shape, same policy as a non-list target below. The
+            # cost is the same too: any analytic structure a producer put
+            # there burns rather than round-tripping.
+            return self._burn_strings(value, keep)
         if lowered in COMPOSITE_TARGET:
             if isinstance(value, list):
                 return self._mask_target(value, mapping, keep)

--- a/tests/test_masking_wrapper.py
+++ b/tests/test_masking_wrapper.py
@@ -545,3 +545,137 @@ class TestInstallMasking:
         import os
 
         assert os.environ.get("FAZ_MASKING_KEY") == KEY
+
+
+class TestCompositeListShapes:
+    """#73 item 1: composite keys arriving as lists must not fall through
+    to the allowlist walk, which cannot type a bare string element."""
+
+    def test_prefixed_list_masks_each_element(self, masker: OutputMasker):
+        raw = "192.0.2.90"
+        masked = masker.mask_result({"groupby1": [f"srcip:{raw}", "srcport:443"]})
+
+        assert raw not in str(masked)
+        assert masked["groupby1"][0].startswith("srcip:")
+        # same treatment as the string shape, element for element
+        twin = masker.mask_result({"groupby1": f"srcip:{raw}"})["groupby1"]
+        assert masked["groupby1"][0] == twin
+        # an untyped inner field is left alone, exactly like the string shape
+        assert masked["groupby1"][1] == "srcport:443"
+
+    def test_prefixed_list_non_string_item_is_walked(self, masker: OutputMasker):
+        masked = masker.mask_result({"groupby1": ["srcip:192.0.2.90", {"srcip": "192.0.2.91"}]})
+
+        assert "192.0.2.90" not in str(masked)
+        assert "192.0.2.91" not in str(masked)
+
+    def test_url_host_list_masks_each_element(self, masker: OutputMasker):
+        masked = masker.mask_result(
+            {"http_url": ["https://bad.example.com/x", "https://other.example.net/y"]}
+        )
+
+        assert "bad.example.com" not in str(masked)
+        assert "other.example.net" not in str(masked)
+        # host-only masking: request mechanics stay readable
+        assert masked["http_url"][0].endswith("/x")
+        twin = masker.mask_result({"http_url": "https://bad.example.com/x"})["http_url"]
+        assert masked["http_url"][0] == twin
+
+
+class TestCompositeDictShapesFailClosed:
+    """#73 item 1, the dict half: a map under a URL composite key has no
+    slot the handler can type, so it burns whole, same policy as target."""
+
+    def test_url_full_dict_burns(self, masker: OutputMasker):
+        masked = masker.mask_result({"url": {"u": "https://bad.example.com/x"}})
+
+        assert "bad.example.com" not in str(masked)
+        # keys burn too: a key can carry the identifier just as a value can
+        value = next(iter(masked["url"].values()))
+        assert value.startswith("masked-unrepresentable-")
+
+    def test_url_host_dict_burns(self, masker: OutputMasker):
+        masked = masker.mask_result({"http_url": {"u": "https://bad.example.com/x"}})
+
+        assert "bad.example.com" not in str(masked)
+
+    def test_url_dict_key_is_burned(self, masker: OutputMasker):
+        masked = masker.mask_result({"url": {"https://bad.example.com/x": 3}})
+
+        assert "bad.example.com" not in str(masked)
+
+    def test_prefixed_dict_keeps_allowlist_walk(self, masker: OutputMasker):
+        # groupby1 as a dict is typed by its inner keys and was never the
+        # leak; pin that it keeps the reversible walk rather than burning.
+        raw = "192.0.2.92"
+        masked = masker.mask_result({"groupby1": {"srcip": raw}})
+
+        assert raw not in str(masked)
+        assert not masked["groupby1"]["srcip"].startswith("masked-unrepresentable-")
+
+
+class TestTargetEntryWithoutNameOrValue:
+    """#73 item 2: an entry dict with neither slot parks the identifier in
+    its own key, where the rebuild loop used to copy it through."""
+
+    def test_entry_keyed_by_identifier_burns(self, masker: OutputMasker):
+        masked = masker.mask_result({"target": [{"192.0.2.5": {"note": "campus"}}]})
+
+        assert "192.0.2.5" not in str(masked)
+        assert "campus" not in str(masked)
+
+    def test_entry_with_name_slot_keeps_current_treatment(self, masker: OutputMasker):
+        # Only the neither-slot shape burns; a named entry keeps the walk.
+        masked = masker.mask_result({"target": [{"name": "ip", "note": "campus"}]})
+
+        assert masked["target"][0]["note"] == "campus"
+
+
+class TestAssetValueDiffering:
+    """#73 item 3: an asset_value that differs from value used to pass
+    through in clear even when it is a second identifier."""
+
+    def test_differing_string_asset_value_masks_by_name_type(self, masker: OutputMasker):
+        import ipaddress
+
+        masked = masker.mask_result(
+            {"target": [{"name": "ip", "value": "192.0.2.57", "asset_value": "192.0.2.58"}]}
+        )
+        entry = masked["target"][0]
+
+        assert "192.0.2.58" not in str(masked)
+        # reversibly masked by the entry's own type, not burned
+        ipaddress.IPv4Address(entry["asset_value"])
+
+    def test_numeric_id_asset_value_stays_clear(self, masker: OutputMasker):
+        masked = masker.mask_result(
+            {"target": [{"name": "ip", "value": "192.0.2.57", "asset_value": "84021"}]}
+        )
+
+        assert masked["target"][0]["asset_value"] == "84021"
+
+    def test_differing_asset_value_unknown_name_burns(self, masker: OutputMasker):
+        masked = masker.mask_result(
+            {"target": [{"name": "whatever", "value": "x", "asset_value": "192.0.2.59"}]}
+        )
+
+        assert "192.0.2.59" not in str(masked)
+        assert masked["target"][0]["asset_value"].startswith("masked-unrepresentable-")
+
+    def test_differing_container_asset_value_burns(self, masker: OutputMasker):
+        masked = masker.mask_result(
+            {"target": [{"name": "ip", "value": "192.0.2.60", "asset_value": ["192.0.2.61"]}]}
+        )
+
+        assert "192.0.2.61" not in str(masked)
+
+    def test_asset_value_in_keep_stays_clear(self, masker: OutputMasker):
+        devid = "FGT60F0000000000"
+        masked = masker.mask_result(
+            {
+                "devid": devid,
+                "target": [{"name": "ip", "value": "192.0.2.62", "asset_value": devid}],
+            }
+        )
+
+        assert masked["target"][0]["asset_value"] == devid


### PR DESCRIPTION
Closes items 1, 2 and 3 of the #73 backlog, the three Roland marked most actionable in the 2026-07-28 reconciliation. Every closed case reproduces on `main` (`627a138`) before this change.

## 1. Composite keys in an unexpected shape no longer fall through

Each composite branch in `_mask_entry` was guarded by `isinstance` with no else, so a differently-shaped payload skipped the handler and fell to the allowlist walk, which cannot type a bare string element:

- **`groupby1`/`groupby2` as a list** now mask each element with the same prefixed handler the string form gets, element for element (a test asserts the list element equals the string-shape twin). Non-string elements keep the structured walk. This is the shape the issue called the most plausible, since list-valued group-bys are a normal FAZ variation.
- **`http_url` as a list** masks each element host-only, the same convention `COMPOSITE_URL_FULL` already had for its list branch.
- **A dict under a URL key (`url`, `referralurl`, `link`, `http_url`)** burns whole. This is the case the issue said wants a decision rather than a patch, so here is the decision as implemented, with the alternative stated: the dict has no slot the URL handlers can type and the allowlist knows none of its inner keys, so the choice is between failing closed (the policy the non-list `target` shapes already got in the #71 round, cost documented in the same words) and walking the dict to url-mask each string leaf, which would preserve the #40 analytic structure at the price of sealing every non-URL string it contains into a url token. I took the precedented fail-closed route; if the analytic-value trade reads better, the branch swaps to a per-leaf walk in one small commit and the tests flip with it.
- **Deliberately untouched, with a pinning test:** `groupby1` as a dict keeps the allowlist walk, which types it by its inner keys and was never the leak. `grpby` and `devvds` shapes are untouched per the issue's "a sweep does not need to touch them".

## 2. A target entry keyed by its own identifier burns

An entry that is a dict but carries neither `name` nor `value` parked the identifier in the entry's own key, which the rebuild loop copied through in clear. Such an entry now burns whole (`_burn_strings` burns keys as well as values, which is the point). The boundary is presence of the slots, not their content, and a second test pins that an entry with a `name` keeps the current treatment, so the burn cannot creep to shapes that can still be typed.

## 3. A differing `asset_value` is no longer echoed in clear

`asset_value` was masked only when it equaled `value`, on the documented grounds that it otherwise carries an internal numeric id. The id case keeps that behavior: a bare-number string stays readable, as does anything in the device-identity keep set. What changes is the rest: a differing non-numeric string is a second identifier for the same asset, so it now masks by the entry's own name-derived type (reversible where the alphabet allows), an unknown-name entry burns it exactly the way its `value` already burned, and a differing container burns whole.

## Evidence

- Suite: 1559 pass on 3.12 and 3.13 (main baseline 1545; fourteen new tests). `ruff check` and `ruff format --check` clean over `src/` and `tests/`.
- Red first: all ten leak tests fail on `main` before the change, for the reasons the issue describes.
- Mutation: six mutants run against the final tree, each killed by a distinct test, including two over-reach mutants (burning entries that have a `name`, and burning groupby dicts) that the two pinning tests catch. Pristine control green.

Items 4-7 of #73 stay open; nothing here touches `mapping`, the keep-set consultation, or the clause regex.
