### PR TITLE
fix(masking): anchor the filter-clause field group at a word boundary (#73)

### DIFF
--- a/src/fortianalyzer_mcp/masking/unmask.py
+++ b/src/fortianalyzer_mcp/masking/unmask.py
@@ -68,14 +68,19 @@ from fortianalyzer_mcp.utils.validation import sanitize_filter_value
 logger = logging.getLogger(__name__)
 
 # field==value / field=value / field contain value, single or double quoted.
-# The lookbehind keeps the field group from starting mid-word: without it a
-# non-clause fragment like "a-srcip=<ip>" reads as a srcip clause and the
-# address is silently transformed (#73 7a). The cost is that a dotted
-# spelling ("foo.srcip") no longer resolves as srcip, which prices at zero:
-# on live 7.6.7 and 8.0.0 a dotted field matches nothing at the appliance,
-# so such a clause only ever produced zero rows.
+# The lookbehind keeps the field group from starting mid-string: without it
+# a non-clause fragment like "a-srcip=<ip>" (or "x /srcip==<ip>", any
+# separator) reads as a srcip clause and the address is silently
+# transformed (#73 7a). It is an allowlist of the places a clause can
+# legitimately begin, measured against live 7.6.7 and 8.0.0: start of
+# string, after whitespace, after "(" (grouping and the !(...) complement),
+# after "&" ("a&&b" parses identically to "a and b"; single "&", "|", "||"
+# and "," are all rejected by the appliance), and after "!" (bare "!f==v"
+# negation is served). The cost is that a dotted spelling ("foo.srcip") no
+# longer resolves as srcip, which prices at zero: a dotted field matches
+# nothing at the appliance, so such a clause only ever produced zero rows.
 _FILTER_CLAUSE_RE = re.compile(
-    r"(?<![A-Za-z0-9_.-])"
+    r"(?<![^\s(!&])"
     r"(?P<field>[A-Za-z_][A-Za-z0-9_]*)"
     r"\s*(?P<op>==|!=|<=|>=|=~|!~|<|>|=(?![=~])|~|!contain\b|\bcontain\b|\b(?ai:like)\b)\s*"
     r"(?P<quote>[\"']?)(?P<value>[^\"'\s()]+)(?P=quote)"

--- a/src/fortianalyzer_mcp/masking/unmask.py
+++ b/src/fortianalyzer_mcp/masking/unmask.py
@@ -67,8 +67,15 @@ from fortianalyzer_mcp.utils.validation import sanitize_filter_value
 
 logger = logging.getLogger(__name__)
 
-# field==value / field=value / field contain value, single or double quoted
+# field==value / field=value / field contain value, single or double quoted.
+# The lookbehind keeps the field group from starting mid-word: without it a
+# non-clause fragment like "a-srcip=<ip>" reads as a srcip clause and the
+# address is silently transformed (#73 7a). The cost is that a dotted
+# spelling ("foo.srcip") no longer resolves as srcip, which prices at zero:
+# on live 7.6.7 and 8.0.0 a dotted field matches nothing at the appliance,
+# so such a clause only ever produced zero rows.
 _FILTER_CLAUSE_RE = re.compile(
+    r"(?<![A-Za-z0-9_.-])"
     r"(?P<field>[A-Za-z_][A-Za-z0-9_]*)"
     r"\s*(?P<op>==|!=|<=|>=|=~|!~|<|>|=(?![=~])|~|!contain\b|\bcontain\b|\b(?ai:like)\b)\s*"
     r"(?P<quote>[\"']?)(?P<value>[^\"'\s()]+)(?P=quote)"

--- a/tests/test_masking_unmask.py
+++ b/tests/test_masking_unmask.py
@@ -150,13 +150,40 @@ class TestFilterExpressions:
             unmasker.unmask_filter(f'!(srcip like "%{token}%")') == '!(srcip like "%192.0.2.102%")'
         )
 
-    def test_field_must_start_at_a_word_boundary(self, unmasker: ArgUnmasker):
-        # #73 item 7a: the field group could start mid-word, so a non-clause
-        # fragment like "a-srcip=<ip>" was read as a srcip clause and the
-        # address silently transformed to a different one.
-        fragment = "note a-srcip=192.0.2.7 tail"
-
+    @pytest.mark.parametrize(
+        "fragment",
+        [
+            "note a-srcip=192.0.2.7 tail",
+            "x /srcip==192.0.2.7",
+            "x :srcip==192.0.2.7",
+            "x @srcip==192.0.2.7",
+            "x *srcip==192.0.2.7",
+        ],
+    )
+    def test_field_must_start_where_a_clause_can(self, unmasker: ArgUnmasker, fragment: str):
+        # #73 item 7a: the field group could start mid-string, so a
+        # non-clause fragment was read as a srcip clause and the address
+        # silently transformed to a different one. The lookbehind is an
+        # allowlist, so every separator is closed at once.
         assert unmasker.unmask_filter(fragment) == fragment
+
+    def test_ampersand_join_resolves_both_clauses(self, unmasker: ArgUnmasker, engine: FPEEngine):
+        # "a&&b" is a working join on live 7.6.7 and 8.0.0 (identical row
+        # counts to "a and b"), so a clause legitimately begins after "&"
+        # and the second token must still resolve.
+        t1 = engine.mask_ip("192.0.2.102")
+        t2 = engine.mask_ip("198.51.100.7")
+
+        out = unmasker.unmask_filter(f'srcip=="{t1}"&&dstip=="{t2}"')
+
+        assert out == 'srcip=="192.0.2.102"&&dstip=="198.51.100.7"'
+
+    def test_bare_negation_resolves(self, unmasker: ArgUnmasker, engine: FPEEngine):
+        # "!f==v" (no parens) is served by the appliance, so a clause
+        # legitimately begins after "!".
+        token = engine.mask_ip("192.0.2.102")
+
+        assert unmasker.unmask_filter(f'!srcip=="{token}"') == '!srcip=="192.0.2.102"'
 
     def test_dotted_field_is_left_untouched(self, unmasker: ArgUnmasker, engine: FPEEngine):
         # The documented cost of the anchor: "foo.srcip" no longer resolves

--- a/tests/test_masking_unmask.py
+++ b/tests/test_masking_unmask.py
@@ -150,6 +150,25 @@ class TestFilterExpressions:
             unmasker.unmask_filter(f'!(srcip like "%{token}%")') == '!(srcip like "%192.0.2.102%")'
         )
 
+    def test_field_must_start_at_a_word_boundary(self, unmasker: ArgUnmasker):
+        # #73 item 7a: the field group could start mid-word, so a non-clause
+        # fragment like "a-srcip=<ip>" was read as a srcip clause and the
+        # address silently transformed to a different one.
+        fragment = "note a-srcip=192.0.2.7 tail"
+
+        assert unmasker.unmask_filter(fragment) == fragment
+
+    def test_dotted_field_is_left_untouched(self, unmasker: ArgUnmasker, engine: FPEEngine):
+        # The documented cost of the anchor: "foo.srcip" no longer resolves
+        # as srcip. Priced at zero against the appliance: on live 7.6.7 and
+        # 8.0.0 a dotted spelling matches nothing (srcmac==<present mac>
+        # returns thousands of rows, foo.srcmac==<same> returns zero), so a
+        # dotted clause only ever produced zero rows anyway.
+        token = engine.mask_ip("192.0.2.102")
+        expression = f'foo.srcip=="{token}"'
+
+        assert unmasker.unmask_filter(expression) == expression
+
     @pytest.mark.parametrize(
         "expression",
         [


### PR DESCRIPTION
Closes item 7a of #73 with the anchor the issue proposed, and prices its documented cost against the appliance so the decision is measured rather than assumed.

## What

`_FILTER_CLAUSE_RE` let the field group start mid-word, so a non-clause fragment such as `a-srcip=192.0.2.7` inside a filter string was read as a `srcip` clause and the address silently transformed to a different, valid-looking one. Pre-existing for `==`; the #71 round widened the operator set, and #98's `like` widened it again, as noted in the 2026-07-28 reconciliation. The lookbehind `(?<![A-Za-z0-9_.-])` closes it for every operator at once, exactly as sketched in the issue.

## The cost, measured

The issue named the trade: a dotted spelling like `foo.srcip` no longer matches (today it resolves via the mid-word bug itself, the field group starting after the dot). Before accepting that, we checked what a dotted field is worth at the appliance. Fixed one-hour window, live:

| filter | 7.6.7 | 8.0.0 |
|---|---|---|
| `srcmac==<present mac>` | 2426 | (positive control, prior probe: 3434) |
| `foo.srcmac==<same mac>` | 0 | 0 |

Both probes carried the identical resolved value through the same inbound path, so the only variable is the field spelling, and the dotted spelling matches nothing on either version. FortiAnalyzer's grammar has no dotted fields in any dialect we have probed (logview, eventmgmt, dvmdb, FortiView), and `FIELD_TYPES` contains no dotted key. So a dotted clause could only ever produce zero rows; after this change its token is left unresolved and it still produces zero rows. The corruption case, by contrast, silently rewrote a real address. That is the whole trade, and it is one-sided.

What keeps working, pinned by existing tests: clause at the start of the expression, after a space in an `and`-joined compound, and after `(` in the `!(field like "%x%")` complement form, since `(` is deliberately not in the lookbehind class.

## Verification

- Two new tests, red first on `main` for the reasons above: the fragment case asserts the string passes through untouched, and the dotted case pins the accepted cost with the live measurement in its comment.
- Suite: 1547 pass on 3.12 and 3.13 (baseline 1545). `ruff check` and `ruff format --check` clean.
- Mutation: removing the lookbehind kills both tests; dropping `.` or `-` from the class each kills the specific test that depends on it. Pristine control green.

Independent of #104 (different files); no conflict whichever lands first. Items 4, 5, 6 and 7b/7c of #73 stay open.
