### PR TITLE
fix(masking): fail-closed values and kept values in the second pass (#73)

### DIFF
--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -190,7 +190,14 @@ class OutputMasker:
                 for part in value.split(",")
             )
         token = self._mask_one(vtype, value)
-        if mapping is not None and token != value and _PLACEHOLDER_MARK not in token:
+        if mapping is not None and token != value:
+            # Fail-closed placeholders are recorded too (#73 item 4). Pass 2
+            # substitutes only what pass 1 recorded, so excluding them left
+            # the raw value in the prose beside its own burned key, which is
+            # the "masked here, cleartext two keys away" failure the second
+            # pass exists to close. A placeholder stays self-identifying by
+            # its marker, so a consumer that must tell the two apart still
+            # can, exactly as this method does above.
             mapping[value] = token
         return token
 
@@ -355,7 +362,12 @@ class OutputMasker:
 
     # -- free-text IOC scan --------------------------------------------- #
 
-    def mask_text(self, text: str, mapping: dict[str, str] | None = None) -> str:
+    def mask_text(
+        self,
+        text: str,
+        mapping: dict[str, str] | None = None,
+        keep: frozenset[str] = frozenset(),
+    ) -> str:
         """Mask embedded IPv4/MAC/email IOCs, then any known raw value."""
 
         def ip_sub(m: re.Match[str]) -> str:
@@ -384,9 +396,14 @@ class OutputMasker:
         out = _IPV4_RE.sub(ip_sub, text)
         out = _MAC_RE.sub(mac_sub, out)
         out = _EMAIL_RE.sub(email_sub, out)
-        return self._substitute_known(out, mapping)
+        return self._substitute_known(out, mapping, keep)
 
-    def _substitute_known(self, text: str, mapping: dict[str, str] | None) -> str:
+    def _substitute_known(
+        self,
+        text: str,
+        mapping: dict[str, str] | None,
+        keep: frozenset[str] = frozenset(),
+    ) -> str:
         """Replace values that were masked elsewhere in this response.
 
         Hostnames and domains cannot be recognized by pattern, but they can
@@ -407,7 +424,12 @@ class OutputMasker:
         raws = [
             raw
             for raw in sorted(mapping, key=len, reverse=True)
-            if len(raw) >= _MIN_SUBSTITUTION_LEN
+            # A value the deployment chose to leave readable stays readable in
+            # prose too (#73 item 5). Some composite key may still have masked
+            # it into ``mapping`` on the way past; substituting it here would
+            # print a token for a name shown in clear two keys away, which is
+            # the pairing the keep set exists to withhold.
+            if len(raw) >= _MIN_SUBSTITUTION_LEN and raw not in keep
         ]
         if not raws:
             return text
@@ -458,7 +480,7 @@ class OutputMasker:
         mapping: dict[str, str] = {}
         keep = frozenset() if self._mask_device_identity else self._device_identity_values(obj)
         staged = self._mask_structured(obj, mapping, keep)
-        return self._mask_free_text(staged, mapping)
+        return self._mask_free_text(staged, mapping, keep)
 
     def _device_identity_values(self, obj: Any) -> frozenset[str]:
         """Device-identity values present in this response, pre-collected.
@@ -812,6 +834,14 @@ class OutputMasker:
         vtype = self._field_types.get(lowered)
         if vtype is not None and vtype != TEXT:
             if isinstance(value, str):
+                # A value the deployment chose to leave readable (device
+                # identity with the flag off) must stay readable under every
+                # key, not just the device-identity ones (#73 item 5).
+                # Masking it here while ``devname`` shows it two keys away
+                # hands over the token-to-name pairing the keep set exists
+                # to withhold.
+                if value in keep:
+                    return value
                 return self._mask_scalar(vtype, value, mapping)
             if isinstance(value, list):
                 # e.g. dns "ipaddr" is a list of resolved addresses
@@ -825,23 +855,27 @@ class OutputMasker:
             return self._mask_structured(value, mapping, keep)
         return value  # TEXT values are deliberately left for pass 2
 
-    def _mask_free_text(self, obj: Any, mapping: dict[str, str]) -> Any:
+    def _mask_free_text(
+        self, obj: Any, mapping: dict[str, str], keep: frozenset[str] = frozenset()
+    ) -> Any:
         """Pass 2: mask TEXT fields, now that the raw -> token map is known."""
         if isinstance(obj, dict):
             out: dict[str, Any] = {}
             for key, value in obj.items():
                 if key.lower() in COMPOSITE_FILTER_ENTRIES and isinstance(value, list):
-                    out[key] = self._mask_filter_entries(value, mapping)
+                    out[key] = self._mask_filter_entries(value, mapping, keep)
                 elif self._field_types.get(key.lower()) == TEXT:
-                    out[key] = self._mask_text_tree(value, mapping)
+                    out[key] = self._mask_text_tree(value, mapping, keep)
                 else:
-                    out[key] = self._mask_free_text(value, mapping)
+                    out[key] = self._mask_free_text(value, mapping, keep)
             return out
         if isinstance(obj, list):
-            return [self._mask_free_text(item, mapping) for item in obj]
+            return [self._mask_free_text(item, mapping, keep) for item in obj]
         return obj
 
-    def _mask_filter_entries(self, value: Any, mapping: dict[str, str]) -> Any:
+    def _mask_filter_entries(
+        self, value: Any, mapping: dict[str, str], keep: frozenset[str] = frozenset()
+    ) -> Any:
         """``filter_applied`` as compiled ``[field, op, value]`` entries.
 
         A tool that compiles a structured filter echoes what it actually sent,
@@ -871,33 +905,37 @@ class OutputMasker:
         out: list[Any] = []
         for entry in value:
             if not isinstance(entry, list | tuple) or len(entry) != 3:
-                out.append(self._mask_text_tree(entry, mapping))
+                out.append(self._mask_text_tree(entry, mapping, keep))
                 continue
             field, op, raw = entry
             vtype = self._field_types.get(field.lower()) if isinstance(field, str) else None
             if vtype is None or vtype == TEXT or not isinstance(raw, str):
-                out.append(self._mask_text_tree(list(entry), mapping))
+                out.append(self._mask_text_tree(list(entry), mapping, keep))
                 continue
             masked = self._mask_scalar(vtype, raw, mapping)
             out.append([field, op, masked] if isinstance(entry, list) else (field, op, masked))
         return out
 
-    def _mask_text_tree(self, value: Any, mapping: dict[str, str]) -> Any:
+    def _mask_text_tree(
+        self, value: Any, mapping: dict[str, str], keep: frozenset[str] = frozenset()
+    ) -> Any:
         if isinstance(value, str):
-            return self._mask_scalar_text(value, mapping)
+            return self._mask_scalar_text(value, mapping, keep)
         if isinstance(value, list):
             # Free-text lines; each string leaf gets the IOC scan. Nested dicts
             # in a list were already masked in pass 1, so recursion leaves them be.
-            return [self._mask_text_tree(item, mapping) for item in value]
+            return [self._mask_text_tree(item, mapping, keep) for item in value]
         # A dict under a TEXT key is a structured object already masked key-by-key
         # in pass 1; scanning it here would double-mask its tokens. Leave it.
         return value
 
-    def _mask_scalar_text(self, value: str, mapping: dict[str, str]) -> str:
+    def _mask_scalar_text(
+        self, value: str, mapping: dict[str, str], keep: frozenset[str] = frozenset()
+    ) -> str:
         if value.strip() in SKIP_VALUES:
             return value
         try:
-            return self.mask_text(value, mapping)
+            return self.mask_text(value, mapping, keep)
         except Exception:
             logger.exception("unexpected error masking free text; placeholder used")
             return self.placeholder(value)

--- a/tests/test_masking_wrapper.py
+++ b/tests/test_masking_wrapper.py
@@ -920,3 +920,94 @@ class TestMutatingToolGate:
 
         assert calls == []
         assert result["error"] == "masked_token_in_mutating_args"
+
+
+class TestFailClosedValuesInProse:
+    """#73 item 4: a value that fails closed under a typed key was not
+    recorded, so pass 2 had nothing to substitute and the raw form of the
+    same value rode out in the prose beside it."""
+
+    def test_burned_value_does_not_survive_in_prose(self, masker: OutputMasker):
+        raw = "DOMAIN\\alice"
+        masked = masker.mask_result({"user": raw, "msg": f"login failure for {raw} at the console"})
+
+        assert raw not in masked["msg"]
+        # the prose carries the same placeholder the typed key got, so the
+        # two references stay recognisable as one identifier
+        assert masked["msg"] == f"login failure for {masked['user']} at the console"
+        assert masked["user"].startswith("masked-unrepresentable-")
+
+    def test_reversible_values_still_map_to_their_token(self, masker: OutputMasker):
+        # the ordinary path is unchanged: a maskable value still substitutes
+        # to its reversible token, not to a placeholder
+        masked = masker.mask_result(
+            {"hostname": "fw-branch.example.com", "msg": "seen on fw-branch.example.com"}
+        )
+
+        assert masked["msg"] == f"seen on {masked['hostname']}"
+        assert not masked["hostname"].startswith("masked-unrepresentable-")
+
+
+class TestKeepSetAcrossBothPasses:
+    """#73 item 5: with device identity left clear, the same name masked
+    under another typed key and was then substituted into prose, so a
+    reader saw the name and a token for it in one record."""
+
+    def test_kept_name_stays_clear_under_another_typed_key(self, masker: OutputMasker):
+        name = "fgt-branch-01"
+        masked = masker.mask_result({"devname": name, "hostname": name})
+
+        assert masked["devname"] == name
+        assert masked["hostname"] == name
+
+    def test_kept_name_stays_clear_in_prose(self, masker: OutputMasker):
+        name = "fgt-branch-01"
+        masked = masker.mask_result(
+            {"devname": name, "hostname": name, "msg": f"seen on {name} overnight"}
+        )
+
+        assert masked["msg"] == f"seen on {name} overnight"
+
+    def test_flag_on_masks_every_occurrence(
+        self, engine: FPEEngine, monkeypatch: pytest.MonkeyPatch
+    ):
+        # With the flag set there is no keep set, so the same record masks
+        # everywhere and the prose token matches the structured one.
+        monkeypatch.setenv("FAZ_MASKING_KEY", KEY)
+        flagged = OutputMasker(engine, mask_device_identity=True)
+        name = "fgt-branch-01"
+        masked = flagged.mask_result(
+            {"devname": name, "hostname": name, "msg": f"seen on {name} overnight"}
+        )
+
+        assert name not in str(masked)
+        assert masked["msg"] == f"seen on {masked['devname']} overnight"
+
+    def test_kept_name_stays_clear_in_prose_even_when_a_composite_masked_it(
+        self, masker: OutputMasker
+    ):
+        # A URL host reaches the masker through the composite path, which does
+        # not consult the keep set, so the name can still land in the mapping.
+        # Pass 2 must refuse it anyway, or the prose prints a token for a name
+        # the response shows in clear.
+        name = "fgt-branch-01"
+        masked = masker.mask_result(
+            {"devname": name, "url": f"https://{name}/admin", "msg": f"seen on {name}"}
+        )
+
+        assert masked["devname"] == name
+        assert masked["msg"] == f"seen on {name}"
+
+    def test_unrelated_identifier_still_masks_when_keep_set_is_present(self, masker: OutputMasker):
+        # The keep set must not become a blanket exemption: a different
+        # identifier in the same response still masks normally.
+        masked = masker.mask_result(
+            {
+                "devname": "fgt-branch-01",
+                "hostname": "nas-branch.example.com",
+                "msg": "seen on nas-branch.example.com",
+            }
+        )
+
+        assert "nas-branch.example.com" not in str(masked)
+        assert masked["msg"] == f"seen on {masked['hostname']}"


### PR DESCRIPTION
Closes items **4** and **5** of #73. Both live in the pass-2 substitution path, which is why they are one PR. Item 6 is assessed at the end and deliberately not attempted.

## Item 4: a fail-closed value still echoed raw in the prose

`_mask_scalar` recorded a value in the response mapping only when it masked reversibly, so a value that failed closed was absent from the map, pass 2 had nothing to substitute, and the raw form rode out beside its own burned key:

```
{"user": "DOMAIN\\alice", "msg": "login failure for DOMAIN\\alice at the console"}
  before -> user: masked-unrepresentable-da1694a7d6
            msg : login failure for DOMAIN\alice at the console     <- raw survives
  after  -> msg : login failure for masked-unrepresentable-da1694a7d6 at the console
```

That is exactly the "masked under one key, cleartext two keys away" failure the second pass exists to close. Fail-closed values are now recorded like any other. Placeholders remain self-identifying by their marker, so any consumer that has to tell a burned value from a reversible token still can, the same test this method already applies.

## Item 5: a value kept clear on purpose was masked elsewhere and tokenised in prose

With `FAZ_MASK_DEVICE_IDENTITY` off the appliance's own name stays readable by design. It was still masked under any *other* typed key carrying the same string, and then substituted into the prose:

```
{"devname": "fgt-branch-01", "hostname": "fgt-branch-01", "msg": "seen on fgt-branch-01 overnight"}
  before -> devname : fgt-branch-01                              (clear, as intended)
            hostname: host-2a85-1uk-r2r2yn0nv
            msg     : seen on host-2a85-1uk-r2r2yn0nv overnight  <- name and its token, one record
  after  -> all three readable
```

Closed on both sides, because they fail differently:

- **Pass 1** now leaves a kept value alone in the typed path. That is the root cause: the keep set was consulted by `_mask_target` and the composite handlers but not by the ordinary typed branch, so the value entered the mapping in the first place.
- **Pass 2** now refuses to substitute a kept value whatever route recorded it, which is what the issue asked for and what covers the handlers that do not consult the keep set. A URL host is the live example: it masks through the composite path, so with only the pass-1 fix the prose would still have printed that token.

## Boundaries, pinned

Three of the nine tests exist to stop either fix widening into a blanket exemption:

- a maskable value still substitutes to its reversible token, not to a placeholder
- an unrelated identifier in a response that *has* a keep set still masks normally
- with the flag on there is no keep set, so every occurrence masks and the prose token matches the structured one

## Item 6, not attempted

A masked IPv4 is itself a valid IPv4, so a token re-entering `mask_result` is masked again (`192.0.2.9` to `248.194.94.248` to `246.228.153.113`, confirmed on the tag). There is no content-only test that separates a token from a real address, because the cipher is a permutation over valid addresses, so any heuristic here would guess. It needs provenance at the masker entry point or a marked representation for IPs, which is the v2 format work on #40. Left open rather than papered over.

## Verification

- 1589 pass on 3.12 and 3.13 (baseline 1582). `ruff check`, `ruff format --check` and `mypy src/` clean.
- Red first: six of the nine tests fail on `v2.11.0` for the reasons above.
- Mutation, each killed by a distinct test with a green control: reverting item 4, reverting either half of item 5, and two over-reach mutants (keep exempting every value in pass 2, and the typed path returning everything unmasked, which turns 18 tests red).

Independent of #111, which touches `unmask.py`.
