### PR TITLE
feat: port to the mcp 2.0 MCPServer API and lift the <2 pin (#103)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,10 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "mcp>=2.0.0",  # ported to the MCPServer API in #103; 1.x lacks mcp.server.mcpserver
+    # Upper bound is deliberate: this server leans on framework internals
+    # (the tool-registration monkeypatch and ToolAnnotations field names),
+    # and 2.0 renamed read_only_hint out from under us on a major bump.
+    "mcp>=2.0.0,<3",  # ported to the MCPServer API in #103; 1.x lacks mcp.server.mcpserver
     "pydantic>=2.0.0",
     "pydantic-settings>=2.3.0",
     "httpx>=0.27.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "mcp>=1.0.0,<2",  # 2.0 removed mcp.server.fastmcp (our whole API); pin to 1.x until a deliberate migration
+    "mcp>=2.0.0",  # ported to the MCPServer API in #103; 1.x lacks mcp.server.mcpserver
     "pydantic>=2.0.0",
     "pydantic-settings>=2.3.0",
     "httpx>=0.27.0",

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -3,7 +3,7 @@
 Masks every tool result before it leaves the MCP toward the LLM. There is
 no central tool-registration function to hook (tool modules self-register
 with module-level ``@mcp.tool(...)`` at import time), so ``install_masking``
-patches ``mcp.tool`` on the shared FastMCP instance BEFORE the tool
+patches ``mcp.tool`` on the shared MCPServer instance BEFORE the tool
 modules are imported; every subsequently registered tool is wrapped.
 
 Masking runs in two passes over the result, because a value is only safe
@@ -1316,12 +1316,21 @@ def install_masking(mcp: Any) -> tuple[OutputMasker, ArgUnmasker]:
         # dict-shaped annotations object is honored too; anything else
         # (positional, absent, unrecognized) computes read_only=False and
         # the tool loses restoration rather than gaining a write path.
+        # Both attribute spellings are read because mcp 2.x renamed the
+        # python-side field to snake_case while keeping the camelCase
+        # constructor alias and the camelCase wire form. Reading only
+        # ``readOnlyHint`` there is not an error -- ``getattr`` returns the
+        # default -- so every read-only tool would silently lose restoration.
+        # The dict branch stays camelCase: a dict is the wire spelling.
         annotations = kwargs.get("annotations")
         if isinstance(annotations, dict):
             read_only = bool(annotations.get("readOnlyHint", False))
+        elif annotations is None:
+            read_only = False
         else:
             read_only = bool(
-                annotations is not None and getattr(annotations, "readOnlyHint", False)
+                getattr(annotations, "read_only_hint", None)
+                or getattr(annotations, "readOnlyHint", None)
             )
 
         def register(fn: Any) -> Any:

--- a/src/fortianalyzer_mcp/query/filters.py
+++ b/src/fortianalyzer_mcp/query/filters.py
@@ -92,7 +92,7 @@ _MULTI_VALUE_OPS = frozenset({"in", "not_in"})
 class FilterCondition(BaseModel):
     """One field/operator/value condition, independent of dialect.
 
-    A Pydantic model rather than a dict so FastMCP publishes a real JSON schema
+    A Pydantic model rather than a dict so MCPServer publishes a real JSON schema
     for it -- including the ``op`` enum, which is what stops an invalid operator
     at the protocol boundary instead of at the appliance.
     """

--- a/src/fortianalyzer_mcp/server.py
+++ b/src/fortianalyzer_mcp/server.py
@@ -6,7 +6,7 @@ import logging
 from collections.abc import AsyncIterator, Mapping
 from typing import Any
 
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 from mcp.server.transport_security import TransportSecuritySettings
 from pydantic import BaseModel
 from pydantic import ValidationError as PydanticValidationError
@@ -45,15 +45,21 @@ if settings.MCP_ALLOWED_HOSTS:
         allowed_hosts=settings.MCP_ALLOWED_HOSTS,
     )
 
-# Create FastMCP server.
+# Create the MCP server.
 #
 # Lifecycle ownership of the process-global ``faz_client`` is deliberately held
 # by exactly one path: ``run_http``'s ``app_lifespan`` in HTTP mode and
-# ``run_stdio`` in stdio mode. We do NOT pass a FastMCP ``lifespan`` here: with
+# ``run_stdio`` in stdio mode. We do NOT pass a ``lifespan`` here: with
 # ``stateless_http=True`` that lifespan runs per request/session, so it would
 # connect and then *disconnect* the shared client around every call, dropping the
 # session out from under concurrent requests.
-mcp = FastMCP(
+#
+# ``stateless_http`` and ``transport_security`` are NOT constructor arguments on
+# mcp 2.x -- they moved to the transport layer, so they are passed to
+# ``streamable_http_app()`` in ``run_http`` instead. Both still have to be set:
+# dropping them here without setting them there would silently make the HTTP
+# deployment stateful and unbound by the allowed-hosts list.
+mcp = MCPServer(
     "FortiAnalyzer API Server",
     # Cross-cutting usage guidance that no single tool docstring can carry --
     # chiefly that ``tid`` means five incompatible things across the async
@@ -61,8 +67,6 @@ mcp = FastMCP(
     # section is appended only when masking is on, so a default deployment does
     # not pay handshake tokens for advice about tokens it will never emit.
     instructions=build_instructions(masking_enabled=settings.MASKING_ENABLED),
-    stateless_http=True,  # Stateless for Docker deployment
-    transport_security=_transport_security,
 )
 
 if settings.MASKING_ENABLED:
@@ -95,7 +99,7 @@ def health_check() -> str:
 def _coerce_model_list(
     raw: object, model: type[BaseModel], param: str, shape: str
 ) -> list[BaseModel]:
-    """Validate a caller's list-of-models parameter, as FastMCP would have.
+    """Validate a caller's list-of-models parameter, as MCPServer would have.
 
     ``execute_advanced_tool`` invokes tool functions directly, so the protocol
     layer that turns JSON arguments into typed parameters never runs and a
@@ -108,7 +112,7 @@ def _coerce_model_list(
 
     Any tool parameter typed ``list[SomeModel]`` needs an entry in
     ``_STRUCTURED_PARAMS`` or it breaks in dynamic mode only — full mode keeps
-    working because FastMCP coerces there, which is what made this class of bug
+    working because MCPServer coerces there, which is what made this class of bug
     easy to ship.
 
     Raises:
@@ -282,7 +286,7 @@ _CATEGORY_DESCRIPTIONS: Mapping[str, str] = {
 
 
 # Dynamic mode: lightweight discovery tools
-def register_dynamic_tools(mcp_server: FastMCP) -> None:
+def register_dynamic_tools(mcp_server: MCPServer) -> None:
     """Register discovery tools for dynamic mode only."""
 
     @mcp_server.tool(annotations=READ_ONLY_LOCAL)
@@ -511,7 +515,7 @@ def run_stdio() -> None:
             logger.warning(f"FortiAnalyzer connection failed: {e}. Server will still start.")
 
         try:
-            # Run FastMCP in stdio mode
+            # Run MCPServer in stdio mode
             await mcp.run_stdio_async()
         finally:
             # Cleanup
@@ -660,7 +664,15 @@ def run_http() -> None:
     app = Starlette(
         routes=[
             Route("/health", health_endpoint, methods=["GET"]),
-            Mount("/", app=mcp.streamable_http_app()),
+            # stateless_http/transport_security live here on mcp 2.x; see the
+            # MCPServer construction above.
+            Mount(
+                "/",
+                app=mcp.streamable_http_app(
+                    stateless_http=True,  # Stateless for Docker deployment
+                    transport_security=_transport_security,
+                ),
+            ),
         ],
         lifespan=app_lifespan,
         middleware=middleware,

--- a/src/fortianalyzer_mcp/skills/handlers.py
+++ b/src/fortianalyzer_mcp/skills/handlers.py
@@ -13,7 +13,7 @@ Design constraints (RFC #44):
 
 Tool modules are imported lazily inside each handler: importing them at
 module scope would register every raw tool as a side effect (they attach
-to the shared FastMCP instance on import), which must not happen before
+to the shared MCPServer instance on import), which must not happen before
 the server's tool-mode branch has run.
 """
 

--- a/src/fortianalyzer_mcp/tool_annotations.py
+++ b/src/fortianalyzer_mcp/tool_annotations.py
@@ -48,31 +48,31 @@ from mcp.types import ToolAnnotations
 #: ``fetch_*``, the TID-creating queries, the local-file writers and the
 #: ``faz_skill`` dispatcher (whose skills are all readers by contract).
 READ_ONLY = ToolAnnotations(
-    readOnlyHint=True,
-    destructiveHint=False,
-    idempotentHint=True,
-    openWorldHint=True,
+    read_only_hint=True,
+    destructive_hint=False,
+    idempotent_hint=True,
+    open_world_hint=True,
 )
 
 #: Reads nothing outside this process. Only the dynamic-mode discovery
 #: tools, which answer from an in-process catalogue and never reach the
-#: network -- hence ``openWorldHint=False``, the one place in this server
+#: network -- hence ``open_world_hint=False``, the one place in this server
 #: where that field is not true.
 READ_ONLY_LOCAL = ToolAnnotations(
-    readOnlyHint=True,
-    destructiveHint=False,
-    idempotentHint=True,
-    openWorldHint=False,
+    read_only_hint=True,
+    destructive_hint=False,
+    idempotent_hint=True,
+    open_world_hint=False,
 )
 
 #: Adds new state to FortiAnalyzer. Additive, so not destructive; a
 #: repeat call adds again (a second device, a second comment, a second
 #: rescan job), so not idempotent.
 CREATES = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=False,
-    idempotentHint=False,
-    openWorldHint=True,
+    read_only_hint=False,
+    destructive_hint=False,
+    idempotent_hint=False,
+    open_world_hint=True,
 )
 
 #: Flips a reversible flag on existing FortiAnalyzer state. Not
@@ -80,10 +80,10 @@ CREATES = ToolAnnotations(
 #: undoes it -- and idempotent because acknowledging an acknowledged
 #: alert is a no-op.
 UPDATES = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=False,
-    idempotentHint=True,
-    openWorldHint=True,
+    read_only_hint=False,
+    destructive_hint=False,
+    idempotent_hint=True,
+    open_world_hint=True,
 )
 
 #: Removes FortiAnalyzer state, or replaces it with no recovery path.
@@ -91,10 +91,10 @@ UPDATES = ToolAnnotations(
 #: value is unrecoverable afterwards, which is what "destructive update"
 #: means in the spec as opposed to "additive only".
 DESTRUCTIVE = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=True,
-    openWorldHint=True,
+    read_only_hint=False,
+    destructive_hint=True,
+    idempotent_hint=True,
+    open_world_hint=True,
 )
 
 #: Dispatches to an arbitrary tool chosen by name at call time, so its
@@ -104,10 +104,10 @@ DESTRUCTIVE = ToolAnnotations(
 #: the server: one tool that advertises "changes nothing" while exposing
 #: every mutating operation behind a string argument.
 UNCONSTRAINED = ToolAnnotations(
-    readOnlyHint=False,
-    destructiveHint=True,
-    idempotentHint=False,
-    openWorldHint=True,
+    read_only_hint=False,
+    destructive_hint=True,
+    idempotent_hint=False,
+    open_world_hint=True,
 )
 
 #: Every approved category, by name. The annotation contract test asserts

--- a/src/fortianalyzer_mcp/tools/ioc_tools.py
+++ b/src/fortianalyzer_mcp/tools/ioc_tools.py
@@ -27,7 +27,7 @@ class IocEventRef(BaseModel):
     endpoint it fired on (``endpoint-id`` and/or ``source-ip``) plus the
     ``timestamp`` it fired at -- so an acknowledgement needs the identity
     triple, not an opaque handle. A Pydantic model rather than a dict so
-    FastMCP publishes a real JSON schema and a caller cannot silently omit
+    MCPServer publishes a real JSON schema and a caller cannot silently omit
     the whole identity.
 
     Take the values straight off an IOC event row rather than composing

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,7 @@ def import_dispatcher_isolated(*names: str) -> tuple[Any, ...]:
     ``test_tool_catalogue_parity.py``), and doing so in a way that depended
     on which of the eleven files happened to collect first.
 
-    A throwaway ``FastMCP`` substitute for the duration of the import would
+    A throwaway ``MCPServer`` substitute for the duration of the import would
     also stop the registration leak, but changes ``faz_skill``'s own
     *behavior*: ``install_masking()`` (``masking/wrapper.py``) patches
     ``mcp.tool`` on the real, process-global singleton to wrap every
@@ -46,7 +46,7 @@ def import_dispatcher_isolated(*names: str) -> tuple[Any, ...]:
     ``MASKING_ENABLED=true``, silently testing a differently-behaved
     function than a real deployment (or ``FAZ_SKILLS_ENABLED=true``) would
     have. (This is exactly what the first version of this fix, isolating via
-    a substitute ``FastMCP``, got wrong: it made a masked-suite failure that
+    a substitute ``MCPServer``, got wrong: it made a masked-suite failure that
     predates this plan -- ``test_skills_network_context.py``'s
     ``test_success_envelope_with_serialized_gap`` -- disappear depending on
     which test file happened to import the dispatcher first, rather than

--- a/tests/test_dynamic_mode_filters.py
+++ b/tests/test_dynamic_mode_filters.py
@@ -1,6 +1,6 @@
 """Structured ``filters`` must survive the dynamic-mode dispatch path.
 
-Full mode gets dict-to-model coercion for free: FastMCP validates a caller's
+Full mode gets dict-to-model coercion for free: MCPServer validates a caller's
 JSON into ``FilterCondition`` models before a tool body runs, which is the
 assumption ``TestCompilerRequiresModelsNotDicts`` pins. Dynamic mode's
 ``execute_advanced_tool`` bypasses that layer -- it invokes the raw tool
@@ -10,7 +10,7 @@ buried it in a generic ``faz_operation_failed``. Structured filters were
 silently unusable on the whole dynamic surface (``query_logs``,
 ``search_devices``, ``list_tasks``); found in review of #94.
 
-The dispatch path therefore has to perform the validation FastMCP would
+The dispatch path therefore has to perform the validation MCPServer would
 have: dicts become models before the tool runs, and a malformed condition
 is rejected with the standard ``validation_error`` envelope instead of
 reaching a compiler.
@@ -27,7 +27,7 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
 
 from fortianalyzer_mcp.query.filters import FilterCondition
 from fortianalyzer_mcp.server import register_dynamic_tools
@@ -36,13 +36,13 @@ from fortianalyzer_mcp.tools import dvm_tools, ioc_tools
 
 @pytest.fixture(scope="module")
 def execute_advanced_tool() -> Any:
-    """The dispatcher off a private FastMCP instance, not the global one.
+    """The dispatcher off a private MCPServer instance, not the global one.
 
     ``register_dynamic_tools`` only needs a server to hang tools on; using a
     fresh instance keeps this module independent of ``FAZ_TOOL_MODE`` in the
     test environment.
     """
-    server = FastMCP("dynamic-filters-test")
+    server = MCPServer("dynamic-filters-test")
     register_dynamic_tools(server)
     tools = {tool.name: tool for tool in server._tool_manager.list_tools()}
     return tools["execute_advanced_tool"].fn

--- a/tests/test_masking_filter_conditions.py
+++ b/tests/test_masking_filter_conditions.py
@@ -121,7 +121,7 @@ class TestAliasFieldNames:
 
 
 class TestFilterConditionModels:
-    """The model form, which is what FastMCP passes to the tool."""
+    """The model form, which is what MCPServer passes to the tool."""
 
     def test_model_instance_is_resolved_and_stays_a_model(self) -> None:
         engine = _engine()
@@ -176,7 +176,7 @@ class TestCompilerRequiresModelsNotDicts:
     meet. The compilers below it cannot consume one -- both use attribute
     access -- so the dict form is supported at one layer and rejected at the
     next. That is harmless in production only because every boundary coerces
-    before a tool body runs: FastMCP validates into models in full mode, and
+    before a tool body runs: MCPServer validates into models in full mode, and
     ``server._coerce_model_list`` does the same for dynamic mode's
     direct dispatch (``tests/test_dynamic_mode_filters.py``). It is worth
     pinning so the two layers are not mistaken for having the same contract.
@@ -191,7 +191,7 @@ class TestCompilerRequiresModelsNotDicts:
             compiler([{"field": "name", "op": "eq", "value": "x"}], vocabulary)  # type: ignore[operator]
 
     def test_the_model_form_of_the_same_condition_compiles(self) -> None:
-        """Control: the shape FastMCP actually hands over works fine."""
+        """Control: the shape MCPServer actually hands over works fine."""
         result, _ = compile_to_array([FilterCondition(field="name", op="eq", value="x")], "device")
         assert result == [["name", "==", "x"]]
 

--- a/tests/test_masking_unmask.py
+++ b/tests/test_masking_unmask.py
@@ -326,12 +326,12 @@ class TestRoundTrip:
     async def test_wrapped_tool_unmasks_args_and_masks_output(
         self, monkeypatch: pytest.MonkeyPatch, engine: FPEEngine
     ):
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server.mcpserver import MCPServer
 
         from fortianalyzer_mcp.tool_annotations import READ_ONLY
 
         monkeypatch.setenv("FAZ_MASKING_KEY", KEY)
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         install_masking(mcp)
         seen: dict[str, str] = {}
 
@@ -357,10 +357,10 @@ class TestRoundTrip:
         token) and a second pass over a first-pass token can fail closed
         into a placeholder. Found by the flag-on live round: 8 of 8
         fortiview threat rows arrived double-masked, 2 as placeholders."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server.mcpserver import MCPServer
 
         monkeypatch.setenv("FAZ_MASKING_KEY", KEY)
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         install_masking(mcp)
 
         @mcp.tool()

--- a/tests/test_masking_wrapper.py
+++ b/tests/test_masking_wrapper.py
@@ -513,10 +513,10 @@ class TestInstallMasking:
     async def test_tools_registered_after_install_are_wrapped(
         self, monkeypatch: pytest.MonkeyPatch
     ):
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server.mcpserver import MCPServer
 
         monkeypatch.setenv("FAZ_MASKING_KEY", KEY)
-        mcp = FastMCP("test")
+        mcp = MCPServer("test")
         install_masking(mcp)
 
         @mcp.tool()
@@ -529,7 +529,7 @@ class TestInstallMasking:
         assert result["logs"][0]["user"].startswith("user-")
 
     def test_install_without_key_fails_loud(self, monkeypatch: pytest.MonkeyPatch):
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server.mcpserver import MCPServer
 
         import fortianalyzer_mcp.utils.config as config_mod
         from fortianalyzer_mcp.masking.fpe_engine import MaskingError
@@ -542,7 +542,7 @@ class TestInstallMasking:
             config_mod, "get_settings", lambda: _settings_with(FAZ_MASKING_KEY=None)
         )
         with pytest.raises(MaskingError, match="FAZ_MASKING_KEY"):
-            install_masking(FastMCP("test"))
+            install_masking(MCPServer("test"))
 
     def test_key_resolves_from_settings_when_not_in_environment(
         self, monkeypatch: pytest.MonkeyPatch
@@ -551,13 +551,13 @@ class TestInstallMasking:
         reads FAZ_MASKING_KEY from os.environ. If the key lives only in .env
         (as the README documents), install_masking must bridge it or the
         server crashes fail-closed on startup. A real env var still wins."""
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server.mcpserver import MCPServer
 
         import fortianalyzer_mcp.utils.config as config_mod
 
         monkeypatch.delenv("FAZ_MASKING_KEY", raising=False)
         monkeypatch.setattr(config_mod, "get_settings", lambda: _settings_with(FAZ_MASKING_KEY=KEY))
-        masker, _ = install_masking(FastMCP("test"))
+        masker, _ = install_masking(MCPServer("test"))
         assert masker is not None
         # the bridge exported it so the engine and placeholder key both see it
         import os
@@ -708,10 +708,10 @@ class TestMutatingToolGate:
     """
 
     def _install(self, monkeypatch: pytest.MonkeyPatch):
-        from mcp.server.fastmcp import FastMCP
+        from mcp.server.mcpserver import MCPServer
 
         monkeypatch.setenv("FAZ_MASKING_KEY", KEY)
-        mcp = FastMCP("test-gate")
+        mcp = MCPServer("test-gate")
         install_masking(mcp)
         return mcp
 

--- a/tests/test_server_instructions.py
+++ b/tests/test_server_instructions.py
@@ -1,6 +1,6 @@
 """Contract tests for the server-level ``instructions`` block.
 
-``FastMCP(instructions=...)`` is the only text this server ships that a
+``MCPServer(instructions=...)`` is the only text this server ships that a
 client reads *before* choosing a tool. Per-tool docstrings cannot carry a
 cross-cutting fact, because a caller holding one tool's docstring has no
 reason to suspect a neighbouring tool disagrees -- and here several do.
@@ -67,10 +67,10 @@ STRUCTURED_FILTER_OPS = (
 
 @pytest.fixture(scope="module")
 def instructions() -> str:
-    """The live ``instructions`` string off the module-global FastMCP."""
+    """The live ``instructions`` string off the module-global MCPServer."""
     server = importlib.import_module("fortianalyzer_mcp.server")
     text = server.mcp.instructions
-    assert text is not None, "FastMCP was constructed without instructions="
+    assert text is not None, "MCPServer was constructed without instructions="
     return text
 
 

--- a/tests/test_tool_annotations.py
+++ b/tests/test_tool_annotations.py
@@ -91,7 +91,10 @@ EXPECTED_DYNAMIC_SURFACE = {
     "list_fortianalyzer_categories",
 }
 
-HINT_FIELDS = ("readOnlyHint", "destructiveHint", "idempotentHint", "openWorldHint")
+#: Python-side attribute names. mcp 2.x renamed these to snake_case while
+#: keeping the camelCase constructor aliases and the camelCase wire form,
+#: so the CATEGORIES below still spell them camelCase when constructing.
+HINT_FIELDS = ("read_only_hint", "destructive_hint", "idempotent_hint", "open_world_hint")
 
 #: Env vars the loader sets. Snapshotted and restored around the fixture.
 _TOUCHED_ENV = (
@@ -287,7 +290,7 @@ def test_full_mode_registers_the_whole_surface(full_tools: dict[str, Any]) -> No
 def test_full_mode_mutating_set_is_frozen(full_tools: dict[str, Any]) -> None:
     """The write surface is exactly EXPECTED_MUTATING -- no more, no less."""
     actual = {
-        name for name, tool in full_tools.items() if tool.annotations.readOnlyHint is not True
+        name for name, tool in full_tools.items() if tool.annotations.read_only_hint is not True
     }
     expected = set(EXPECTED_MUTATING)
 
@@ -314,7 +317,7 @@ def test_full_mode_mutating_categories_match(full_tools: dict[str, Any]) -> None
 def test_dynamic_mode_mutating_set_is_frozen(dynamic_tools: dict[str, Any]) -> None:
     """Dynamic mode's write surface is execute_advanced_tool alone."""
     actual = {
-        name for name, tool in dynamic_tools.items() if tool.annotations.readOnlyHint is not True
+        name for name, tool in dynamic_tools.items() if tool.annotations.read_only_hint is not True
     }
     assert actual == set(EXPECTED_MUTATING_DYNAMIC), (
         f"dynamic-mode write surface changed: {sorted(actual)}"
@@ -331,7 +334,7 @@ def test_open_world_is_false_only_for_the_local_catalogue_tools(
         name
         for tools in (full_tools, dynamic_tools)
         for name, tool in tools.items()
-        if tool.annotations.openWorldHint is False
+        if tool.annotations.open_world_hint is False
     }
     assert closed == EXPECTED_LOCAL, (
         f"openWorldHint=False set changed: {sorted(closed)}; a tool that queries "

--- a/tests/test_tool_catalogue_parity.py
+++ b/tests/test_tool_catalogue_parity.py
@@ -67,7 +67,7 @@ skip_if_dynamic_mode = pytest.mark.skipif(
 def _registered_tool_names() -> set[str]:
     """Every tool name registered in full mode, minus the one deliberate exception.
 
-    Read from FastMCP, not from `tools.__all__`: that list holds the ten tool
+    Read from MCPServer, not from `tools.__all__`: that list holds the ten tool
     *modules*, never the tool functions, so using it here would compare the
     catalogue against the wrong thing and pass while saying nothing.
 


### PR DESCRIPTION
Closes #103. The port from `mcp.server.fastmcp.FastMCP` to `mcp.server.mcpserver.MCPServer`, with the `<2` pin lifted.

My spike on #103 said the risky part (the masking monkeypatch) was fine and the real work was two constructor kwargs. The first half held exactly. The second half was incomplete, and the gap was the interesting part.

## What the spike got right

The masking patch needed **no changes**. `mcp.tool` is still an instance attribute the patch replaces, tools still register through it, and schema generation still follows `__wrapped__`. Schemas, dict-to-model coercion for the `list[FilterCondition]` parameters, and the `FAZ_TOOL_MODE=dynamic` path all behave as before.

`stateless_http` and `transport_security` are indeed gone from the constructor and now belong to `streamable_http_app()`. Both still have to be set. Dropping them from the constructor without adding them to the transport would quietly make the HTTP deployment stateful and unbound by `MCP_ALLOWED_HOSTS`, and nothing would fail to say so.

## What the spike missed

`ToolAnnotations` renamed its **python-side attributes** to snake_case. The camelCase constructor aliases and the camelCase wire form are both retained, so clients see a byte-identical document. My spike checked construction and the wire dump, and concluded the only rename was `Tool.inputSchema`. It never checked attribute *reads*.

The masking gate reads one:

```python
read_only = bool(annotations is not None and getattr(annotations, "readOnlyHint", False))
```

On 2.0 that attribute does not exist, and `getattr` with a default is not an error. It returns `False`. **Every read-only tool would have silently lost argument restoration.** That is fail-closed, so it is a functional regression rather than an exposure, but nothing in the system would have said a word about it. The suite caught it (`TestMutatingToolGate::test_read_only_tool_still_restores`), which is the argument for having written that test in #108.

The gate now reads both spellings. The dict branch stays camelCase, because a dict is the wire spelling.

The annotation constructors move to snake_case keywords too. The camelCase aliases work at runtime but mypy rejects them: 24 errors in `tool_annotations.py` alone. Prose naming `readOnlyHint` and friends is deliberately left alone, since those are the spec and wire names and they have not changed.

## Verification

- **CI's own command** (`pytest tests/ --ignore=tests/integration`): **2050 passed, exit 0** on this branch under mcp 2.0.0, and **2050 passed, exit 0** on `main` under 1.27.0. Same count, same result, so the port is behaviour-neutral for the suite.
- `ruff check`, `ruff format --check`, `mypy src/` all clean.
- **HTTP transport served end to end**: `/health` 200, `initialize` returns capabilities and instructions, `tools/list` returns all **73 tools, all 73 annotated**, and a `tools/call` through the masking wrapper came back with the target address masked, so the FPE boundary works on the new transport stack.
- **`transport_security` proven live in its new home**: an allowed-hosts list that did not match the request produced `Invalid Host header` instead of serving. That is the check actually running, not just the kwarg being accepted.
- **stdio transport**: `initialize` plus `tools/list` returning the same 73.
- **Wire annotations remain camelCase**, read off the running server: `{"destructiveHint": false, "idempotentHint": true, "openWorldHint": true, "readOnlyHint": true}`.

## What I have not done

**A soak against a live FortiAnalyzer.** The two lab instances share one virtualenv, so `pip install mcp>=2` there flips both at once, and that is not something to do with an unreviewed port on the box that is currently running the v2.12.0 release. (The FortiManager services are on their own venv, so they are not in the blast radius.) Worth doing before this merges, on a split venv or a throwaway instance, and I am happy to run it.

One consequence to be explicit about: this makes **mcp 2.x required**, not optional. There is no dual-support path, because the import moved. Anyone pinned to 1.x stays on v2.12.0.
