### PR TITLE
masking: record the uuid_name round-trip residual (#80)

### DIFF
--- a/src/fortianalyzer_mcp/masking/fields.py
+++ b/src/fortianalyzer_mcp/masking/fields.py
@@ -253,6 +253,16 @@ FIELD_TYPES: dict[str, str] = {
     # accepted here as the conservative direction (a burned routing/label
     # value is worse than a readable object name); revisit at GA if a
     # burn-tolerant name type is added.
+    # Round-trip residual: the traffic vocabulary is complete=False, so these
+    # names pass through as structured filter fields and the appliance does
+    # serve them (exact equality on a displayed label returns rows on 7.6.7
+    # and 8.0.0). A label carrying an embedded IOC masks outbound but does
+    # not resolve inbound: _unmask_entry passes a vtype to resolve_scalar
+    # only for IP/MAC/IP_OR_HOST, so a TEXT value falls through untyped and
+    # reverses only when the *whole* string is a marked token. An IP token
+    # sitting mid-string is neither, so re-using a displayed label as a
+    # filter value sends a plausible-but-wrong address to the appliance,
+    # silently. Pre-existing to every filterable TEXT field; tracked on #73.
     "srcuuid_name": TEXT,
     "dstuuid_name": TEXT,
     # --- eventmgmt / incidentmgmt object keys (NOT log fields; found by


### PR DESCRIPTION
The residual comment I drafted on #80 §1, as a commit rather than a review note — @rstierli asked for TEXT to land as written and this changes nothing about that. **Comment only, no behaviour change**, stacked on `mask-uuid-name-labels` so it merges into #101 rather than around it. Close it and I'll re-post as a suggestion if you'd rather not carry a second merge.

### Why

The block #101 adds documents the outbound half of the residual — a plain label with no embedded IOC rides through clear. The inbound half is the sharper one and was unstated:

- The `traffic` vocabulary is `complete=False` (`query/fields.py:262`) and `srcuuid_name` is absent from `_TRAFFIC_FIELDS`, so these names pass through as structured filter fields today. @inxbit confirmed the appliance genuinely serves the column: exact equality on a displayed label returns 694 rows on 7.6.7, and `srcuuid_name!=""` is populated on ~230k/256k rows on both versions.
- A label that *does* carry an IOC masks in place outbound, but `_unmask_entry` (`unmask.py:327`) types the whole value TEXT and falls to `resolve_scalar` with no `vtype` (`unmask.py:342`), which only reverses a whole-string marked token. An IP token sitting mid-string is neither marked nor typed, so it passes through verbatim.

Re-measured on this branch's head (`mask_result` → `unmask_filter_conditions`, same key as the #80 table):

| label | shown | back | |
|---|---|---|---|
| `Printer Floor 3` | `Printer Floor 3` | `Printer Floor 3` | round-trips |
| `jdoe-laptop` | `jdoe-laptop` | `jdoe-laptop` | round-trips |
| `all` | `all` | `all` | round-trips |
| `host 192.0.2.51` | `host 125.177.139.124` | `host 125.177.139.124` | **lost** |

Row 4 reaches the appliance as a different, entirely plausible address — no error, no warning, a filter that matches the wrong thing or nothing. That is worth a line in the block precisely because it is invisible.

Not a reason to hold #101: it is pre-existing to every filterable TEXT field, and @inxbit measured it as latent on their estate (`srcuuid_name like "%.%"` → 0 rows on both versions, with `%-%` → 228,602 as the positive control, so no label there carries a dotted string). The general inbound fix — reverse embedded tokens the way the outbound path masks them in place — is tracked on #73.

### Verification

- `ruff check` / `ruff format --check` clean, `mypy src/` clean (40 files)
- `pytest tests/ --ignore=tests/integration` → **1547 passed**, unchanged from this branch's baseline (comment-only diff)
- CI does not run on this PR: `ci.yml` and `no-ai-attribution.yml` both trigger only on `branches: [main]`, and this one targets `mask-uuid-name-labels`. It runs on #101 against main once this is folded in — hence the local gate results above.
