### PR TITLE
fix(masking): a clause after a close paren is a clause (#73 7b)

### DIFF
--- a/src/fortianalyzer_mcp/masking/unmask.py
+++ b/src/fortianalyzer_mcp/masking/unmask.py
@@ -74,13 +74,14 @@ logger = logging.getLogger(__name__)
 # transformed (#73 7a). It is an allowlist of the places a clause can
 # legitimately begin, measured against live 7.6.7 and 8.0.0: start of
 # string, after whitespace, after "(" (grouping and the !(...) complement),
-# after "&" ("a&&b" parses identically to "a and b"; single "&", "|", "||"
-# and "," are all rejected by the appliance), and after "!" (bare "!f==v"
-# negation is served). The cost is that a dotted spelling ("foo.srcip") no
+# after ")" ("(a==b)c==d" parses identically to "a==b and c==d", so a clause
+# does begin there), after "&" ("a&&b" parses identically to "a and b";
+# single "&", "|", "||", "," and "[" are all rejected by the appliance), and
+# after "!" (bare "!f==v" negation is served). The cost is that a dotted spelling ("foo.srcip") no
 # longer resolves as srcip, which prices at zero: a dotted field matches
 # nothing at the appliance, so such a clause only ever produced zero rows.
 _FILTER_CLAUSE_RE = re.compile(
-    r"(?<![^\s(!&])"
+    r"(?<![^\s()!&])"
     r"(?P<field>[A-Za-z_][A-Za-z0-9_]*)"
     r"\s*(?P<op>==|!=|<=|>=|=~|!~|<|>|=(?![=~])|~|!contain\b|\bcontain\b|\b(?ai:like)\b)\s*"
     r"(?P<quote>[\"']?)(?P<value>[^\"'\s()]+)(?P=quote)"

--- a/tests/test_masking_unmask.py
+++ b/tests/test_masking_unmask.py
@@ -178,6 +178,18 @@ class TestFilterExpressions:
 
         assert out == 'srcip=="192.0.2.102"&&dstip=="198.51.100.7"'
 
+    def test_clause_after_close_paren_resolves(self, unmasker: ArgUnmasker, engine: FPEEngine):
+        # "(a==b)c==d" is a working filter on live 7.6.7 and 8.0.0, with the
+        # same row count as "a==b and c==d", so a clause legitimately begins
+        # after ")". Without ")" in the class the second token reached the
+        # appliance unresolved and the query silently matched nothing.
+        t1 = engine.mask_ip("192.0.2.102")
+        t2 = engine.mask_ip("198.51.100.7")
+
+        out = unmasker.unmask_filter(f'(srcip=="{t1}")dstip=="{t2}"')
+
+        assert out == '(srcip=="192.0.2.102")dstip=="198.51.100.7"'
+
     def test_bare_negation_resolves(self, unmasker: ArgUnmasker, engine: FPEEngine):
         # "!f==v" (no parens) is served by the appliance, so a clause
         # legitimately begins after "!".


### PR DESCRIPTION
Closes item 7b of #73, with a smaller change than the issue proposes, because the appliance says the other separators cannot occur.

## What

`(a==b)c==d` is a working filter. Measured on 7.6.7 in a fixed window:

| filter | rows |
|---|---|
| `service==DNS and dstport==53` | 4691 |
| `(service==DNS)dstport==53` | **4691** |

So a clause genuinely begins after `)`, and `)` was missing from the lookbehind #107 added. Without it the second clause did not anchor, so a masked token there reached FortiAnalyzer unresolved and the query matched nothing, silently, which is the silent-zero class rather than a disclosure.

## Why not widen further

The issue also names `,`, `[` and `|`. Each is rejected by the appliance, so no token can sit after one in a filter that runs:

```
service==DNS,dstport==53     -> Invalid filter
service==DNS[dstport==53     -> Invalid filter
service==DNS||dstport==53    -> Invalid filter
service==DNS&&&dstport==53   -> Invalid filter
```

Every character added to this class is a character a prose fragment can use to get a real address transformed, which is what 7a was about, so admitting characters the grammar rejects would be a straight loss.

## Verification

- One new test pinning the paren-adjacent form, red before the change.
- The three fragments that motivated the anchor re-checked and still unresolved with `)` admitted: `note a-srcip=<ip> tail`, `x /srcip==<ip>`, and the dotted `foo.srcip==<token>`. The `&&` join, bare `!` negation and the `!(field like "%x%")` complement all still resolve.
- Suite 1583 pass, `ruff check` and `ruff format --check` clean.

Item 7c on the same issue is already closed by #108's token-shape gate; I verified that against the `v2.11.0` tag and noted it on the issue rather than here.
