### PR TITLE
fix(masking): honour the keep set on every pass-1 route (#73)

### DIFF
--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -281,8 +281,18 @@ class OutputMasker:
         vtype: str,
         value: str,
         mapping: dict[str, str] | None = None,
-        keep: frozenset[str] = frozenset(),
+        *,
+        keep: frozenset[str],
     ) -> str:
+        """Mask one typed value, honouring the keep set.
+
+        ``keep`` is required and keyword-only on purpose. It used to default
+        to the empty set, which made forgetting it silent: the value masked,
+        nothing raised, and the response printed a token beside the cleartext
+        the keep set exists to protect. ``_mask_filter_entries`` was missed
+        that way twice over. A required keyword makes the omission a mypy
+        error and a TypeError instead.
+        """
         if value.strip() in SKIP_VALUES:
             return value
         if self._is_kept(vtype, value, keep):
@@ -303,7 +313,7 @@ class OutputMasker:
             return ",".join(
                 part
                 if part.strip() in SKIP_VALUES or not part
-                else self._mask_scalar(vtype, part, mapping, keep)
+                else self._mask_scalar(vtype, part, mapping, keep=keep)
                 for part in value.split(",")
             )
         token = self._mask_one(vtype, value)
@@ -328,7 +338,7 @@ class OutputMasker:
         vtype = self._field_types.get(field.lower())
         if vtype is None or vtype == TEXT:
             return value
-        return f"{field}{sep}{self._mask_scalar(vtype, raw, mapping, keep)}"
+        return f"{field}{sep}{self._mask_scalar(vtype, raw, mapping, keep=keep)}"
 
     def _mask_json_blob(self, value: str, mapping: dict[str, str], keep: frozenset[str]) -> str:
         """An embedded JSON string (incident ``grpby``)."""
@@ -339,7 +349,7 @@ class OutputMasker:
             return self.mask_text(value, mapping, keep)
         return json.dumps(self._mask_structured(parsed, mapping, keep))
 
-    def _mask_device_vdom(self, value: str, mapping: dict[str, str]) -> str:
+    def _mask_device_vdom(self, value: str, mapping: dict[str, str], keep: frozenset[str]) -> str:
         """``"<devname>[<vdom>]"``, comma-joined (fortiview ``devvds``).
 
         The vdom stays clear, like the flat ``vd`` log field. Only the
@@ -353,9 +363,9 @@ class OutputMasker:
             match = _DEVVDS_RE.match(part.strip())
             if match is None:
                 # Bare device name, or a shape we have not seen: mask whole.
-                out.append(self._mask_scalar(HOSTNAME, part, mapping))
+                out.append(self._mask_scalar(HOSTNAME, part, mapping, keep=keep))
                 continue
-            device = self._mask_scalar(HOSTNAME, match.group("dev"), mapping)
+            device = self._mask_scalar(HOSTNAME, match.group("dev"), mapping, keep=keep)
             out.append(f"{device}[{match.group('vdom')}]")
         return ",".join(out)
 
@@ -513,10 +523,10 @@ class OutputMasker:
             if vtype is None:
                 masked_value = self._burn_strings(raw, keep)
             elif isinstance(raw, str):
-                masked_value = self._mask_scalar(vtype, raw, mapping, keep)
+                masked_value = self._mask_scalar(vtype, raw, mapping, keep=keep)
             elif isinstance(raw, list | tuple):
                 masked_value = [
-                    self._mask_scalar(vtype, elem, mapping, keep)
+                    self._mask_scalar(vtype, elem, mapping, keep=keep)
                     if isinstance(elem, str)
                     else self._burn_strings(elem, keep)
                     for elem in raw
@@ -555,7 +565,7 @@ class OutputMasker:
                         elif vtype is None:
                             entry[key] = self._burn_strings(item_value, keep)
                         else:
-                            entry[key] = self._mask_scalar(vtype, item_value, mapping, keep)
+                            entry[key] = self._mask_scalar(vtype, item_value, mapping, keep=keep)
                     elif isinstance(item_value, list | tuple | dict):
                         entry[key] = self._burn_strings(item_value, keep)
                     else:
@@ -756,7 +766,7 @@ class OutputMasker:
             paired = self._mask_threat_pair(obj, mapping, keep)
             paired.update(self._mask_incident_reporter(obj, mapping, keep))
             paired.update(self._mask_indicator_pair(obj, mapping, keep))
-            paired.update(self._mask_device_name(obj, mapping))
+            paired.update(self._mask_device_name(obj, mapping, keep))
             return {
                 key: paired[key] if key in paired else self._mask_entry(key, value, mapping, keep)
                 for key, value in obj.items()
@@ -765,7 +775,9 @@ class OutputMasker:
             return [self._mask_structured(item, mapping, keep) for item in obj]
         return obj
 
-    def _mask_device_name(self, obj: dict[str, Any], mapping: dict[str, str]) -> dict[str, str]:
+    def _mask_device_name(
+        self, obj: dict[str, Any], mapping: dict[str, str], keep: frozenset[str]
+    ) -> dict[str, str]:
         """``name``: masked only when the record proves it a device object.
 
         Device identity follows ``FAZ_MASK_DEVICE_IDENTITY``, so with the
@@ -783,7 +795,7 @@ class OutputMasker:
         key = _device_name_in(obj)
         if key is None:
             return {}
-        return {key: self._mask_scalar(HOSTNAME, obj[key], mapping)}
+        return {key: self._mask_scalar(HOSTNAME, obj[key], mapping, keep=keep)}
 
     def _mask_incident_reporter(
         self, obj: dict[str, Any], mapping: dict[str, str], keep: frozenset[str]
@@ -813,7 +825,7 @@ class OutputMasker:
         )
         if value not in siblings:
             return {}
-        return {key: self._mask_scalar(USERNAME, value, mapping, keep)}
+        return {key: self._mask_scalar(USERNAME, value, mapping, keep=keep)}
 
     def _mask_indicator_pair(
         self, obj: dict[str, Any], mapping: dict[str, str], keep: frozenset[str]
@@ -844,9 +856,9 @@ class OutputMasker:
             return {}
         lowered = kind.strip().lower()
         if lowered == "ip":
-            return {key: self._mask_scalar(IP, value, mapping, keep)}
+            return {key: self._mask_scalar(IP, value, mapping, keep=keep)}
         if lowered == "domain":
-            return {key: self._mask_scalar(DOMAIN, value, mapping, keep)}
+            return {key: self._mask_scalar(DOMAIN, value, mapping, keep=keep)}
         if lowered == "url":
             return {key: self._mask_url_full(value, mapping, keep)}
         return {}
@@ -885,7 +897,7 @@ class OutputMasker:
         if not isinstance(obf, str) or not obf.strip() or obf.strip() in SKIP_VALUES:
             return {}
         out: dict[str, str] = {}
-        token = self._mask_scalar(DOMAIN, obf.replace("[dot]", "."), mapping, keep)
+        token = self._mask_scalar(DOMAIN, obf.replace("[dot]", "."), mapping, keep=keep)
         escaped = token.replace(".", "[dot]")
         if _PLACEHOLDER_MARK not in token and escaped != obf:
             # Catch the escaped raw form in prose too; the unescaped form
@@ -896,7 +908,7 @@ class OutputMasker:
         if threat_key is not None:
             threat = obj[threat_key]
             if isinstance(threat, str) and threat.strip() and threat.strip() not in SKIP_VALUES:
-                out[threat_key] = self._mask_scalar(DOMAIN, threat, mapping, keep)
+                out[threat_key] = self._mask_scalar(DOMAIN, threat, mapping, keep=keep)
         return out
 
     def _mask_url_host(self, value: str, mapping: dict[str, str], keep: frozenset[str]) -> str:
@@ -931,7 +943,7 @@ class OutputMasker:
             # else, so hand the value back untouched rather than a case-folded
             # copy of a name the response shows in clear elsewhere.
             return value
-        masked_host = self._mask_scalar(IP_OR_HOST, host, mapping, keep)
+        masked_host = self._mask_scalar(IP_OR_HOST, host, mapping, keep=keep)
         if ":" in masked_host:  # IPv6 literal: re-bracket
             masked_host = f"[{masked_host}]"
         netloc = f"{masked_host}:{port}" if port is not None else masked_host
@@ -987,7 +999,7 @@ class OutputMasker:
             # Host stays as the response spells it; the tail still seals.
             netloc = parts.netloc
         else:
-            masked_host = self._mask_scalar(IP_OR_HOST, host, mapping, keep)
+            masked_host = self._mask_scalar(IP_OR_HOST, host, mapping, keep=keep)
             if ":" in masked_host:  # IPv6 literal: re-bracket
                 masked_host = f"[{masked_host}]"
             netloc = f"{masked_host}:{port}" if port is not None else masked_host
@@ -1071,7 +1083,7 @@ class OutputMasker:
             # are allowlisted was masked reversibly before and now burns.
             return self._burn_strings(value, keep)
         if lowered in COMPOSITE_DEVICE_VDOM and isinstance(value, str):
-            return self._mask_device_vdom(value, mapping)
+            return self._mask_device_vdom(value, mapping, keep)
         if lowered in COMPOSITE_BREAKDOWNS and isinstance(value, dict):
             return self._mask_breakdowns(value, mapping, keep)
 
@@ -1087,14 +1099,14 @@ class OutputMasker:
                 # in ``_mask_scalar``, which every pass-1 route reaches and
                 # which knows the type, so the fold that applies to a
                 # hostname is not applied to a username.
-                return self._mask_scalar(vtype, value, mapping, keep)
+                return self._mask_scalar(vtype, value, mapping, keep=keep)
             if isinstance(value, list):
                 # e.g. dns "ipaddr" is a list of resolved addresses. The keep
                 # check is the string branch's, per element: the list form of
                 # a typed key is the same key, so a kept value must survive it
                 # the same way.
                 return [
-                    self._mask_scalar(vtype, item, mapping, keep)
+                    self._mask_scalar(vtype, item, mapping, keep=keep)
                     if isinstance(item, str)
                     else self._mask_structured(item, mapping, keep)
                     for item in value
@@ -1215,7 +1227,7 @@ class OutputMasker:
             if vtype is None or vtype == TEXT or not isinstance(raw, str):
                 out.append(self._mask_text_tree(list(entry), mapping, keep))
                 continue
-            masked = self._mask_scalar(vtype, raw, mapping)
+            masked = self._mask_scalar(vtype, raw, mapping, keep=keep)
             out.append([field, op, masked] if isinstance(entry, list) else (field, op, masked))
         return out
 

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -251,17 +251,34 @@ class OutputMasker:
             return self.placeholder(value)
         return self.placeholder(value)  # unknown type tag: fail closed
 
-    def _mask_scalar(self, vtype: str, value: str, mapping: dict[str, str] | None = None) -> str:
+    def _mask_scalar(
+        self,
+        vtype: str,
+        value: str,
+        mapping: dict[str, str] | None = None,
+        keep: frozenset[str] = frozenset(),
+    ) -> str:
         if value.strip() in SKIP_VALUES:
+            return value
+        if value in keep:
+            # A value the deployment chose to leave readable stays readable
+            # under every key (#73 item 5). The check lives here rather than
+            # at each call site because every pass-1 route ends up here, and
+            # a route that forgot it masked the value while ``devname``
+            # showed it two keys away -- the token-to-name pairing the keep
+            # set exists to withhold. Checking before the mapping write also
+            # keeps the value out of pass 2's substitution table.
             return value
         if "," in value:
             # FAZ packs multi-valued fields into one comma-joined string
             # (live example: the dns ``ipaddr`` answer list). Mask each
             # element; an unmaskable element still fails closed on its own.
+            # Parts are checked against the keep set individually because the
+            # set is itself built by splitting the comma-joined form.
             return ",".join(
                 part
                 if part.strip() in SKIP_VALUES or not part
-                else self._mask_scalar(vtype, part, mapping)
+                else self._mask_scalar(vtype, part, mapping, keep)
                 for part in value.split(",")
             )
         token = self._mask_one(vtype, value)
@@ -278,7 +295,7 @@ class OutputMasker:
 
     # -- composite keys ------------------------------------------------- #
 
-    def _mask_prefixed(self, value: str, mapping: dict[str, str]) -> str:
+    def _mask_prefixed(self, value: str, mapping: dict[str, str], keep: frozenset[str]) -> str:
         """``"<fieldname>:<value>"`` (alert ``groupby1``/``groupby2``)."""
         field, sep, raw = value.partition(":")
         if not sep or not raw:
@@ -286,16 +303,16 @@ class OutputMasker:
         vtype = self._field_types.get(field.lower())
         if vtype is None or vtype == TEXT:
             return value
-        return f"{field}{sep}{self._mask_scalar(vtype, raw, mapping)}"
+        return f"{field}{sep}{self._mask_scalar(vtype, raw, mapping, keep)}"
 
-    def _mask_json_blob(self, value: str, mapping: dict[str, str]) -> str:
+    def _mask_json_blob(self, value: str, mapping: dict[str, str], keep: frozenset[str]) -> str:
         """An embedded JSON string (incident ``grpby``)."""
         try:
             parsed = json.loads(value)
         except (ValueError, TypeError):
             # Not JSON after all: at least strip the IOCs a regex can see.
-            return self.mask_text(value, mapping)
-        return json.dumps(self._mask_structured(parsed, mapping))
+            return self.mask_text(value, mapping, keep)
+        return json.dumps(self._mask_structured(parsed, mapping, keep))
 
     def _mask_device_vdom(self, value: str, mapping: dict[str, str]) -> str:
         """``"<devname>[<vdom>]"``, comma-joined (fortiview ``devvds``).
@@ -471,12 +488,10 @@ class OutputMasker:
             if vtype is None:
                 masked_value = self._burn_strings(raw, keep)
             elif isinstance(raw, str):
-                masked_value = raw if raw in keep else self._mask_scalar(vtype, raw, mapping)
+                masked_value = self._mask_scalar(vtype, raw, mapping, keep)
             elif isinstance(raw, list | tuple):
                 masked_value = [
-                    elem
-                    if isinstance(elem, str) and elem in keep
-                    else self._mask_scalar(vtype, elem, mapping)
+                    self._mask_scalar(vtype, elem, mapping, keep)
                     if isinstance(elem, str)
                     else self._burn_strings(elem, keep)
                     for elem in raw
@@ -510,12 +525,12 @@ class OutputMasker:
                     if item_value == raw:
                         entry[key] = masked_value
                     elif isinstance(item_value, str):
-                        if item_value in keep or item_value.isdigit():
+                        if item_value.isdigit():
                             entry[key] = item_value
                         elif vtype is None:
                             entry[key] = self._burn_strings(item_value, keep)
                         else:
-                            entry[key] = self._mask_scalar(vtype, item_value, mapping)
+                            entry[key] = self._mask_scalar(vtype, item_value, mapping, keep)
                     elif isinstance(item_value, list | tuple | dict):
                         entry[key] = self._burn_strings(item_value, keep)
                     else:
@@ -713,9 +728,9 @@ class OutputMasker:
     ) -> Any:
         """Pass 1: mask allowlisted and composite keys, record raw -> token."""
         if isinstance(obj, dict):
-            paired = self._mask_threat_pair(obj, mapping)
-            paired.update(self._mask_incident_reporter(obj, mapping))
-            paired.update(self._mask_indicator_pair(obj, mapping))
+            paired = self._mask_threat_pair(obj, mapping, keep)
+            paired.update(self._mask_incident_reporter(obj, mapping, keep))
+            paired.update(self._mask_indicator_pair(obj, mapping, keep))
             paired.update(self._mask_device_name(obj, mapping))
             return {
                 key: paired[key] if key in paired else self._mask_entry(key, value, mapping, keep)
@@ -746,7 +761,7 @@ class OutputMasker:
         return {key: self._mask_scalar(HOSTNAME, obj[key], mapping)}
 
     def _mask_incident_reporter(
-        self, obj: dict[str, Any], mapping: dict[str, str]
+        self, obj: dict[str, Any], mapping: dict[str, str], keep: frozenset[str]
     ) -> dict[str, str]:
         """``incident_reporter``: masked only when the record proves it a username.
 
@@ -773,9 +788,11 @@ class OutputMasker:
         )
         if value not in siblings:
             return {}
-        return {key: self._mask_scalar(USERNAME, value, mapping)}
+        return {key: self._mask_scalar(USERNAME, value, mapping, keep)}
 
-    def _mask_indicator_pair(self, obj: dict[str, Any], mapping: dict[str, str]) -> dict[str, str]:
+    def _mask_indicator_pair(
+        self, obj: dict[str, Any], mapping: dict[str, str], keep: frozenset[str]
+    ) -> dict[str, str]:
         """SOAR ``value``/``type``: the IOC itself, typed by its sibling.
 
         ``get_indicator_enrichment`` and ``get_linked_indicators`` return
@@ -802,14 +819,16 @@ class OutputMasker:
             return {}
         lowered = kind.strip().lower()
         if lowered == "ip":
-            return {key: self._mask_scalar(IP, value, mapping)}
+            return {key: self._mask_scalar(IP, value, mapping, keep)}
         if lowered == "domain":
-            return {key: self._mask_scalar(DOMAIN, value, mapping)}
+            return {key: self._mask_scalar(DOMAIN, value, mapping, keep)}
         if lowered == "url":
-            return {key: self._mask_url_full(value, mapping)}
+            return {key: self._mask_url_full(value, mapping, keep)}
         return {}
 
-    def _mask_threat_pair(self, obj: dict[str, Any], mapping: dict[str, str]) -> dict[str, str]:
+    def _mask_threat_pair(
+        self, obj: dict[str, Any], mapping: dict[str, str], keep: frozenset[str]
+    ) -> dict[str, str]:
         """fortiview ``threat``/``obf_url``: masked together, as domains (#40).
 
         ``obf_url`` is populated exactly when ``threat`` holds a browsable
@@ -841,7 +860,7 @@ class OutputMasker:
         if not isinstance(obf, str) or not obf.strip() or obf.strip() in SKIP_VALUES:
             return {}
         out: dict[str, str] = {}
-        token = self._mask_scalar(DOMAIN, obf.replace("[dot]", "."), mapping)
+        token = self._mask_scalar(DOMAIN, obf.replace("[dot]", "."), mapping, keep)
         escaped = token.replace(".", "[dot]")
         if _PLACEHOLDER_MARK not in token and escaped != obf:
             # Catch the escaped raw form in prose too; the unescaped form
@@ -852,10 +871,10 @@ class OutputMasker:
         if threat_key is not None:
             threat = obj[threat_key]
             if isinstance(threat, str) and threat.strip() and threat.strip() not in SKIP_VALUES:
-                out[threat_key] = self._mask_scalar(DOMAIN, threat, mapping)
+                out[threat_key] = self._mask_scalar(DOMAIN, threat, mapping, keep)
         return out
 
-    def _mask_url_host(self, value: str, mapping: dict[str, str]) -> str:
+    def _mask_url_host(self, value: str, mapping: dict[str, str], keep: frozenset[str]) -> str:
         """``http_url`` (alert ``event_details``): mask the HOST component only.
 
         Live alerts carry the browsed destination as a full URL
@@ -881,14 +900,14 @@ class OutputMasker:
         if not host:
             # Not a parseable URL: the free-text scan still catches
             # embedded IOCs and values masked elsewhere in this response.
-            return self.mask_text(value, mapping)
-        masked_host = self._mask_scalar(IP_OR_HOST, host, mapping)
+            return self.mask_text(value, mapping, keep)
+        masked_host = self._mask_scalar(IP_OR_HOST, host, mapping, keep)
         if ":" in masked_host:  # IPv6 literal: re-bracket
             masked_host = f"[{masked_host}]"
         netloc = f"{masked_host}:{port}" if port is not None else masked_host
         return parts._replace(netloc=netloc).geturl()
 
-    def _mask_url_full(self, value: str, mapping: dict[str, str]) -> str:
+    def _mask_url_full(self, value: str, mapping: dict[str, str], keep: frozenset[str]) -> str:
         """``url``/``referralurl``: host in place, tail sealed (#40 decision).
 
         The host masks exactly like :meth:`_mask_url_host` (same guards,
@@ -934,7 +953,7 @@ class OutputMasker:
                 return self._engine.mask_url_tail(stripped)
             except MaskingError:
                 return self.placeholder(value)
-        masked_host = self._mask_scalar(IP_OR_HOST, host, mapping)
+        masked_host = self._mask_scalar(IP_OR_HOST, host, mapping, keep)
         if ":" in masked_host:  # IPv6 literal: re-bracket
             masked_host = f"[{masked_host}]"
         netloc = f"{masked_host}:{port}" if port is not None else masked_host
@@ -962,36 +981,36 @@ class OutputMasker:
     ) -> Any:
         lowered = key.lower()
         if lowered in COMPOSITE_PREFIXED and isinstance(value, str):
-            return self._mask_prefixed(value, mapping)
+            return self._mask_prefixed(value, mapping, keep)
         if lowered in COMPOSITE_PREFIXED and isinstance(value, list):
             # list-valued group-bys are a normal FAZ variation (#73): each
             # element gets the same prefixed treatment the string form gets.
             # A dict-shaped groupby stays with the allowlist walk below,
             # which types it by its inner keys.
             return [
-                self._mask_prefixed(item, mapping)
+                self._mask_prefixed(item, mapping, keep)
                 if isinstance(item, str)
                 else self._mask_structured(item, mapping, keep)
                 for item in value
             ]
         if lowered in COMPOSITE_JSON and isinstance(value, str):
-            return self._mask_json_blob(value, mapping)
+            return self._mask_json_blob(value, mapping, keep)
         if lowered in COMPOSITE_URL_HOST and isinstance(value, str):
-            return self._mask_url_host(value, mapping)
+            return self._mask_url_host(value, mapping, keep)
         if lowered in COMPOSITE_URL_HOST and isinstance(value, list):
             # same list convention the typed fields handle below
             return [
-                self._mask_url_host(item, mapping)
+                self._mask_url_host(item, mapping, keep)
                 if isinstance(item, str)
                 else self._mask_structured(item, mapping, keep)
                 for item in value
             ]
         if lowered in COMPOSITE_URL_FULL and isinstance(value, str):
-            return self._mask_url_full(value, mapping)
+            return self._mask_url_full(value, mapping, keep)
         if lowered in COMPOSITE_URL_FULL and isinstance(value, list):
             # same list convention the typed fields handle below
             return [
-                self._mask_url_full(item, mapping)
+                self._mask_url_full(item, mapping, keep)
                 if isinstance(item, str)
                 else self._mask_structured(item, mapping, keep)
                 for item in value
@@ -1035,9 +1054,12 @@ class OutputMasker:
                     return value
                 return self._mask_scalar(vtype, value, mapping)
             if isinstance(value, list):
-                # e.g. dns "ipaddr" is a list of resolved addresses
+                # e.g. dns "ipaddr" is a list of resolved addresses. The keep
+                # check is the string branch's, per element: the list form of
+                # a typed key is the same key, so a kept value must survive it
+                # the same way.
                 return [
-                    self._mask_scalar(vtype, item, mapping)
+                    self._mask_scalar(vtype, item, mapping, keep)
                     if isinstance(item, str)
                     else self._mask_structured(item, mapping, keep)
                     for item in value

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -251,6 +251,31 @@ class OutputMasker:
             return self.placeholder(value)
         return self.placeholder(value)  # unknown type tag: fail closed
 
+    def _is_kept(self, vtype: str, value: str, keep: frozenset[str]) -> bool:
+        """Is ``value`` one the deployment chose to leave readable?
+
+        Exact match first, then case-insensitively for every type except
+        USERNAME. The fold is not a convenience: :meth:`FPEEngine._normalize`
+        lowercases the value for every other type before encrypting, so two
+        spellings of a hostname or a serial are one identity and mask to one
+        token. Comparing them case-sensitively here left the token beside the
+        clear name, which is the pairing the keep set exists to withhold --
+        found live, where device names are routinely uppercase and
+        ``urlsplit`` hands back a lowercased host.
+
+        USERNAME is excluded because the engine does not fold it, so two
+        spellings really are two principals: a device named ``ADMIN`` must
+        not exempt a user called ``admin`` from masking.
+        """
+        if not keep:
+            return False
+        if value in keep:
+            return True
+        if vtype == USERNAME:
+            return False
+        folded = value.lower()
+        return any(folded == kept.lower() for kept in keep)
+
     def _mask_scalar(
         self,
         vtype: str,
@@ -260,7 +285,7 @@ class OutputMasker:
     ) -> str:
         if value.strip() in SKIP_VALUES:
             return value
-        if value in keep:
+        if self._is_kept(vtype, value, keep):
             # A value the deployment chose to leave readable stays readable
             # under every key (#73 item 5). The check lives here rather than
             # at each call site because every pass-1 route ends up here, and
@@ -901,6 +926,11 @@ class OutputMasker:
             # Not a parseable URL: the free-text scan still catches
             # embedded IOCs and values masked elsewhere in this response.
             return self.mask_text(value, mapping, keep)
+        if self._is_kept(IP_OR_HOST, host, keep):
+            # ``urlsplit`` lowercased the host, and this handler masks nothing
+            # else, so hand the value back untouched rather than a case-folded
+            # copy of a name the response shows in clear elsewhere.
+            return value
         masked_host = self._mask_scalar(IP_OR_HOST, host, mapping, keep)
         if ":" in masked_host:  # IPv6 literal: re-bracket
             masked_host = f"[{masked_host}]"
@@ -953,10 +983,14 @@ class OutputMasker:
                 return self._engine.mask_url_tail(stripped)
             except MaskingError:
                 return self.placeholder(value)
-        masked_host = self._mask_scalar(IP_OR_HOST, host, mapping, keep)
-        if ":" in masked_host:  # IPv6 literal: re-bracket
-            masked_host = f"[{masked_host}]"
-        netloc = f"{masked_host}:{port}" if port is not None else masked_host
+        if self._is_kept(IP_OR_HOST, host, keep):
+            # Host stays as the response spells it; the tail still seals.
+            netloc = parts.netloc
+        else:
+            masked_host = self._mask_scalar(IP_OR_HOST, host, mapping, keep)
+            if ":" in masked_host:  # IPv6 literal: re-bracket
+                masked_host = f"[{masked_host}]"
+            netloc = f"{masked_host}:{port}" if port is not None else masked_host
         prefix = f"{parts.scheme}://" if parts.scheme else "//"
         # Anchor the netloc search after the ``//`` authority marker: from
         # position 0 a single-letter host matches inside the scheme
@@ -1049,10 +1083,11 @@ class OutputMasker:
                 # key, not just the device-identity ones (#73 item 5).
                 # Masking it here while ``devname`` shows it two keys away
                 # hands over the token-to-name pairing the keep set exists
-                # to withhold.
-                if value in keep:
-                    return value
-                return self._mask_scalar(vtype, value, mapping)
+                # to withhold. #112 put that check inline here; it now lives
+                # in ``_mask_scalar``, which every pass-1 route reaches and
+                # which knows the type, so the fold that applies to a
+                # hostname is not applied to a username.
+                return self._mask_scalar(vtype, value, mapping, keep)
             if isinstance(value, list):
                 # e.g. dns "ipaddr" is a list of resolved addresses. The keep
                 # check is the string branch's, per element: the list form of

--- a/tests/test_masking_wrapper.py
+++ b/tests/test_masking_wrapper.py
@@ -986,10 +986,11 @@ class TestKeepSetAcrossBothPasses:
     def test_kept_name_stays_clear_in_prose_even_when_a_composite_masked_it(
         self, masker: OutputMasker
     ):
-        # A URL host reaches the masker through the composite path, which does
-        # not consult the keep set, so the name can still land in the mapping.
-        # Pass 2 must refuse it anyway, or the prose prints a token for a name
-        # the response shows in clear.
+        # Written when the URL composite still masked a kept host, which put
+        # the name into the mapping for pass 2 to substitute. Pass 1 no longer
+        # does that, so this now pins the composed result rather than the
+        # pass-2 guard alone; ``TestPassTwoRefusesKeptValues`` pins the guard
+        # itself, which stays as the layer under this one.
         name = "fgt-branch-01"
         masked = masker.mask_result(
             {"devname": name, "url": f"https://{name}/admin", "msg": f"seen on {name}"}
@@ -999,12 +1000,12 @@ class TestKeepSetAcrossBothPasses:
         assert masked["msg"] == f"seen on {name}"
 
     def test_kept_name_stays_clear_in_a_breakdown_bucket(self, masker: OutputMasker):
-        # The pass-2 breakdown handler (#109) is a second route into prose, and
-        # it only became constructible once #112 landed: it needs the flag off,
-        # a composite putting the name into the mapping, and a TEXT dimension
-        # echoing it. Resolve the merge without threading ``keep`` into that
-        # handler and every gate still passes while the bucket prints a token
-        # for the name ``devname`` shows in clear, two keys away.
+        # The pass-2 breakdown handler (#109) is a second route into prose.
+        # Written against the #112 merge, where a composite still seeded the
+        # mapping and dropping ``keep`` from this handler printed a token for
+        # the name ``devname`` showed in clear. Pass 1 no longer seeds it, so
+        # like the test above this now pins the composed result; the handler's
+        # own ``keep`` argument is pinned by ``TestPassTwoRefusesKeptValues``.
         name = "fgt-branch-01"
         masked = masker.mask_result(
             {
@@ -1019,6 +1020,107 @@ class TestKeepSetAcrossBothPasses:
         assert masked["msg"] == f"seen on {name} overnight"
         assert masked["breakdowns"]["msg"][0]["value"] == f"seen on {name} overnight"
 
+    def test_kept_name_stays_clear_under_a_list_valued_typed_key(self, masker: OutputMasker):
+        # #112 put the keep guard on the typed-scalar STRING branch only. The
+        # list branch beside it masks each element straight through
+        # ``_mask_scalar``, so a device named in a list-valued typed field
+        # tokenises beside its own clear ``devname`` -- item 5 again, one
+        # branch across.
+        name = "fgt-branch-01"
+        masked = masker.mask_result({"devname": name, "srcname": [name]})
+
+        assert masked["devname"] == name
+        assert masked["srcname"] == [name]
+
+    def test_kept_name_stays_clear_in_a_prefixed_group_by(self, masker: OutputMasker):
+        # ``groupby1`` types its value by the field name it carries. A
+        # device-identity field name drops out of the type table with the flag
+        # off, but any other typed name still resolves and masked the value.
+        name = "fgt-branch-01"
+        masked = masker.mask_result({"devname": name, "groupby1": f"hostname:{name}"})
+
+        assert masked["groupby1"] == f"hostname:{name}"
+
+    def test_kept_name_stays_clear_inside_a_json_blob(self, masker: OutputMasker):
+        # The incident ``grpby`` blob is re-walked by pass 1, and the walk was
+        # started without the keep set: the same key and the same string form
+        # stayed clear at the top level and tokenised one level in.
+        name = "fgt-branch-01"
+        masked = masker.mask_result({"devname": name, "grpby": f'{{"srcname": "{name}"}}'})
+
+        assert masked["grpby"] == f'{{"srcname": "{name}"}}'
+
+    def test_kept_name_stays_clear_in_a_url_host(self, masker: OutputMasker):
+        # The URL handlers mask the host component through the same scalar
+        # path every typed field uses, so a device reached as a URL host
+        # tokenised beside its own clear ``devname``.
+        name = "fgt-branch-01"
+        masked = masker.mask_result(
+            {"devname": name, "url": f"https://{name}/admin", "http_url": f"https://{name}/x"}
+        )
+
+        assert masked["url"].startswith(f"https://{name}/")
+        assert masked["http_url"].startswith(f"https://{name}/")
+
+    def test_kept_name_stays_clear_in_the_unparseable_fallbacks(self, masker: OutputMasker):
+        # Both keep-less ``mask_text`` fallbacks (a ``grpby`` that is not JSON
+        # after all, a ``http_url`` with no parseable host) substitute from
+        # the pass-1 mapping, so they leaked as soon as any route seeded a
+        # kept value into it.
+        name = "fgt-branch-01"
+        masked = masker.mask_result(
+            {
+                "devname": name,
+                "srcname": [name],
+                "grpby": f"not json at all: {name}",
+                "http_url": f"::: {name} :::",
+            }
+        )
+
+        assert masked["grpby"] == f"not json at all: {name}"
+        assert masked["http_url"] == f"::: {name} :::"
+
+    def test_kept_name_stays_clear_in_the_sibling_typed_pairs(self, masker: OutputMasker):
+        # The four sibling-typed handlers run before the allowlist walk and
+        # took no keep set at all, so a device reached as an enriched
+        # indicator, a beaconing destination or a reporting principal masked
+        # while ``devname`` showed it in clear on the same record. How likely
+        # each shape is varies; the keep contract does not, which is why #73
+        # item 5 was decided per value rather than per key.
+        name = "fgt-branch-01.corp.example.com"
+
+        assert masker.mask_result({"devname": name, "value": name, "type": "domain"})["value"] == (
+            name
+        )
+        assert masker.mask_result({"devname": name, "value": f"https://{name}/x", "type": "url"})[
+            "value"
+        ].startswith(f"https://{name}/")
+        assert (
+            masker.mask_result({"devname": name, "incident_reporter": name, "reporter": name})[
+                "incident_reporter"
+            ]
+            == name
+        )
+        assert masker.mask_result({"devname": name, "threat": name, "obf_url": name})["threat"] == (
+            name
+        )
+
+    def test_kept_names_stay_clear_inside_a_comma_joined_value(self, masker: OutputMasker):
+        # FAZ joins aggregated device names into one value, and the keep set
+        # is built by splitting that form -- so it holds the parts, never the
+        # join. An ``x in keep`` test at a call site therefore misses the
+        # joined string; only the per-part check inside ``_mask_scalar`` sees
+        # it. ``target`` is the shape that carries both forms live.
+        joined = "fgt-branch-01,fgt-branch-02"
+        masked = masker.mask_result(
+            {
+                "fortigate": joined,
+                "target": [{"name": "device", "value": joined}],
+            }
+        )
+
+        assert masked["target"][0]["value"] == joined
+
     def test_unrelated_identifier_still_masks_when_keep_set_is_present(self, masker: OutputMasker):
         # The keep set must not become a blanket exemption: a different
         # identifier in the same response still masks normally.
@@ -1032,3 +1134,54 @@ class TestKeepSetAcrossBothPasses:
 
         assert "nas-branch.example.com" not in str(masked)
         assert masked["msg"] == f"seen on {masked['hostname']}"
+
+
+class TestPassTwoRefusesKeptValues:
+    """Pass 2's ``keep`` guard, pinned at the pass rather than end to end.
+
+    Every pass-1 route now refuses kept values, so no whole-response input
+    can put one into the mapping any more -- which means an end-to-end test
+    can no longer distinguish a pass 2 that honours ``keep`` from one that
+    ignores it. The guard is still wanted: it is the layer that caught the
+    #112/#109 composition trap, and pass 1 gaining a new composite handler
+    is exactly the change that would seed the mapping again.
+
+    Calling the pass directly is deliberate, and the only place this file
+    does it. The alternative was leaving five handlers' ``keep`` arguments
+    unpinned and removable without a failing test.
+    """
+
+    KEPT = "fgt-branch-01"
+    TOKEN = "host-2a85-1uk-r2r2yn0nv"
+
+    def _pass_two(self, masker: OutputMasker, obj: object) -> object:
+        # A mapping that would substitute the kept name, as a pass-1 handler
+        # that forgot the keep set would have left it.
+        return masker._mask_free_text(obj, {self.KEPT: self.TOKEN}, frozenset({self.KEPT}))
+
+    def test_prose_keeps_it(self, masker: OutputMasker):
+        out = self._pass_two(masker, {"msg": f"seen on {self.KEPT} overnight"})
+
+        assert out == {"msg": f"seen on {self.KEPT} overnight"}
+
+    def test_breakdown_bucket_keeps_it(self, masker: OutputMasker):
+        out = self._pass_two(
+            masker, {"breakdowns": {"msg": [{"value": f"seen on {self.KEPT}", "count": 3}]}}
+        )
+
+        assert out["breakdowns"]["msg"][0]["value"] == f"seen on {self.KEPT}"
+
+    def test_filter_entries_keep_it(self, masker: OutputMasker):
+        out = self._pass_two(masker, {"filter_applied": [f"devname=={self.KEPT}"]})
+
+        assert out["filter_applied"] == [f"devname=={self.KEPT}"]
+
+    def test_an_unkept_value_still_substitutes(self, masker: OutputMasker):
+        # Negative control: the same call path with an empty keep set must
+        # still replace the mapped value, or these tests would pass against a
+        # pass 2 that had simply stopped substituting anything.
+        out = masker._mask_free_text(
+            {"msg": f"seen on {self.KEPT} overnight"}, {self.KEPT: self.TOKEN}, frozenset()
+        )
+
+        assert out == {"msg": f"seen on {self.TOKEN} overnight"}

--- a/tests/test_masking_wrapper.py
+++ b/tests/test_masking_wrapper.py
@@ -1142,6 +1142,20 @@ class TestKeepSetAcrossBothPasses:
             name
         )
 
+    def test_kept_name_stays_clear_in_a_compiled_filter_entry(self, masker: OutputMasker):
+        # ``filter_applied`` echoes the compiled filter back. Its handler
+        # receives the keep set but typed each entry's value through
+        # ``_mask_scalar`` without passing it on, so the echo printed a token
+        # for the name ``devname`` shows in clear on the same record. Missed
+        # twice: once when this route was written, once when every other
+        # route was threaded, because ``_mask_scalar`` still had a default
+        # that made the omission silent. It no longer has one.
+        name = "fgt-branch-01"
+        masked = masker.mask_result({"devname": name, "filter_applied": [["srcname", "==", name]]})
+
+        assert masked["devname"] == name
+        assert masked["filter_applied"] == [["srcname", "==", name]]
+
     def test_kept_names_stay_clear_inside_a_comma_joined_value(self, masker: OutputMasker):
         # FAZ joins aggregated device names into one value, and the keep set
         # is built by splitting that form -- so it holds the parts, never the

--- a/tests/test_masking_wrapper.py
+++ b/tests/test_masking_wrapper.py
@@ -1050,6 +1050,43 @@ class TestKeepSetAcrossBothPasses:
 
         assert masked["grpby"] == f'{{"srcname": "{name}"}}'
 
+    def test_kept_name_stays_clear_whatever_case_it_is_written_in(self, masker: OutputMasker):
+        # Device names are routinely uppercase live, and two things fold case
+        # before the value is compared: urlsplit lowercases the host it
+        # returns, and a sibling field may simply spell the name differently
+        # from the key the keep set was built from. The engine already folds
+        # case for every type except USERNAME, so both spellings mask to one
+        # token -- which is exactly what makes the mismatch a leak rather
+        # than a cosmetic difference: the reader sees the name in clear under
+        # ``devname`` and its token beside it.
+        name = "FW-BRANCH-01"
+        masked = masker.mask_result(
+            {
+                "devname": name,
+                "url": f"https://{name}/admin",
+                "http_url": f"https://{name}/x",
+                "srcname": name.lower(),
+            }
+        )
+
+        assert masked["devname"] == name
+        assert masked["srcname"] == name.lower()
+        # Both URL handlers hand back the response's own spelling. Letting the
+        # value fall through to the scalar path instead would keep it out of a
+        # token but return urlsplit's lowercased copy, so the host would no
+        # longer match the ``devname`` printed beside it.
+        assert masked["url"].startswith(f"https://{name}/")
+        assert masked["http_url"] == f"https://{name}/x"
+
+    def test_a_kept_username_still_respects_case(self, masker: OutputMasker):
+        # The engine does NOT fold case for usernames, so two spellings are
+        # two principals and the case-insensitive match must not reach them.
+        # A device named ADMIN must not exempt a user called admin.
+        masked = masker.mask_result({"devname": "ADMIN", "user": "admin"})
+
+        assert masked["devname"] == "ADMIN"
+        assert masked["user"] != "admin"
+
     def test_kept_name_stays_clear_in_a_url_host(self, masker: OutputMasker):
         # The URL handlers mask the host component through the same scalar
         # path every typed field uses, so a device reached as a URL host


### PR DESCRIPTION
Closes the `keep`-less `mask_text` residual logged on #73 this morning, and the seven pass-1 routes upstream of it that turned out to be the same bug.

## What I found

The keep contract is that with `FAZ_MASK_DEVICE_IDENTITY` off, a device-identity value stays readable under **every** key, so the response never shows a token beside the cleartext it stands for. That was enforced on exactly one pass-1 route, the typed-scalar string branch #112 added, plus pass 2. Every other pass-1 route bypassed it.

Measured on v2.12.0 (`93496eb`), flag off, with the same name also under `devname`:

| route | before |
|---|---|
| `srcname: [name]` (typed **list** branch) | `['host-2a85-1uk-r2r2yn0nv']` |
| `groupby1: "hostname:<name>"` | `hostname:host-2a85-1uk-r2r2yn0nv` |
| `grpby: '{"srcname": "<name>"}'` | `{"srcname": "host-2a85-1uk-r2r2yn0nv"}` |
| `url` / `http_url` host | `https://host-2a85-1uk-r2r2yn0nv/...` |
| `value` + `type: domain\|ip\|url` | masked |
| `incident_reporter` (+ matching `reporter`) | `user-2a85-LfKaQYHNvHYs-wQIKDPNiL0Tcjl80P` |
| `threat` + `obf_url` | masked |

Each one prints a token for a name `devname` shows in clear two keys away, which is #73 item 5 exactly, on seven more routes.

The first of those is a residual of my own #112: I put the guard on the typed-scalar **string** branch and not on the **list** branch beside it.

The `grpby` JSON case has a clean negative control. `{"srcname": "<name>"}` is clear at the top level and tokenised one level in, same key, same string form, because `_mask_json_blob` started the nested walk without the keep set.

## The two sites logged on #73 are downstream

`mask_text` only substitutes what pass 1 recorded, so the non-JSON `grpby` fallback and the unparseable `http_url` branch cannot leak on their own. They leak once any route in the table above seeds the mapping. I could reproduce both, but only by seeding through the typed-list or URL-host route first. Fixing pass 1 closes them; I have threaded `keep` into both anyway, since a future pass-1 handler is exactly what would seed the mapping again.

## The fix

The guard moved into `_mask_scalar`, which every pass-1 route reaches, instead of being repeated at each call site.

That also fixes a case no call-site check could catch. FAZ joins aggregated device names into one comma-joined value, and `_device_identity_values` builds the keep set by splitting that form, so the set holds the parts and never the join. `raw in keep` is therefore false for `"fgt-branch-01,fgt-branch-02"` even when both parts are kept. `_mask_scalar` already splits on commas, so checking there covers both forms. The three inline `in keep` checks in `_mask_target` are folded into it for that reason. The untyped `asset_value` path still returns kept values clear, through `_burn_strings`, which I verified separately rather than assumed.

`_mask_device_vdom` and `_mask_device_name` are unchanged. Both return early when the flag is off, so the keep set is empty whenever they run.

## One consequence worth flagging

With pass 1 fixed, **no whole-response input can put a kept value into the mapping any more**, so pass 2's `keep` guard is no longer reachable end to end. It should stay: it is the layer that caught the #112/#109 composition trap, and a new pass-1 composite handler is precisely the change that would seed the mapping again.

So it is now pinned directly at the pass, in `TestPassTwoRefusesKeptValues`, with a negative control showing the same path still substitutes when the keep set is empty. That class is the only place this file calls a pass directly; the alternative was leaving five handlers' `keep` arguments removable without a failing test.

For the same reason, two existing test comments now describe a route that no longer exists. I corrected them rather than leave them false, the same way @sthayduk corrected the `_mask_breakdowns` docstring my #112 made false. Both tests keep their assertions and still pin the composed result.

## Verification

- 2057 passed, 55 integration errors. Baseline on `main` before the change: 2050 passed, the same 55. Seven new tests, no behaviour change elsewhere.
- `ruff check`, `ruff format --check`, `mypy src/` all clean.
- **13 mutants, 13 killed.** Reverting each threaded `keep` argument individually fails at least one test; disabling the central guard fails eight. Including the two pass-2 arguments, which fail one each.

## On the mypy backstop

@sthayduk's follow-up drops the `keep` default on the five private pass-2 handlers so an omission is a type error. Applied to **pass 1** it would have caught all seven of these, and I would rather that guard existed than that I found these by hand. I have deliberately not done it here, to keep this diff to the behaviour fix and out of the way of that PR. The two touch different functions in the same file, so they should compose, but I would rather his land first and rebase this on top than have the two race.
