### PR TITLE
fix(masking): gate argument restoration on the read-only annotation (#106)

### DIFF
--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -929,7 +929,11 @@ def install_masking(mcp: Any) -> tuple[OutputMasker, ArgUnmasker]:
 
     Wrapped tools unmask their keyword arguments on the way in (Phase 2,
     before the tool body reaches any validator) and mask their result on
-    the way out (Phase 1). The boundary is the OUTERMOST wrapped call
+    the way out (Phase 1). Argument restoration is gated on the tool's
+    ``readOnlyHint`` annotation (#106): a mutating tool never restores,
+    and a whole-value marked token in its arguments is refused, because
+    an unauthenticated FF3 token would decrypt to a plausible wrong value
+    and be written to the estate. The boundary is the OUTERMOST wrapped call
     only: a wrapped tool invoked from inside another wrapped tool runs
     bare, because the outer boundary already unmasked the arguments and
     masks the combined result exactly once.
@@ -955,8 +959,61 @@ def install_masking(mcp: Any) -> tuple[OutputMasker, ArgUnmasker]:
     unmasker = ArgUnmasker(engine)
     original_tool = mcp.tool
 
+    def marked_arg_key(value: Any, key: str = "") -> str | None:
+        """Key under which a whole-value marked token sits, or None.
+
+        Only whole-value tokens count: a token embedded in a longer string
+        has nothing that would restore it, so it passes through as token
+        text and cannot become a decrypted write. A marker that matches
+        but does not decrypt is the forged/stale case, which is exactly
+        the threat, so it refuses rather than passing.
+        """
+        if isinstance(value, str):
+            try:
+                return key if engine.unmask_token(value) is not None else None
+            except MaskingError:
+                return key
+        if isinstance(value, dict):
+            for inner_key, inner in value.items():
+                found = marked_arg_key(inner, str(inner_key))
+                if found is not None:
+                    return found
+            return None
+        if isinstance(value, list | tuple):
+            for inner in value:
+                found = marked_arg_key(inner, key)
+                if found is not None:
+                    return found
+        return None
+
+    def refuse_restore(tool_name: str, arg_key: str) -> dict[str, Any]:
+        # #106: FF3 tokens carry no integrity tag, so a stale or forged
+        # token decrypts to some plausible value; restored into a write
+        # surface that value is silently written to the estate. The
+        # message names the argument, never the token.
+        return {
+            "status": "error",
+            "error": "masked_token_in_mutating_args",
+            "message": (
+                f"{tool_name}: argument '{arg_key}' carries a masking token. "
+                "This tool changes FortiAnalyzer state, so tokens are not "
+                "restored here: a stale or forged token would decrypt to a "
+                "plausible wrong value and be written. Re-run with the real "
+                "value, obtained from a read-only tool or an operator."
+            ),
+        }
+
     def patched_tool(*args: Any, **kwargs: Any) -> Any:
         decorator = original_tool(*args, **kwargs)
+        # #106: only tools that annotate themselves read-only get argument
+        # restoration. Everything else, including an unannotated tool and
+        # the dynamic dispatcher (whose annotation is deliberately the
+        # union of everything it can reach), fails closed: no restore, and
+        # a whole-value marked token is refused outright. Unmarked IP/MAC
+        # tokens are indistinguishable from real addresses and pass
+        # through; making them detectable is the #40 v2 envelope work.
+        annotations = kwargs.get("annotations")
+        read_only = bool(annotations is not None and getattr(annotations, "readOnlyHint", False))
 
         def register(fn: Any) -> Any:
             if inspect.iscoroutinefunction(fn):
@@ -967,6 +1024,11 @@ def install_masking(mcp: Any) -> tuple[OutputMasker, ArgUnmasker]:
                         return await fn(*fa, **fk)
                     token = _AT_BOUNDARY.set(True)
                     try:
+                        if not read_only:
+                            offending = marked_arg_key(fk)
+                            if offending is not None:
+                                return refuse_restore(fn.__name__, offending)
+                            return masker.mask_tool_result(await fn(*fa, **fk), fn.__name__)
                         return masker.mask_tool_result(
                             await fn(*fa, **unmasker.unmask_args(fk)), fn.__name__
                         )
@@ -981,6 +1043,11 @@ def install_masking(mcp: Any) -> tuple[OutputMasker, ArgUnmasker]:
                     return fn(*fa, **fk)
                 token = _AT_BOUNDARY.set(True)
                 try:
+                    if not read_only:
+                        offending = marked_arg_key(fk)
+                        if offending is not None:
+                            return refuse_restore(fn.__name__, offending)
+                        return masker.mask_tool_result(fn(*fa, **fk), fn.__name__)
                     return masker.mask_tool_result(fn(*fa, **unmasker.unmask_args(fk)), fn.__name__)
                 finally:
                     _AT_BOUNDARY.reset(token)

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -95,6 +95,10 @@ _MIN_SUBSTITUTION_LEN = 4
 
 _PLACEHOLDER_MARK = "masked-unrepresentable-"
 
+#: Structural shape of a prefix-marked token: ``<marker>-<4-hex-kid>-``.
+#: "host-fw01" has no kid group and is a legitimate name, not a token.
+_TOKEN_PREFIX_SHAPE_RE = re.compile(r"^(?:host|user|url)-[0-9a-f]{4}-")
+
 
 def _find_key(obj: dict[str, Any], name: str) -> str | None:
     """Original spelling of the lowercase ``name`` in ``obj``, or None.
@@ -959,31 +963,43 @@ def install_masking(mcp: Any) -> tuple[OutputMasker, ArgUnmasker]:
     unmasker = ArgUnmasker(engine)
     original_tool = mcp.tool
 
-    def marked_arg_key(value: Any, key: str = "") -> str | None:
-        """Key under which a whole-value marked token sits, or None.
+    def contains_marked(value: Any) -> bool:
+        """True when a whole-value marked token sits anywhere in ``value``.
 
         Only whole-value tokens count: a token embedded in a longer string
         has nothing that would restore it, so it passes through as token
         text and cannot become a decrypted write. A marker that matches
-        but does not decrypt is the forged/stale case, which is exactly
-        the threat, so it refuses rather than passing.
+        but does not decrypt counts only when the value is structurally a
+        token: the ``<marker>-<4-hex-kid>-`` group, or the domain/email
+        suffix form. A genuine name that merely starts with ``host-`` /
+        ``user-`` / ``url-`` ("host-fw01") is not token-shaped, so its
+        decrypt failure means "not a token", not "forged".
         """
         if isinstance(value, str):
             try:
-                return key if engine.unmask_token(value) is not None else None
+                return engine.unmask_token(value) is not None
             except MaskingError:
-                return key
+                candidate = value.strip().lower()
+                return bool(
+                    _TOKEN_PREFIX_SHAPE_RE.match(candidate)
+                    or candidate.endswith("." + engine.mask_suffix)
+                )
         if isinstance(value, dict):
-            for inner_key, inner in value.items():
-                found = marked_arg_key(inner, str(inner_key))
-                if found is not None:
-                    return found
-            return None
+            return any(contains_marked(inner) for inner in value.values())
         if isinstance(value, list | tuple):
-            for inner in value:
-                found = marked_arg_key(inner, key)
-                if found is not None:
-                    return found
+            return any(contains_marked(inner) for inner in value)
+        return False
+
+    def marked_arg_key(kwargs: dict[str, Any]) -> str | None:
+        """The tool parameter whose value carries a marked token, or None.
+
+        Reports the top-level parameter name even when the token sits in
+        a nested container, so the refusal points the caller at an
+        argument that actually exists on the tool.
+        """
+        for param, value in kwargs.items():
+            if contains_marked(value):
+                return param
         return None
 
     def refuse_restore(tool_name: str, arg_key: str) -> dict[str, Any]:
@@ -1012,8 +1028,17 @@ def install_masking(mcp: Any) -> tuple[OutputMasker, ArgUnmasker]:
         # a whole-value marked token is refused outright. Unmarked IP/MAC
         # tokens are indistinguishable from real addresses and pass
         # through; making them detectable is the #40 v2 envelope work.
+        # The hint is read from the keyword form every tool uses today. A
+        # dict-shaped annotations object is honored too; anything else
+        # (positional, absent, unrecognized) computes read_only=False and
+        # the tool loses restoration rather than gaining a write path.
         annotations = kwargs.get("annotations")
-        read_only = bool(annotations is not None and getattr(annotations, "readOnlyHint", False))
+        if isinstance(annotations, dict):
+            read_only = bool(annotations.get("readOnlyHint", False))
+        else:
+            read_only = bool(
+                annotations is not None and getattr(annotations, "readOnlyHint", False)
+            )
 
         def register(fn: Any) -> Any:
             if inspect.iscoroutinefunction(fn):

--- a/tests/test_masking_unmask.py
+++ b/tests/test_masking_unmask.py
@@ -270,12 +270,16 @@ class TestRoundTrip:
     ):
         from mcp.server.fastmcp import FastMCP
 
+        from fortianalyzer_mcp.tool_annotations import READ_ONLY
+
         monkeypatch.setenv("FAZ_MASKING_KEY", KEY)
         mcp = FastMCP("test")
         install_masking(mcp)
         seen: dict[str, str] = {}
 
-        @mcp.tool()
+        # Restoration is gated on the read-only annotation (#106), so the
+        # fixture models a reader the way every real reader is annotated.
+        @mcp.tool(annotations=READ_ONLY)
         async def fake_search(srcip: str) -> dict:
             seen["srcip"] = srcip  # what the tool body (and validators) observe
             return {"logs": [{"srcip": srcip}]}

--- a/tests/test_masking_wrapper.py
+++ b/tests/test_masking_wrapper.py
@@ -697,3 +697,175 @@ class TestAssetValueDiffering:
         )
 
         assert masked["target"][0]["asset_value"] == devid
+
+
+class TestMutatingToolGate:
+    """#106: unmask_args must not restore tokens into mutating tools.
+
+    FF3 tokens carry no integrity tag, so a stale or forged token decrypts
+    to some plausible value; restored into a write surface that value is
+    silently written to the estate. Read-only tools keep restoration.
+    """
+
+    def _install(self, monkeypatch: pytest.MonkeyPatch):
+        from mcp.server.fastmcp import FastMCP
+
+        monkeypatch.setenv("FAZ_MASKING_KEY", KEY)
+        mcp = FastMCP("test-gate")
+        install_masking(mcp)
+        return mcp
+
+    async def test_marked_token_to_mutating_tool_is_refused(self, monkeypatch: pytest.MonkeyPatch):
+        from fortianalyzer_mcp.tool_annotations import CREATES
+
+        mcp = self._install(monkeypatch)
+        engine = FPEEngine(KEY)
+        token = engine.mask_hostname("fw-branch.example.com")
+        calls: list[str] = []
+
+        @mcp.tool(annotations=CREATES)
+        async def fake_add_device(name: str) -> dict:
+            calls.append(name)
+            return {"status": "success"}
+
+        result = await fake_add_device(name=token)
+
+        assert calls == []  # the body never ran
+        assert result["status"] == "error"
+        assert result["error"] == "masked_token_in_mutating_args"
+        assert "name" in result["message"]
+        assert token not in str(result)  # the token itself is not echoed
+
+    async def test_forged_token_to_mutating_tool_is_refused(self, monkeypatch: pytest.MonkeyPatch):
+        # A marker that matches but does not decrypt is the forged/stale
+        # case, which is exactly the threat: it must refuse, not pass.
+        from fortianalyzer_mcp.tool_annotations import DESTRUCTIVE
+
+        mcp = self._install(monkeypatch)
+        calls: list[str] = []
+
+        @mcp.tool(annotations=DESTRUCTIVE)
+        async def fake_delete_device(name: str) -> dict:
+            calls.append(name)
+            return {"status": "success"}
+
+        result = await fake_delete_device(name="host-ffff-zzzzzzzzzzzz")
+
+        assert calls == []
+        assert result["error"] == "masked_token_in_mutating_args"
+
+    async def test_real_value_to_mutating_tool_runs_and_masks_output(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        from fortianalyzer_mcp.tool_annotations import CREATES
+
+        mcp = self._install(monkeypatch)
+        calls: list[str] = []
+
+        @mcp.tool(annotations=CREATES)
+        async def fake_add_device(name: str) -> dict:
+            calls.append(name)
+            return {"status": "success", "hostname": name}
+
+        result = await fake_add_device(name="fw-branch.example.com")
+
+        assert calls == ["fw-branch.example.com"]  # arg untouched on the way in
+        assert result["hostname"].startswith("host-")  # output still masks
+
+    async def test_unmarked_ip_token_passes_through_untouched(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        # An IP token carries no marker, so it is indistinguishable from a
+        # real address and passes through as given: the gate closes the
+        # decrypt-and-write path, it cannot detect unmarked ciphertext.
+        # That detection is the #40 v2 envelope work.
+        from fortianalyzer_mcp.tool_annotations import CREATES
+
+        mcp = self._install(monkeypatch)
+        engine = FPEEngine(KEY)
+        ip_token = engine.mask_ip("192.0.2.55")
+        calls: list[str] = []
+
+        @mcp.tool(annotations=CREATES)
+        async def fake_add_device(ip: str) -> dict:
+            calls.append(ip)
+            return {"status": "success"}
+
+        await fake_add_device(ip=ip_token)
+
+        assert calls == [ip_token]  # NOT decrypted
+
+    async def test_read_only_tool_still_restores(self, monkeypatch: pytest.MonkeyPatch):
+        from fortianalyzer_mcp.tool_annotations import READ_ONLY
+
+        mcp = self._install(monkeypatch)
+        engine = FPEEngine(KEY)
+        token = engine.mask_ip("192.0.2.102")
+        calls: list[str] = []
+
+        @mcp.tool(annotations=READ_ONLY)
+        async def fake_query(srcip: str) -> dict:
+            calls.append(srcip)
+            return {"count": 0}
+
+        await fake_query(srcip=token)
+
+        assert calls == ["192.0.2.102"]  # restored before the body
+
+    async def test_unannotated_tool_fails_closed_as_mutating(self, monkeypatch: pytest.MonkeyPatch):
+        mcp = self._install(monkeypatch)
+        engine = FPEEngine(KEY)
+        token = engine.mask_hostname("fw-branch.example.com")
+        calls: list[str] = []
+
+        @mcp.tool()
+        async def unannotated(name: str) -> dict:
+            calls.append(name)
+            return {"status": "success"}
+
+        result = await unannotated(name=token)
+
+        assert calls == []
+        assert result["error"] == "masked_token_in_mutating_args"
+
+    async def test_token_embedded_in_prose_passes_as_token_text(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        # A token inside a longer string cannot be decrypted-and-written
+        # (nothing restores it), so it passes through as token text: the
+        # estate-side record shows the token, which discloses nothing.
+        from fortianalyzer_mcp.tool_annotations import UPDATES
+
+        mcp = self._install(monkeypatch)
+        engine = FPEEngine(KEY)
+        token = engine.mask_hostname("fw-branch.example.com")
+        calls: list[str] = []
+
+        @mcp.tool(annotations=UPDATES)
+        async def fake_update_incident(description: str) -> dict:
+            calls.append(description)
+            return {"status": "success"}
+
+        await fake_update_incident(description=f"seen on {token} overnight")
+
+        assert calls == [f"seen on {token} overnight"]
+
+    async def test_marked_token_nested_in_container_is_refused(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        from fortianalyzer_mcp.tool_annotations import CREATES
+
+        mcp = self._install(monkeypatch)
+        engine = FPEEngine(KEY)
+        token = engine.mask_hostname("fw-branch.example.com")
+        calls: list[object] = []
+
+        @mcp.tool(annotations=CREATES)
+        async def fake_bulk(devices: list[dict]) -> dict:
+            calls.append(devices)
+            return {"status": "success"}
+
+        result = await fake_bulk(devices=[{"name": token}])
+
+        assert calls == []
+        assert result["error"] == "masked_token_in_mutating_args"

--- a/tests/test_masking_wrapper.py
+++ b/tests/test_masking_wrapper.py
@@ -869,3 +869,54 @@ class TestMutatingToolGate:
 
         assert calls == []
         assert result["error"] == "masked_token_in_mutating_args"
+        # the message names the tool's parameter, not the innermost dict key
+        assert "devices" in result["message"]
+
+    @pytest.mark.parametrize(
+        "legit",
+        [
+            "host-fw01",
+            "host-fw01.example",
+            "user-svc",
+            "url-shortener",
+        ],
+    )
+    async def test_marker_prefixed_legit_name_is_not_refused(
+        self, monkeypatch: pytest.MonkeyPatch, legit: str
+    ):
+        # A genuine name can start with host-/user-/url-. Only a value that
+        # is structurally a token (the <4-hex-kid>- group, or the suffix
+        # form) is treated as forged when it fails to decrypt.
+        from fortianalyzer_mcp.tool_annotations import CREATES
+
+        mcp = self._install(monkeypatch)
+        calls: list[str] = []
+
+        @mcp.tool(annotations=CREATES)
+        async def fake_add_device(name: str) -> dict:
+            calls.append(name)
+            return {"status": "success"}
+
+        result = await fake_add_device(name=legit)
+
+        assert calls == [legit]
+        assert result.get("error") != "masked_token_in_mutating_args"
+
+    async def test_forged_suffix_form_is_refused(self, monkeypatch: pytest.MonkeyPatch):
+        # The domain/email token form is marked by its suffix; a value in
+        # that shape which does not decrypt is forged and stays refused.
+        from fortianalyzer_mcp.tool_annotations import CREATES
+
+        mcp = self._install(monkeypatch)
+        engine = FPEEngine(KEY)
+        calls: list[str] = []
+
+        @mcp.tool(annotations=CREATES)
+        async def fake_add_device(name: str) -> dict:
+            calls.append(name)
+            return {"status": "success"}
+
+        result = await fake_add_device(name="zzz." + engine.mask_suffix)
+
+        assert calls == []
+        assert result["error"] == "masked_token_in_mutating_args"


### PR DESCRIPTION
Implements the interim fix from #106: argument restoration is now gated on the tool's `readOnlyHint` annotation, so a masking token can no longer be decrypted into a mutating tool's arguments and written to the estate. The #40 v2 authenticated-envelope work stays the proper fix; nothing here changes the token format.

## Behavior

- **Read-only tools are unchanged.** `unmask_args` runs exactly as before for every tool annotated `READ_ONLY`/`READ_ONLY_LOCAL`, so query filters and reader arguments keep restoring.
- **Mutating tools never restore.** For any tool not annotated read-only, arguments pass to the body exactly as the caller sent them.
- **A whole-value marked token in a mutating tool's arguments is refused** with an error envelope (`masked_token_in_mutating_args`) that names the argument and never echoes the token. This includes a marker that matches but does not decrypt, which is precisely the stale/forged case the issue describes, and it works at any nesting depth (a token inside `devices=[{"name": ...}]` refuses too). The refusal runs before the tool body, so nothing is written.
- **Output masking is untouched**: mutating tools still mask their results on the way out.

Three deliberate boundaries, each pinned by a test:

- **The dynamic dispatcher fails closed.** `execute_advanced_tool` advertises the union of everything it can reach, per its own annotation rationale, so it gets the mutating treatment even when dispatching a reader. The refinement, per-dispatch gating inside the dispatcher, which knows its target, is a follow-up if a masked estate runs dynamic mode; today that intersection is empty (masking ships flag-off and dynamic mode is non-default).
- **An unannotated tool fails closed as mutating.** Every one of the 85 registered tools carries an annotation today, so this default only exists for future code, and it errs toward not writing. One existing test fixture registered its reader bare and now carries `READ_ONLY`, the way every real reader is annotated.
- **A token embedded inside a longer string passes through as token text.** Nothing restores it, so it cannot become a decrypted write; an estate-side record showing a token discloses nothing. Refusing on substring heuristics would false-positive on real values that merely look token-shaped.

Known residual, stated in the issue and pinned by a test: an unmarked IP/MAC token is indistinguishable from a real address, so it passes through as given. Making those detectable is exactly the #40 v2 envelope.

## Verification

- Eight new tests, red-first against main (the three behavior pins passed before the change, the five gate cases failed).
- Suite: 1553 pass on 3.12 and 3.13 (baseline 1545). `ruff check` and `ruff format --check` clean.
- Mutation, four mutants each killed by a distinct test, pristine control green: gate disabled (five tests red), forged-token pass-through (the forged test red), everything-treated-as-mutating over-reach (read-only restore tests red), container recursion dropped (the nested test red).

Touches `wrapper.py` in a different region than #104; the two merge cleanly in either order.
