### PR TITLE
feat(masking): v2 token envelope with authenticated tags, shape gate and deprecation window (#40)

### DIFF
--- a/src/fortianalyzer_mcp/masking/fields.py
+++ b/src/fortianalyzer_mcp/masking/fields.py
@@ -488,7 +488,11 @@ DEVICE_IDENTITY_TYPES: dict[str, str] = {
     "sndetected": SERIAL,
     "snclosest": SERIAL,
     "fortigate": HOSTNAME,  # fortiview: reporting device, comma-joined when aggregated
-    "detectkey": HOSTNAME,  # ueba endpoints: serial of the detecting appliance
+    # This table's own comment called it a serial, and it was still typed as
+    # a hostname, so it kept the exact round-trip bug the serial type was
+    # added to fix. Found by review after the first pass moved only the
+    # sn-spelled keys.
+    "detectkey": SERIAL,  # ueba endpoints: serial of the detecting appliance
     # eventmgmt alert subject_details: {alertid, devs, epids, euids}. Same
     # class as devname, and until it was listed here it defeated the flag
     # rather than following it: the device stayed clear under "devs" while

--- a/src/fortianalyzer_mcp/masking/fields.py
+++ b/src/fortianalyzer_mcp/masking/fields.py
@@ -481,7 +481,20 @@ COMPOSITE_DEVICE_VDOM = ("devvds",)
 #: opts in via ``FAZ_MASK_DEVICE_IDENTITY``; see the module docstring.
 DEVICE_IDENTITY_TYPES: dict[str, str] = {
     "devname": HOSTNAME,
-    "devid": HOSTNAME,
+    # This repo's own tools layer documents devid as the SERIAL-carrying
+    # spelling, in three places: fortiview_tools.py builds
+    # [{"devid": <serial>}] for a serial-shaped value and notes that "a
+    # serial under devname silently matches nothing", and report_tools.py
+    # routes "serials -> devid, names -> devname". Typed HOSTNAME it kept
+    # the exact round-trip bug SERIAL was added to fix: a serial came back
+    # lowercased, and it minted a different token from the same serial
+    # under sn on the same list_devices row.
+    #
+    # IP_HOST_OR_SERIAL rather than a flat SERIAL because devid is
+    # polymorphic in practice, holding a device NAME on the surfaces the
+    # #80 sweep sampled. Same reasoning, and the same type, as the
+    # "device" target slot.
+    "devid": IP_HOST_OR_SERIAL,
     # The serial-carrying keys take SERIAL rather than HOSTNAME, so they
     # round-trip byte-exact. Only keys already in this table move; the
     # spelling variants found in #80 (module_sn, tunnel_sn) are not added

--- a/src/fortianalyzer_mcp/masking/fields.py
+++ b/src/fortianalyzer_mcp/masking/fields.py
@@ -134,6 +134,12 @@ HOSTNAME = "hostname"
 USERNAME = "username"
 DOMAIN = "domain"
 EMAIL = "email"
+#: Device serials. Separate from HOSTNAME because the string alphabet is
+#: lowercase and a serial is not: masked as a hostname, ``FGT60FTK20000001``
+#: comes back ``fgt60ftk20000001``, which is no longer the serial. The serial
+#: cipher base32-shields the value first, so case and the hyphen survive.
+#: Settled on #40; matches the type that shipped on fortimanager-mcp.
+SERIAL = "serial"
 TEXT = "text"  # free text: embedded IOCs are masked in place
 #: Holds either an address or a name depending on the record. Masks as
 #: whichever it parses as; the two token forms stay distinguishable on the
@@ -467,11 +473,20 @@ COMPOSITE_DEVICE_VDOM = ("devvds",)
 DEVICE_IDENTITY_TYPES: dict[str, str] = {
     "devname": HOSTNAME,
     "devid": HOSTNAME,
-    "sn": HOSTNAME,
-    "serialno": HOSTNAME,
-    "csf": HOSTNAME,
-    "sndetected": HOSTNAME,
-    "snclosest": HOSTNAME,
+    # The serial-carrying keys take SERIAL rather than HOSTNAME, so they
+    # round-trip byte-exact. Only keys already in this table move; the
+    # spelling variants found in #80 (module_sn, tunnel_sn) are not added
+    # here, because which table they belong in is still Roland's call.
+    #
+    # Safe even where one of these turns out to carry something that is not
+    # a serial: the serial cipher shields arbitrary bytes through base32, so
+    # it accepts strictly more than the hostname alphabet does. The visible
+    # change is the token prefix, sn- instead of host-.
+    "sn": SERIAL,
+    "serialno": SERIAL,
+    "csf": HOSTNAME,  # Security Fabric name, a label rather than a serial
+    "sndetected": SERIAL,
+    "snclosest": SERIAL,
     "fortigate": HOSTNAME,  # fortiview: reporting device, comma-joined when aggregated
     "detectkey": HOSTNAME,  # ueba endpoints: serial of the detecting appliance
     # eventmgmt alert subject_details: {alertid, devs, epids, euids}. Same

--- a/src/fortianalyzer_mcp/masking/fields.py
+++ b/src/fortianalyzer_mcp/masking/fields.py
@@ -147,6 +147,15 @@ TEXT = "text"  # free text: embedded IOCs are masked in place
 #: parses as an IP), so the round trip is unambiguous.
 IP_OR_HOST = "ip_or_host"
 
+#: Like IP_OR_HOST, plus a device serial. Needed for target[].value under
+#: name=="device": measured fixture data shows this slot carries either an
+#: endpoint hostname or the device's own serial (see the "sn" field type's
+#: docstring for why a serial cannot round-trip as a hostname -- case is
+#: lost). Kept separate from IP_OR_HOST rather than teaching every
+#: IP_OR_HOST field to also try serial-shape, since none of the others
+#: (endpoint, host_name) are documented to ever carry one.
+IP_HOST_OR_SERIAL = "ip_host_or_serial"
+
 FIELD_TYPES: dict[str, str] = {
     # --- IP carriers (log fields + alert/event_details variants)
     "srcip": IP,
@@ -510,7 +519,7 @@ DEVICE_IDENTITY_TYPES: dict[str, str] = {
 TARGET_NAME_TYPES: dict[str, str] = {
     "ip": IP,
     "domain": DOMAIN,
-    "device": IP_OR_HOST,
+    "device": IP_HOST_OR_SERIAL,
     "endpoint": IP_OR_HOST,
     "user": USERNAME,
     # Live webfilter alerts carry the browsed destination as a host_name

--- a/src/fortianalyzer_mcp/masking/fpe_engine.py
+++ b/src/fortianalyzer_mcp/masking/fpe_engine.py
@@ -580,7 +580,14 @@ class FPEEngine:
         if match is None:
             raise MaskingError("not a v2 token")
         marker = match.group("marker").lower()
-        vtype = next(t for t, m in V2_MARKERS.items() if m == marker)
+        try:
+            vtype = next(t for t, m in V2_MARKERS.items() if m == marker)
+        except StopIteration:  # pragma: no cover - markers are a closed set
+            # Same guard is_own_v2_token takes on the identical lookup: if
+            # V2_MARKERS and _V2_SHAPE_RE's marker alternation ever diverge,
+            # this fails closed with the documented refusal instead of an
+            # unhandled StopIteration escaping the masking boundary.
+            raise MaskingError("not a v2 token") from None
         # Username ciphertext is case-sensitive; every other payload is
         # lowercase by construction and folding tolerates a re-cased token.
         payload = match.group("ct") if vtype == "username" else match.group("ct").lower()

--- a/src/fortianalyzer_mcp/masking/fpe_engine.py
+++ b/src/fortianalyzer_mcp/masking/fpe_engine.py
@@ -127,8 +127,18 @@ _TWEAK_LABELS = {
 
 
 #: Width of the v2 envelope's authentication tag, in hex characters.
-#: 8 hex = 32 bits = one in 4.3 billion per blind forgery attempt, and every
-#: attempt costs an attacker one tool call, so forgery is strictly online.
+#: 8 hex = 32 bits = one in 4.3 billion per blind forgery attempt. Forgery is
+#: strictly online, because nothing lets an attacker test a guessed tag
+#: locally.
+#:
+#: The bound is per VERIFICATION, not per tool call, and the difference
+#: matters: one call can carry many tokens (measured, 5000 in a single
+#: ``filters`` list, each resolved independently), so 2**31 expected
+#: verifications is on the order of 10**5 calls rather than 10**9. Making
+#: that cost real is the caller's job, not this function's -- the envelope
+#: layer has to cap tokens verified per call and alarm on repeated
+#: verification failures. Sizing alone does not buy the guarantee.
+#:
 #: Settled on #40; it is part of the format shared with fortimanager-mcp and
 #: cannot be changed on one side alone.
 V2_TAG_HEX = 8
@@ -284,7 +294,19 @@ class FPEEngine:
         there would let two distinct principals' tokens authenticate each
         other's payloads.
         """
-        return ct if vtype == "username" else ct.lower()
+        if vtype == "username":
+            return ct
+        if vtype == "ipv6":
+            # ``abcd::1`` and its fully expanded form are one address, and
+            # decryption accepts either, so the tag has to as well. An
+            # unparseable payload is left exactly as written rather than
+            # coerced: collapsing two different unparseable strings to one
+            # canonical form would let them authenticate each other.
+            try:
+                return str(ipaddress.IPv6Address(ct.strip()))
+            except ValueError:
+                return ct.lower()
+        return ct.lower()
 
     def v2_tag_ok(self, vtype: str, ct: str, tag: str) -> bool:
         """Is ``tag`` the authentic tag for this payload?
@@ -311,7 +333,7 @@ class FPEEngine:
         leak nothing, since both are fixed and public.
         """
         expected = self.v2_tag(vtype, ct)
-        candidate = tag.strip().lower()
+        candidate = tag.lower()
         if not _V2_TAG_RE.match(candidate):
             return False
         return hmac.compare_digest(candidate, expected)

--- a/src/fortianalyzer_mcp/masking/fpe_engine.py
+++ b/src/fortianalyzer_mcp/masking/fpe_engine.py
@@ -1136,7 +1136,23 @@ class FPEEngine:
         if not _KEY_ID_RE.match(kid) or sep != "." or not ct:
             raise MaskingError(f"token carries no key id: {token!r}")
         self._check_key_id(kid, token)
-        self._refuse_v1_if_window_closed("suffix")
+        # Deliberately NOT gated by the v1 deprecation window. The suffix
+        # form is domain and email_local, and those two have no v2 envelope
+        # by design (they are suffix-marked, so a v2 spelling would be a
+        # different parse, and they already carry a marker and a key id --
+        # settled on #40). A suffix token is therefore not a legacy
+        # encoding waiting to be retired, it is the only encoding those
+        # types have ever had, and refusing it refuses this build's own
+        # freshly minted output.
+        #
+        # Measured before changing it: with the window closed, mask_domain
+        # produced a token that unmask_domain then refused, in the same
+        # process with the same key. That made the window unclosable, since
+        # closing it broke domain and email masking outright.
+        #
+        # If domain/email_local ever gain a v2 envelope, this call has to
+        # come back. test_domain_and_email_local_have_no_v2_envelope is what
+        # fails first in that case.
         return ct
 
     def _check_key_id(self, kid: str, token: str) -> None:

--- a/src/fortianalyzer_mcp/masking/fpe_engine.py
+++ b/src/fortianalyzer_mcp/masking/fpe_engine.py
@@ -158,6 +158,12 @@ _V2_TAG_RE = re.compile(rf"^[0-9a-f]{{{V2_TAG_HEX}}}$")
 #: MAC), so the first colon after the fixed prefix is what delimits the type.
 #: Add a type with a colon in it and two different (type, ciphertext) pairs
 #: could authenticate each other's tokens.
+#: ``serial`` has no entry in ``_TWEAK_LABELS`` yet, on purpose: it is a
+#: forward declaration of the type the envelope work adds, and nothing can
+#: mint a serial ciphertext today (serials currently ride HOSTNAME). It is
+#: named here so the shared vocabulary is pinned once rather than changed
+#: twice. Whether a ``serialno`` field ends up emitting ``serial`` or
+#: ``hostname`` is still open on #40.
 V2_TYPES = frozenset(
     {"ipv4", "ipv6", "mac", "serial", "hostname", "username", "domain", "email_local", "url_tail"}
 )
@@ -311,8 +317,12 @@ class FPEEngine:
     def v2_tag_ok(self, vtype: str, ct: str, tag: str) -> bool:
         """Is ``tag`` the authentic tag for this payload?
 
-        Total over the tag, which arrives inside a token a model hands back
-        and is therefore untrusted: anything that is not exactly
+        Total over BOTH untrusted inputs, the tag and the payload, since the
+        envelope parser slices both out of token text a model supplied.
+        Minting (:meth:`v2_tag`) still raises on an unencodable payload,
+        because there the ciphertext is one we produced.
+
+        Total over the tag: anything that is not exactly
         :data:`V2_TAG_HEX` hex characters is False, never an exception.
         ``compare_digest`` raises TypeError on a non-ASCII string rather
         than returning False, so the shape check has to come first.
@@ -332,7 +342,15 @@ class FPEEngine:
         2**32 attempts to a few hundred. The length and shape checks above
         leak nothing, since both are fixed and public.
         """
-        expected = self.v2_tag(vtype, ct)
+        try:
+            expected = self.v2_tag(vtype, ct)
+        except UnicodeEncodeError:
+            # A payload that is not encodable UTF-8 (a lone surrogate, which
+            # json.loads produces from a "\\ud800" escape) cannot be a
+            # ciphertext we minted, and the parser slices it out of token text
+            # a model supplied. Same class as an unencodable tag: refuse,
+            # rather than raise out of the inbound path.
+            return False
         candidate = tag.lower()
         if not _V2_TAG_RE.match(candidate):
             return False

--- a/src/fortianalyzer_mcp/masking/fpe_engine.py
+++ b/src/fortianalyzer_mcp/masking/fpe_engine.py
@@ -133,6 +133,12 @@ _TWEAK_LABELS = {
 #: cannot be changed on one side alone.
 V2_TAG_HEX = 8
 
+#: A well-formed tag: exactly V2_TAG_HEX lowercase hex characters.
+#: Checked before comparison because ``hmac.compare_digest`` raises on a
+#: non-ASCII string instead of returning False, and the tag reaches us
+#: from inside a token a model hands back.
+_V2_TAG_RE = re.compile(rf"^[0-9a-f]{{{V2_TAG_HEX}}}$")
+
 #: Value types that may appear in a v2 envelope.
 #:
 #: Pinned, and asserted colon-free, because the tag is computed over
@@ -264,11 +270,28 @@ class FPEEngine:
     def v2_tag_ok(self, vtype: str, ct: str, tag: str) -> bool:
         """Is ``tag`` the authentic tag for this payload?
 
+        Total over the tag, which arrives inside a token a model hands back
+        and is therefore untrusted: anything that is not exactly
+        :data:`V2_TAG_HEX` lowercase hex characters is False, never an
+        exception. ``compare_digest`` raises TypeError on a non-ASCII string
+        rather than returning False, so the shape check has to come first.
+        Rejecting uppercase here is deliberate too: tags are minted
+        lowercase, and treating a re-cased tag as valid would widen what
+        counts as authentic for no benefit.
+
+        ``vtype`` is NOT untrusted, and an unknown one still raises. It comes
+        from this repo's own field table, so it is a bug here rather than
+        something a caller can influence, and swallowing it would hide that.
+
         Constant-time comparison: a timing signal on the tag check would let
         an attacker recover a valid tag byte by byte and reduce forgery from
-        2**32 attempts to a few hundred.
+        2**32 attempts to a few hundred. The length and shape checks above
+        leak nothing, since both are fixed and public.
         """
-        return hmac.compare_digest(tag, self.v2_tag(vtype, ct))
+        expected = self.v2_tag(vtype, ct)
+        if len(tag) != V2_TAG_HEX or not _V2_TAG_RE.match(tag):
+            return False
+        return hmac.compare_digest(tag, expected)
 
     # ------------------------------------------------------------------ #
     # IP addresses                                                       #

--- a/src/fortianalyzer_mcp/masking/fpe_engine.py
+++ b/src/fortianalyzer_mcp/masking/fpe_engine.py
@@ -123,6 +123,16 @@ _TWEAK_LABELS = {
     "domain": "faz-mcp-fpe:v1:domain",
     "email_local": "faz-mcp-fpe:v1:email-local",
     "url_tail": "faz-mcp-fpe:v1:url-tail",
+    # Serials are uppercase alphanumerics, sometimes hyphenated, which the
+    # lowercase string alphabet cannot round-trip: masking one as a hostname
+    # returns it lowercased, so it is not the serial any more. They take the
+    # url-tail construction (base32 shield + string cipher) under their own
+    # label, so serial and URL ciphertext domains stay separate.
+    #
+    # Byte-identical to the label that shipped on fortimanager-mcp
+    # (feat/fpe-masking at 06c968b), because the token format is shared and
+    # a token minted by one server is resolved by the other. Settled on #40.
+    "serial": "faz-mcp-fpe:v1:serial",
 }
 
 
@@ -299,19 +309,24 @@ class FPEEngine:
         and ``Admin`` and ``admin`` can be different principals. Folding case
         there would let two distinct principals' tokens authenticate each
         other's payloads.
+
+        ``ipv6`` had a branch here that canonicalised through
+        ``ipaddress.IPv6Address``, because two spellings of one address both
+        decrypted and so both had to tag alike. #40 settled that v2 payloads
+        carry no colons: an IPv6 payload is plain hex inside the envelope,
+        which has exactly one spelling up to case. The branch is gone rather
+        than kept as insurance, because it would silently start canonicalising
+        again the moment a colon-bearing payload appeared, which is the thing
+        the format now forbids.
+
+        ``serial`` needs no exception either. Its ciphertext is base32 run
+        through the lowercase string cipher, so it is lowercase by
+        construction and folding matches what decryption tolerates. The
+        serial's own case survives inside the base32 shield, below this
+        layer.
         """
         if vtype == "username":
             return ct
-        if vtype == "ipv6":
-            # ``abcd::1`` and its fully expanded form are one address, and
-            # decryption accepts either, so the tag has to as well. An
-            # unparseable payload is left exactly as written rather than
-            # coerced: collapsing two different unparseable strings to one
-            # canonical form would let them authenticate each other.
-            try:
-                return str(ipaddress.IPv6Address(ct.strip()))
-            except ValueError:
-                return ct.lower()
         return ct.lower()
 
     def v2_tag_ok(self, vtype: str, ct: str, tag: str) -> bool:
@@ -497,6 +512,35 @@ class FPEEngine:
         encoded = base64.b32encode(value.encode()).decode("ascii").lower().rstrip("=")
         return f"url-{self._key_id}-{self._encrypt_str('url_tail', encoded)}"
 
+    def mask_serial(self, value: str) -> str:
+        """Mask a device serial into an ``sn-<kid>-<ct>`` token.
+
+        Same construction as :meth:`mask_url_tail`, under the ``serial``
+        label: base32-shield the raw bytes, then run the string cipher.
+        Case survives exactly, which a hostname token cannot manage.
+        Measured before this existed: ``FGT60FTK20000001`` masked as a
+        hostname came back ``fgt60ftk20000001``.
+
+        Named ``seal_serial`` on fortimanager-mcp, which follows a different
+        method convention; the token both produce is the same.
+
+        Residual, inherited from the construction: the token length reveals
+        the serial's length.
+        """
+        if not value.strip():
+            raise MaskingError("cannot mask an empty serial")
+        encoded = base64.b32encode(value.strip().encode()).decode("ascii").lower().rstrip("=")
+        return f"sn-{self._key_id}-{self._encrypt_str('serial', encoded)}"
+
+    def unmask_serial(self, token: str) -> str:
+        """Reverse :meth:`mask_serial`, returning the exact original serial."""
+        payload = self._strip_prefix(token, "sn-")
+        encoded = self._decrypt_str("serial", self._split_key_id(payload, token))
+        try:
+            return base64.b32decode(encoded.upper() + "=" * (-len(encoded) % 8)).decode("utf-8")
+        except (ValueError, UnicodeDecodeError) as exc:
+            raise MaskingError(f"cannot unmask serial token: {exc}") from exc
+
     def unmask_url_tail(self, token: str) -> str:
         """Reverse :meth:`mask_url_tail`, returning the exact original tail."""
         payload = self._strip_prefix(token, "url-")
@@ -546,6 +590,8 @@ class FPEEngine:
             return self.unmask_username(stripped)
         if candidate.startswith("url-"):
             return self.unmask_url_tail(candidate)
+        if candidate.startswith("sn-"):
+            return self.unmask_serial(candidate)
         return None
 
     # ------------------------------------------------------------------ #

--- a/src/fortianalyzer_mcp/masking/fpe_engine.py
+++ b/src/fortianalyzer_mcp/masking/fpe_engine.py
@@ -263,7 +263,12 @@ class FPEEngine:
     with their casing preserved.
     """
 
-    def __init__(self, key: str, mask_suffix: str = DEFAULT_MASK_SUFFIX) -> None:
+    def __init__(
+        self,
+        key: str,
+        mask_suffix: str = DEFAULT_MASK_SUFFIX,
+        accept_v1_tokens: bool = True,
+    ) -> None:
         """Initialize the engine.
 
         Args:
@@ -277,6 +282,12 @@ class FPEEngine:
             # Deliberately does not echo the offending value: the key is a secret.
             raise MaskingError("masking key must be 32, 48 or 64 hex characters (AES-128/192/256)")
         self._mask_suffix = mask_suffix.lower().lstrip(".")
+        # The v1 deprecation window. Open by default for one release:
+        # tokens already sitting in a live conversation have to keep
+        # resolving, or closing the window silently breaks every session
+        # that was mid-flight when the server restarted.
+        self._accept_v1_tokens = accept_v1_tokens
+        self._seen_v1_token = False
         # One-way key fingerprint carried in marked tokens so a token minted
         # under a different key fails loudly instead of decrypting to a
         # plausible wrong value. Key hex is case-normalized first: it is the
@@ -873,6 +884,95 @@ class FPEEngine:
             raise MaskingError(f"token does not carry the {suffix!r} marker: {token!r}")
         return candidate[: -len(suffix)]
 
+    #: v1 minting method per enveloped type whose token is prefix-marked.
+    _V1_MINTERS = {
+        "hostname": "mask_hostname",
+        "username": "mask_username",
+        "url_tail": "mask_url_tail",
+        "serial": "mask_serial",
+    }
+
+    @staticmethod
+    def _v1_payload(token: str) -> str:
+        """Bare ciphertext out of a ``<marker>-<kid>-<ct>`` token.
+
+        Split from the LEFT, because a ciphertext legitimately contains
+        hyphens: the string alphabet has one, and a serial payload reliably
+        does. Splitting from the right truncates those silently.
+        """
+        return token.split("-", 2)[2]
+
+    def mint(self, vtype: str, value: str) -> str:
+        """Mask ``value`` and return it in the format this server emits.
+
+        One mint point, on purpose. Every ``mask_*`` primitive formats its
+        own v1 token inline, so switching the emitted format at each of
+        them would be one decision copied seven times, and this codebase
+        has already paid for that pattern twice. It also has to stay that
+        way: the v1 primitives are pinned by golden vectors shared with
+        fortimanager-mcp, so their output cannot change.
+
+        ``domain`` and ``email_local`` come back v1 by an explicit branch
+        rather than by falling off the end. They are suffix-marked, so
+        their v2 spelling would be a different parse rather than a
+        different envelope, and #40 deliberately left them for later. A
+        test pins their absence; this branch is what keeps that a decision
+        instead of an oversight.
+
+        Raises:
+            MaskingError: If the value cannot be masked, unchanged from the
+                primitive it delegates to.
+        """
+        if vtype in ("ipv4", "ipv6"):
+            # A masked IP is a valid IP, so the primitive's output IS the
+            # bare ciphertext. This is also the type whose v2 payload stays
+            # dotted, which is why the free-text scan needs its guard.
+            return self.v2_token(vtype, self.mask_ip(value))
+        if vtype == "mac":
+            return self.v2_token(vtype, self.mask_mac(value))
+        minter = self._V1_MINTERS.get(vtype)
+        if minter is not None:
+            return self.v2_token(vtype, self._v1_payload(getattr(self, minter)(value)))
+        if vtype == "domain":
+            return self.mask_domain(value)
+        if vtype == "email_local":
+            return self.mask_email(value)
+        raise MaskingError(f"no minting route for value type: {vtype!r}")
+
+    def _refuse_v1_if_window_closed(self, form: str) -> None:
+        """Enforce the v1 deprecation window, or record that v1 is still in use.
+
+        Placed on the two key-id splits rather than on ``unmask_token``'s
+        dispatch, because the dispatch is bypassable: ``ArgUnmasker``
+        resolves a URL tail by calling ``unmask_url_tail`` directly. Every
+        marked v1 token has to pass through one of the splits, so this is
+        the choke point that cannot be routed around.
+
+        The unmarked IP and MAC forms deliberately do not reach here. They
+        carry no key id and are not v1 *tokens*, they are masked values
+        resolved by field context, so there is nothing to refuse.
+
+        While the window is open this logs, because the point of the flag
+        is that a deployment can tell when closing it is safe. The form and
+        the key id are enough for that, and the payload is never logged,
+        which is this module's standing rule.
+        """
+        if self._accept_v1_tokens:
+            if not self._seen_v1_token:
+                self._seen_v1_token = True
+                logger.info(
+                    "v1 masking token accepted (form=%s, key id=%s); the v1 deprecation "
+                    "window is open. Close it once no client returns v1 tokens.",
+                    form,
+                    self._key_id,
+                )
+            else:
+                logger.debug("v1 masking token accepted (form=%s)", form)
+            return
+        raise MaskingError(
+            f"v1 masking token refused: the deprecation window is closed (form={form})"
+        )
+
     def _split_key_id(self, payload: str, token: str) -> str:
         """Split ``<kid>-<ct>``, verify the key id, return the ciphertext."""
         kid, sep, ct = (
@@ -883,6 +983,7 @@ class FPEEngine:
         if not _KEY_ID_RE.match(kid.lower()) or sep != "-" or not ct:
             raise MaskingError(f"token carries no key id: {token!r}")
         self._check_key_id(kid.lower(), token)
+        self._refuse_v1_if_window_closed("prefix")
         return ct
 
     def _split_key_id_suffix(self, payload: str, token: str) -> str:
@@ -895,6 +996,7 @@ class FPEEngine:
         if not _KEY_ID_RE.match(kid) or sep != "." or not ct:
             raise MaskingError(f"token carries no key id: {token!r}")
         self._check_key_id(kid, token)
+        self._refuse_v1_if_window_closed("suffix")
         return ct
 
     def _check_key_id(self, kid: str, token: str) -> None:

--- a/src/fortianalyzer_mcp/masking/fpe_engine.py
+++ b/src/fortianalyzer_mcp/masking/fpe_engine.py
@@ -270,6 +270,18 @@ class MaskingError(Exception):
     """Raised when a value cannot be masked or a token cannot be unmasked."""
 
 
+class VerificationBudgetExhausted(MaskingError):
+    """The per-call tag-verification budget is spent.
+
+    Its own type because the boundary must treat it differently from an
+    ordinary unmask failure. A single token that will not decrypt is
+    passed through so the downstream validator rejects it; doing that with
+    budget exhaustion turns the cap into partial resolution, where the
+    first tokens resolve and the rest ride out as literals with nothing
+    told to the caller. That is the outcome the cap exists to prevent.
+    """
+
+
 def _derive_tweak(label: str, chunk_index: int = 0) -> str:
     """Derive a 56-bit FF3-1 tweak (14 hex chars) from a stable label.
 
@@ -350,7 +362,11 @@ class FPEEngine:
         self._v2_tag_key = hashlib.sha256(f"faz-mcp-fpe:v2:tagkey:{key.lower()}".encode()).digest()
 
     @classmethod
-    def from_env(cls, mask_suffix: str = DEFAULT_MASK_SUFFIX) -> "FPEEngine":
+    def from_env(
+        cls,
+        mask_suffix: str = DEFAULT_MASK_SUFFIX,
+        accept_v1_tokens: bool = True,
+    ) -> "FPEEngine":
         """Build an engine from the ``FAZ_MASKING_KEY`` environment variable.
 
         Raises:
@@ -359,7 +375,7 @@ class FPEEngine:
         key = os.environ.get(MASKING_KEY_ENV, "")
         if not key:
             raise MaskingError(f"{MASKING_KEY_ENV} is not set")
-        return cls(key, mask_suffix=mask_suffix)
+        return cls(key, mask_suffix=mask_suffix, accept_v1_tokens=accept_v1_tokens)
 
     @property
     def mask_suffix(self) -> str:
@@ -577,7 +593,7 @@ class FPEEngine:
             # since it is attacker-influenced text.
             failures = _V2_FAILURE_COUNT.get(0) + 1
             _V2_FAILURE_COUNT.set(failures)
-            if failures >= V2_FAILURE_ALARM:
+            if failures == V2_FAILURE_ALARM:
                 # The alarm, distinct from the per-failure line: a handful of
                 # failures in one call is not a corrupted token being echoed
                 # back, it is someone trying tags.
@@ -611,7 +627,15 @@ class FPEEngine:
                     "v2 verification budget of %d exhausted in one call; refusing the rest",
                     V2_VERIFY_BUDGET,
                 )
-            raise MaskingError("v2 verification budget for this call is exhausted")
+            raise VerificationBudgetExhausted("v2 verification budget for this call is exhausted")
+
+    @staticmethod
+    def _b32_decode(encoded: str, what: str) -> str:
+        """Undo the base32 shield the serial and url-tail forms share."""
+        try:
+            return base64.b32decode(encoded.upper() + "=" * (-len(encoded) % 8)).decode("utf-8")
+        except (ValueError, UnicodeDecodeError) as exc:
+            raise MaskingError(f"cannot unmask {what} token: {exc}") from exc
 
     def _v2_decrypt(self, vtype: str, payload: str) -> str:
         """Decrypt a verified v2 payload through the existing v1 ciphers."""
@@ -630,12 +654,18 @@ class FPEEngine:
         if vtype == "mac":
             return self.unmask_mac(":".join(payload[i : i + 2] for i in range(0, 12, 2)))
         if vtype == "serial":
-            return self.unmask_serial(f"sn-{self._key_id}-{payload}")
+            # Decrypted directly rather than by rebuilding a v1 token and
+            # calling unmask_serial. That round trip sent a v2 payload
+            # through _split_key_id, which is v1 deprecation machinery:
+            # closing the window would have refused the engine's OWN v2
+            # serial and url tokens, and v2 traffic latched the "v1 token
+            # seen" signal so it could never go quiet.
+            return self._b32_decode(self._decrypt_str("serial", payload), "serial")
         if vtype == "hostname":
             return self._decrypt_str("hostname", payload)
         if vtype == "username":
             return self._decrypt_str("username", payload)
-        return self.unmask_url_tail(f"url-{self._key_id}-{payload}")
+        return self._b32_decode(self._decrypt_str("url_tail", payload), "url")
 
     @staticmethod
     def _v2_payload_out(vtype: str, ct: str) -> str:

--- a/src/fortianalyzer_mcp/masking/fpe_engine.py
+++ b/src/fortianalyzer_mcp/masking/fpe_engine.py
@@ -923,6 +923,11 @@ class FPEEngine:
             MaskingError: If the value cannot be masked, unchanged from the
                 primitive it delegates to.
         """
+        if vtype == "ip":
+            # Callers that hold a field type rather than an address family
+            # say "ip" and let the engine pick, because the family decides
+            # the marker and the tag domain and that is format knowledge.
+            vtype = "ipv6" if self._parse_ip(value).version == 6 else "ipv4"
         if vtype in ("ipv4", "ipv6"):
             # A masked IP is a valid IP, so the primitive's output IS the
             # bare ciphertext. This is also the type whose v2 payload stays

--- a/src/fortianalyzer_mcp/masking/fpe_engine.py
+++ b/src/fortianalyzer_mcp/masking/fpe_engine.py
@@ -82,6 +82,7 @@ this module never includes key material in exceptions.
 
 import base64
 import hashlib
+import hmac
 import ipaddress
 import os
 import re
@@ -123,6 +124,26 @@ _TWEAK_LABELS = {
     "email_local": "faz-mcp-fpe:v1:email-local",
     "url_tail": "faz-mcp-fpe:v1:url-tail",
 }
+
+
+#: Width of the v2 envelope's authentication tag, in hex characters.
+#: 8 hex = 32 bits = one in 4.3 billion per blind forgery attempt, and every
+#: attempt costs an attacker one tool call, so forgery is strictly online.
+#: Settled on #40; it is part of the format shared with fortimanager-mcp and
+#: cannot be changed on one side alone.
+V2_TAG_HEX = 8
+
+#: Value types that may appear in a v2 envelope.
+#:
+#: Pinned, and asserted colon-free, because the tag is computed over
+#: ``faz-mcp-fpe:v2:tag:<type>:<ct>`` and that string is only injective while
+#: no type name contains a colon. Ciphertexts DO contain colons today (IPv6,
+#: MAC), so the first colon after the fixed prefix is what delimits the type.
+#: Add a type with a colon in it and two different (type, ciphertext) pairs
+#: could authenticate each other's tokens.
+V2_TYPES = frozenset(
+    {"ipv4", "ipv6", "mac", "serial", "hostname", "username", "domain", "email_local", "url_tail"}
+)
 
 
 class MaskingError(Exception):
@@ -191,6 +212,11 @@ class FPEEngine:
             for vtype in self._str_ciphers
         }
         self._tweak_labels = dict(_TWEAK_LABELS)
+        # Separate subkey for the v2 authentication tag, derived from the same
+        # secret rather than reusing the AES key as an HMAC key. Two
+        # primitives, two keys, and the raw key is not retained on the
+        # instance. The derivation string is part of the shared format.
+        self._v2_tag_key = hashlib.sha256(f"faz-mcp-fpe:v2:tagkey:{key.lower()}".encode()).digest()
 
     @classmethod
     def from_env(cls, mask_suffix: str = DEFAULT_MASK_SUFFIX) -> "FPEEngine":
@@ -213,6 +239,36 @@ class FPEEngine:
     def key_id(self) -> str:
         """4-hex-char one-way fingerprint of the key, embedded in marked tokens."""
         return self._key_id
+
+    # ------------------------------------------------------------------ #
+    # v2 envelope authentication tag (#40)                                #
+    # ------------------------------------------------------------------ #
+
+    def v2_tag(self, vtype: str, ct: str) -> str:
+        """Authentication tag for a v2 envelope payload.
+
+        Keyed and domain-separated per type, so a token cannot be lifted from
+        one value type to another and still verify. Truncated to
+        :data:`V2_TAG_HEX`.
+
+        Raises:
+            MaskingError: If ``vtype`` is not a pinned v2 type. A type
+                carrying a colon would break the injectivity the tag input
+                relies on, so this is enforced rather than documented.
+        """
+        if vtype not in V2_TYPES:
+            raise MaskingError(f"unknown v2 value type: {vtype!r}")
+        message = f"faz-mcp-fpe:v2:tag:{vtype}:{ct}".encode()
+        return hmac.new(self._v2_tag_key, message, hashlib.sha256).hexdigest()[:V2_TAG_HEX]
+
+    def v2_tag_ok(self, vtype: str, ct: str, tag: str) -> bool:
+        """Is ``tag`` the authentic tag for this payload?
+
+        Constant-time comparison: a timing signal on the tag check would let
+        an attacker recover a valid tag byte by byte and reduce forgery from
+        2**32 attempts to a few hundred.
+        """
+        return hmac.compare_digest(tag, self.v2_tag(vtype, ct))
 
     # ------------------------------------------------------------------ #
     # IP addresses                                                       #

--- a/src/fortianalyzer_mcp/masking/fpe_engine.py
+++ b/src/fortianalyzer_mcp/masking/fpe_engine.py
@@ -757,6 +757,23 @@ class FPEEngine:
         # model title-casing a token in prose. The username payload must be
         # kept verbatim (mixed-case alphabet).
         stripped = token.strip()
+        if self.is_v2_shaped(stripped):
+            # The gate, and it has to be FIRST. A v2 hostname token also
+            # starts with "host-", so asking the shape question after the
+            # prefix dispatch below would never reach it, and the v1 path
+            # would decrypt a forged token to plausible garbage: the tag is
+            # hex and a hyphen, both inside the v1 alphabet, so a flipped
+            # tag leaves a byte-valid v1 token. Ordering IS the gate.
+            #
+            # Committed means committed. A v2-shaped token is never retried
+            # on the v1 path, whatever v2 says about it, because a fallback
+            # hands the forger exactly the decrypt this refuses. v2_open
+            # raises, and the caller must let that propagate.
+            #
+            # This is also the first route by which the IP and MAC forms
+            # resolve at all: their v1 tokens carry no marker, so the
+            # dispatch below never covered them and field context had to.
+            return self.v2_open(stripped)
         candidate = stripped.lower()
         # Suffix first: it is the strongest marker. A domain-token payload
         # may itself start with "host-"/"user-" by chance, but a prefix

--- a/src/fortianalyzer_mcp/masking/fpe_engine.py
+++ b/src/fortianalyzer_mcp/masking/fpe_engine.py
@@ -133,7 +133,8 @@ _TWEAK_LABELS = {
 #: cannot be changed on one side alone.
 V2_TAG_HEX = 8
 
-#: A well-formed tag: exactly V2_TAG_HEX lowercase hex characters.
+#: A well-formed tag: exactly V2_TAG_HEX hex characters, checked after
+#: case folding.
 #: Checked before comparison because ``hmac.compare_digest`` raises on a
 #: non-ASCII string instead of returning False, and the tag reaches us
 #: from inside a token a model hands back.
@@ -264,20 +265,41 @@ class FPEEngine:
         """
         if vtype not in V2_TYPES:
             raise MaskingError(f"unknown v2 value type: {vtype!r}")
-        message = f"faz-mcp-fpe:v2:tag:{vtype}:{ct}".encode()
+        message = f"faz-mcp-fpe:v2:tag:{vtype}:{self._v2_canonical_ct(vtype, ct)}".encode()
         return hmac.new(self._v2_tag_key, message, hashlib.sha256).hexdigest()[:V2_TAG_HEX]
+
+    @staticmethod
+    def _v2_canonical_ct(vtype: str, ct: str) -> str:
+        """Canonical spelling of a payload, for tag purposes.
+
+        The tag has to tolerate exactly what decryption tolerates, no more
+        and no less. Every type but ``username`` is case-insensitive here and
+        its payload is lowercased before decryption, so an upper- or
+        title-cased token still round-trips; tagging the verbatim spelling
+        would make a re-cased token fail verification, stop being recognised
+        as ours, and be handed to the appliance as a literal.
+
+        ``username`` is excluded because its cipher alphabet is mixed-case
+        and ``Admin`` and ``admin`` can be different principals. Folding case
+        there would let two distinct principals' tokens authenticate each
+        other's payloads.
+        """
+        return ct if vtype == "username" else ct.lower()
 
     def v2_tag_ok(self, vtype: str, ct: str, tag: str) -> bool:
         """Is ``tag`` the authentic tag for this payload?
 
         Total over the tag, which arrives inside a token a model hands back
         and is therefore untrusted: anything that is not exactly
-        :data:`V2_TAG_HEX` lowercase hex characters is False, never an
-        exception. ``compare_digest`` raises TypeError on a non-ASCII string
-        rather than returning False, so the shape check has to come first.
-        Rejecting uppercase here is deliberate too: tags are minted
-        lowercase, and treating a re-cased tag as valid would widen what
-        counts as authentic for no benefit.
+        :data:`V2_TAG_HEX` hex characters is False, never an exception.
+        ``compare_digest`` raises TypeError on a non-ASCII string rather
+        than returning False, so the shape check has to come first.
+
+        The tag is case-folded before comparison, and the payload is folded
+        by :meth:`_v2_canonical_ct`, so a re-cased token verifies exactly
+        where a re-cased token still decrypts. Being stricter than the
+        decrypt path would not be safer: it would turn a token we minted
+        into one we no longer recognise, and hand it onward as a literal.
 
         ``vtype`` is NOT untrusted, and an unknown one still raises. It comes
         from this repo's own field table, so it is a bug here rather than
@@ -289,9 +311,10 @@ class FPEEngine:
         leak nothing, since both are fixed and public.
         """
         expected = self.v2_tag(vtype, ct)
-        if len(tag) != V2_TAG_HEX or not _V2_TAG_RE.match(tag):
+        candidate = tag.strip().lower()
+        if not _V2_TAG_RE.match(candidate):
             return False
-        return hmac.compare_digest(tag, expected)
+        return hmac.compare_digest(candidate, expected)
 
     # ------------------------------------------------------------------ #
     # IP addresses                                                       #

--- a/src/fortianalyzer_mcp/masking/fpe_engine.py
+++ b/src/fortianalyzer_mcp/masking/fpe_engine.py
@@ -172,16 +172,19 @@ _V2_TAG_RE = re.compile(rf"^[0-9a-f]{{{V2_TAG_HEX}}}$")
 #:
 #: Pinned, and asserted colon-free, because the tag is computed over
 #: ``faz-mcp-fpe:v2:tag:<type>:<ct>`` and that string is only injective while
-#: no type name contains a colon. Ciphertexts DO contain colons today (IPv6,
-#: MAC), so the first colon after the fixed prefix is what delimits the type.
-#: Add a type with a colon in it and two different (type, ciphertext) pairs
-#: could authenticate each other's tokens.
-#: ``serial`` has no entry in ``_TWEAK_LABELS`` yet, on purpose: it is a
-#: forward declaration of the type the envelope work adds, and nothing can
-#: mint a serial ciphertext today (serials currently ride HOSTNAME). It is
-#: named here so the shared vocabulary is pinned once rather than changed
-#: twice. Whether a ``serialno`` field ends up emitting ``serial`` or
-#: ``hostname`` is still open on #40.
+#: no type name contains a colon. Add a type with a colon in it and two
+#: different (type, ciphertext) pairs could authenticate each other's tokens.
+#:
+#: A v2 payload no longer contains a colon either, since #40 settled on hex
+#: for IPv6 and MAC, so the type is not the only thing keeping the input
+#: unambiguous any more. The assertion stays regardless: it costs nothing and
+#: it is the property the construction actually depends on.
+#:
+#: ``serial`` is a full type now, with a tweak label and a cipher, and the
+#: serial-carrying fields route to it. This comment previously described it
+#: as a forward declaration with no cipher behind it, and described payloads
+#: as colon-bearing; both were true when the tag primitive landed and neither
+#: survived the same branch.
 #: Envelope marker per value type. ``ip4``/``ip6``/``mac``/``sn`` are the
 #: spellings that already shipped in fortimanager-mcp's reserved vocabulary
 #: (``masking/tokens.py``, ``PREFIX_MARKERS``), and ``host``/``user``/``url``
@@ -499,7 +502,15 @@ class FPEEngine:
         if vtype == "ipv4":
             return self.unmask_ip(payload)
         if vtype == "ipv6":
-            return self.unmask_ip(str(ipaddress.IPv6Address(int(payload, 16))))
+            # Only reachable behind a valid tag, so a non-hex payload here
+            # means our own minting is broken rather than that someone forged
+            # something. Still converted, because v2_open is documented total
+            # over untrusted text and a bare ValueError out of it would make
+            # that false the moment the assumption stops holding.
+            try:
+                return self.unmask_ip(str(ipaddress.IPv6Address(int(payload, 16))))
+            except ValueError as exc:
+                raise MaskingError("not a valid IPv6 payload") from exc
         if vtype == "mac":
             return self.unmask_mac(":".join(payload[i : i + 2] for i in range(0, 12, 2)))
         if vtype == "serial":
@@ -523,7 +534,20 @@ class FPEEngine:
         v2 gave up looking like an address the moment it grew a marker.
         """
         if vtype == "ipv6":
-            return format(int(ipaddress.IPv6Address(ct.strip())), "032x")
+            try:
+                address = ipaddress.IPv6Address(ct.strip())
+            except ValueError as exc:
+                # Mint side, so this is our own ciphertext and a bug here
+                # rather than hostile input. It still leaves as a MaskingError,
+                # because every caller of the mint path handles that and none
+                # handles AddressValueError, and the raw ct is not echoed.
+                raise MaskingError("not a valid IPv6 ciphertext") from exc
+            # The width is load-bearing and part of the shared format: 32 hex
+            # digits, zero-padded. One in sixteen ciphertexts has a leading
+            # zero nibble, and a port that drops the padding round-trips
+            # against itself perfectly while its tokens fail verification on
+            # the other server and are logged as forgeries.
+            return format(int(address), "032x")
         if vtype == "mac":
             return ct.replace(":", "").replace("-", "").lower()
         return ct

--- a/src/fortianalyzer_mcp/masking/fpe_engine.py
+++ b/src/fortianalyzer_mcp/masking/fpe_engine.py
@@ -506,6 +506,48 @@ class FPEEngine:
         """
         return _V2_SHAPE_RE.match(token.strip()) is not None
 
+    def is_own_v2_token(self, value: str) -> bool:
+        """Did THIS engine mint this token?
+
+        The one predicate the output side may use, and the reason it
+        exists: shape is not ownership. ``is_v2_shaped`` asks whether
+        something LOOKS like a v2 envelope, which is the right question
+        inbound, where a shaped token must be committed to v2 rather than
+        retried on v1. Outbound it is the wrong question, because a real
+        value can be shaped like a token:
+
+            {"hostname": "host-ab12-web-01-cafe0123"}
+
+        is a perfectly ordinary hostname and a perfectly good v2 shape,
+        and a shape-only skip hands it back in clear. The key id is not
+        enough either: the shape regex accepts any four hex characters, so
+        the exposed surface is every kid rather than ours.
+
+        The tag is what separates the two, and it costs one keyed hash. It
+        deliberately does NOT charge the verification budget: that budget
+        exists to bound an attacker grinding tags on the INBOUND path, and
+        spending it on our own output would let a large response starve
+        the calls that follow it.
+
+        Total: never raises. A malformed or foreign token is simply not
+        ours, which is the answer the caller needs.
+        """
+        match = _V2_SHAPE_RE.match(value.strip())
+        if match is None:
+            return False
+        marker = match.group("marker").lower()
+        if match.group("kid").lower() != self._key_id:
+            return False
+        try:
+            vtype = next(t for t, m in V2_MARKERS.items() if m == marker)
+        except StopIteration:  # pragma: no cover - markers are a closed set
+            return False
+        payload = match.group("ct") if vtype == "username" else match.group("ct").lower()
+        try:
+            return self.v2_tag_ok(vtype, payload, match.group("tag"))
+        except Exception:
+            return False
+
     def v2_open(self, token: str) -> str:
         """Verify and decrypt a v2 envelope, returning the real value.
 

--- a/src/fortianalyzer_mcp/masking/fpe_engine.py
+++ b/src/fortianalyzer_mcp/masking/fpe_engine.py
@@ -81,6 +81,7 @@ this module never includes key material in exceptions.
 """
 
 import base64
+import contextvars
 import hashlib
 import hmac
 import ipaddress
@@ -118,6 +119,33 @@ MASKING_KEY_ENV = "FAZ_MASKING_KEY"
 #: Default marker suffix for domain/email tokens. ``.invalid`` is reserved
 #: by RFC 2606 and can never resolve.
 DEFAULT_MASK_SUFFIX = "masked.invalid"
+
+#: Tag verifications allowed within one tool call, and failures tolerated
+#: before the alarm.
+#:
+#: The 32-bit tag is one in 4.3 billion per blind guess, which sounds like
+#: plenty until you count the right unit. The bound is per VERIFICATION,
+#: not per call, and one call can carry thousands of tokens (measured:
+#: 5000 in a single ``filters`` list, each resolved independently). At that
+#: density 2**31 expected verifications is on the order of 10**5 calls
+#: rather than 10**9, so an online grind is a day's work rather than a
+#: geological era. Capping the per-call count is what puts the exponent
+#: back, and it is cheap because no legitimate call comes near the cap.
+#:
+#: Committed to publicly on #40 alongside the tag width, so the width is
+#: only defensible while this exists.
+V2_VERIFY_BUDGET = 2048
+V2_FAILURE_ALARM = 8
+
+_V2_VERIFY_COUNT: contextvars.ContextVar[int] = contextvars.ContextVar("faz_v2_verify_count")
+_V2_FAILURE_COUNT: contextvars.ContextVar[int] = contextvars.ContextVar("faz_v2_failure_count")
+
+
+def begin_v2_verification_budget() -> None:
+    """Reset the per-call verification budget. Called at the tool boundary."""
+    _V2_VERIFY_COUNT.set(0)
+    _V2_FAILURE_COUNT.set(0)
+
 
 # Tweak labels, one per value type. These are part of the token contract:
 # changing a label (or the derivation) invalidates all previously emitted
@@ -499,14 +527,49 @@ class FPEEngine:
         # lowercase by construction and folding tolerates a re-cased token.
         payload = match.group("ct") if vtype == "username" else match.group("ct").lower()
         self._check_key_id(match.group("kid").lower(), token)
+        self._spend_verification()
         if not self.v2_tag_ok(vtype, payload, match.group("tag")):
             # Deliberately loud: this is the only signal that distinguishes a
             # forgery grind from ordinary traffic, and the 32-bit tag is only
             # safe if repeated failures are visible. The token is not logged,
             # since it is attacker-influenced text.
-            logger.warning("v2 token failed tag verification (type=%s); refused", vtype)
+            failures = _V2_FAILURE_COUNT.get(0) + 1
+            _V2_FAILURE_COUNT.set(failures)
+            if failures >= V2_FAILURE_ALARM:
+                # The alarm, distinct from the per-failure line: a handful of
+                # failures in one call is not a corrupted token being echoed
+                # back, it is someone trying tags.
+                logger.error(
+                    "v2 tag verification failed %d times in one call; possible forgery attempt",
+                    failures,
+                )
+            else:
+                # Deliberately loud: this is the only signal that distinguishes a
+                # forgery grind from ordinary traffic, and the 32-bit tag is only
+                # safe if repeated failures are visible. The token is not logged,
+                # since it is attacker-influenced text.
+                logger.warning("v2 token failed tag verification (type=%s); refused", vtype)
             raise MaskingError("tag mismatch: forged or corrupted token")
         return self._v2_decrypt(vtype, payload)
+
+    @staticmethod
+    def _spend_verification() -> None:
+        """Charge one tag verification against this call's budget.
+
+        Counted BEFORE the tag is checked, so a grind pays for its
+        attempts rather than only for its successes. Refusal is a
+        MaskingError like any other, so a caller that hits the cap fails
+        closed on the remaining tokens instead of resolving them.
+        """
+        spent = _V2_VERIFY_COUNT.get(0) + 1
+        _V2_VERIFY_COUNT.set(spent)
+        if spent > V2_VERIFY_BUDGET:
+            if spent == V2_VERIFY_BUDGET + 1:
+                logger.error(
+                    "v2 verification budget of %d exhausted in one call; refusing the rest",
+                    V2_VERIFY_BUDGET,
+                )
+            raise MaskingError("v2 verification budget for this call is exhausted")
 
     def _v2_decrypt(self, vtype: str, payload: str) -> str:
         """Decrypt a verified v2 payload through the existing v1 ciphers."""

--- a/src/fortianalyzer_mcp/masking/fpe_engine.py
+++ b/src/fortianalyzer_mcp/masking/fpe_engine.py
@@ -84,10 +84,18 @@ import base64
 import hashlib
 import hmac
 import ipaddress
+import logging
 import os
 import re
 
 from ff3 import FF3Cipher
+
+# The only logging this module does is the v2 tag-verification failure. It
+# is the one signal that separates a forgery grind from ordinary traffic,
+# and the 32-bit tag size is only defensible while repeated failures are
+# visible (#40). Nothing else here logs, and no value, token or key
+# material is ever passed to it.
+logger = logging.getLogger(__name__)
 
 # Alphabet for string-typed values (hostnames, domains, email parts).
 # 40 chars -> FF3-1 bounds are minLen 4 / maxLen 36. ``~`` is the pad
@@ -174,6 +182,54 @@ _V2_TAG_RE = re.compile(rf"^[0-9a-f]{{{V2_TAG_HEX}}}$")
 #: named here so the shared vocabulary is pinned once rather than changed
 #: twice. Whether a ``serialno`` field ends up emitting ``serial`` or
 #: ``hostname`` is still open on #40.
+#: Envelope marker per value type. ``ip4``/``ip6``/``mac``/``sn`` are the
+#: spellings that already shipped in fortimanager-mcp's reserved vocabulary
+#: (``masking/tokens.py``, ``PREFIX_MARKERS``), and ``host``/``user``/``url``
+#: are this server's existing v1 prefixes, reused so a v1 and a v2 token of
+#: the same type share a marker and the shape gate below is what separates
+#: them.
+#:
+#: Suffix-marked types (``domain``, ``email_local``) are deliberately absent.
+#: Their v2 spelling puts the tag inside a dotted label rather than after a
+#: hyphen, which is a different parse, and they already carry a marker and a
+#: key id today, so they are not what the marked-IP work is blocked on.
+V2_MARKERS: dict[str, str] = {
+    "ipv4": "ip4",
+    "ipv6": "ip6",
+    "mac": "mac",
+    "serial": "sn",
+    "hostname": "host",
+    "username": "user",
+    "url_tail": "url",
+}
+
+#: Structural shape of a v2 envelope: ``<marker>-<kid>-<ct>-<tag>``.
+#:
+#: A ciphertext legitimately contains hyphens (the string alphabet has one),
+#: so the payload/tag boundary has to be unambiguous. What makes it so is the
+#: ``$`` anchor plus the fixed width of the tag group, NOT the greediness of
+#: the payload: the tag is the last 8 characters or the match fails, and the
+#: payload is whatever lies between the key id and that.
+#:
+#: Measured, because the obvious reading is that greediness carries it:
+#: making the payload lazy changes nothing on any input, including a
+#: ciphertext that itself ends in a hyphen and 8 hex. That mutant survives
+#: the whole suite and is meant to -- it is equivalent, not uncovered.
+#:
+#: Matching is case-insensitive because a model may re-case a token in prose,
+#: but only the marker, key id and tag are folded afterwards: the username
+#: payload is case-sensitive and is kept exactly as written.
+#: IGNORECASE covers the marker and the hex groups. It does NOT weaken the
+#: username payload: the flag changes what matches, not what is captured, and
+#: ``.+`` matches any character either way, so ``ct`` comes back exactly as
+#: written. Without the flag an upper-cased ``IP4-`` failed the shape match
+#: entirely, which sent a re-cased token to the appliance as a literal.
+_V2_SHAPE_RE = re.compile(
+    r"^(?P<marker>ip4|ip6|mac|sn|url|host|user)-(?P<kid>[0-9a-f]{4})-"
+    r"(?P<ct>.+)-(?P<tag>[0-9a-f]{8})$",
+    re.IGNORECASE,
+)
+
 V2_TYPES = frozenset(
     {"ipv4", "ipv6", "mac", "serial", "hostname", "username", "domain", "email_local", "url_tail"}
 )
@@ -370,6 +426,107 @@ class FPEEngine:
         if not _V2_TAG_RE.match(candidate):
             return False
         return hmac.compare_digest(candidate, expected)
+
+    # ------------------------------------------------------------------ #
+    # v2 envelope: mint, shape, open (#40)                                #
+    # ------------------------------------------------------------------ #
+
+    def v2_token(self, vtype: str, ct: str) -> str:
+        """Wrap a ciphertext in a v2 envelope: ``<marker>-<kid>-<ct>-<tag>``.
+
+        ``ct`` is the v1 ciphertext for ``vtype``, unchanged: the cipher,
+        chunking and alphabets are untouched by v2, which only adds the
+        envelope around them.
+        """
+        try:
+            marker = V2_MARKERS[vtype]
+        except KeyError:
+            raise MaskingError(f"no v2 envelope for value type: {vtype!r}") from None
+        payload = self._v2_payload_out(vtype, ct)
+        return f"{marker}-{self._key_id}-{payload}-{self.v2_tag(vtype, payload)}"
+
+    @staticmethod
+    def is_v2_shaped(token: str) -> bool:
+        """Does this text have the full shape of a v2 envelope?
+
+        The shape gate settled on #40 rests on this predicate: a token that
+        LOOKS like v2 is committed to v2 and never falls back to the v1
+        path, whatever happens next. Without that, a v2 token with a flipped
+        tag is still a byte-valid v1 token (the tag's hex and hyphen are both
+        inside the v1 alphabet), so the v1 path would decrypt it to plausible
+        garbage and forgery refusal would not hold for any of the prefix
+        types until the deprecation window closed.
+
+        The measured cost is a false refusal for a v1 token whose ciphertext
+        happens to end in a hyphen plus 8 lowercase hex: 1.6e-5 per token,
+        (1/40) * (16/40)**8 over the 40-character alphabet. It fails closed
+        and loudly, which is the trade Roland took.
+        """
+        return _V2_SHAPE_RE.match(token.strip()) is not None
+
+    def v2_open(self, token: str) -> str:
+        """Verify and decrypt a v2 envelope, returning the real value.
+
+        Total over untrusted text: this is handed token-shaped strings a
+        model supplied.
+
+        Raises:
+            MaskingError: If the shape, key id, tag or payload is wrong. The
+                caller must NOT retry such a token on the v1 path -- see
+                :meth:`is_v2_shaped`. Refusal is the point; a refused token
+                is recoverable in a way a silent wrong decrypt is not.
+        """
+        match = _V2_SHAPE_RE.match(token.strip())
+        if match is None:
+            raise MaskingError("not a v2 token")
+        marker = match.group("marker").lower()
+        vtype = next(t for t, m in V2_MARKERS.items() if m == marker)
+        # Username ciphertext is case-sensitive; every other payload is
+        # lowercase by construction and folding tolerates a re-cased token.
+        payload = match.group("ct") if vtype == "username" else match.group("ct").lower()
+        self._check_key_id(match.group("kid").lower(), token)
+        if not self.v2_tag_ok(vtype, payload, match.group("tag")):
+            # Deliberately loud: this is the only signal that distinguishes a
+            # forgery grind from ordinary traffic, and the 32-bit tag is only
+            # safe if repeated failures are visible. The token is not logged,
+            # since it is attacker-influenced text.
+            logger.warning("v2 token failed tag verification (type=%s); refused", vtype)
+            raise MaskingError("tag mismatch: forged or corrupted token")
+        return self._v2_decrypt(vtype, payload)
+
+    def _v2_decrypt(self, vtype: str, payload: str) -> str:
+        """Decrypt a verified v2 payload through the existing v1 ciphers."""
+        if vtype == "ipv4":
+            return self.unmask_ip(payload)
+        if vtype == "ipv6":
+            return self.unmask_ip(str(ipaddress.IPv6Address(int(payload, 16))))
+        if vtype == "mac":
+            return self.unmask_mac(":".join(payload[i : i + 2] for i in range(0, 12, 2)))
+        if vtype == "serial":
+            return self.unmask_serial(f"sn-{self._key_id}-{payload}")
+        if vtype == "hostname":
+            return self._decrypt_str("hostname", payload)
+        if vtype == "username":
+            return self._decrypt_str("username", payload)
+        return self.unmask_url_tail(f"url-{self._key_id}-{payload}")
+
+    @staticmethod
+    def _v2_payload_out(vtype: str, ct: str) -> str:
+        """Spell a ciphertext for the envelope. Colon-free, settled on #40.
+
+        IPv6 and MAC ciphertexts are addresses in v1 and become plain hex
+        here. Colons inside a token broke three things at once: ``urlsplit``
+        raises on a v2 IPv6 token used as a URL host (measured on 3.12), so a
+        re-masked echo burned to an irreversible placeholder; the mint sites
+        re-bracket on a colon; and the free-text ``_MAC_RE`` matched the
+        address sitting inside a ``mac-`` envelope. Hex closes all three, and
+        v2 gave up looking like an address the moment it grew a marker.
+        """
+        if vtype == "ipv6":
+            return format(int(ipaddress.IPv6Address(ct.strip())), "032x")
+        if vtype == "mac":
+            return ct.replace(":", "").replace("-", "").lower()
+        return ct
 
     # ------------------------------------------------------------------ #
     # IP addresses                                                       #

--- a/src/fortianalyzer_mcp/masking/unmask.py
+++ b/src/fortianalyzer_mcp/masking/unmask.py
@@ -198,7 +198,14 @@ class ArgUnmasker:
         # over a case-insensitive alphabet, so this one must too.
         if tail[:5].lower() == "/url-":
             try:
-                resolved_tail = self._engine.unmask_url_tail(tail[1:])
+                # Through the dispatch rather than the v1 primitive, so this
+                # path gets the v2 shape gate and the deprecation window
+                # instead of routing around both. A v2 url token also starts
+                # "url-", so the prefix test above still selects it, and
+                # calling the v1 primitive on one would fail to decrypt and
+                # drop the whole URL. None means no marker matched, which
+                # leaves the tail as it was.
+                resolved_tail = self._engine.unmask_token(tail[1:]) or tail
             except MaskingError:
                 # Marker present but the payload will not decrypt: leave the
                 # whole URL alone so the downstream validator rejects it.

--- a/src/fortianalyzer_mcp/masking/unmask.py
+++ b/src/fortianalyzer_mcp/masking/unmask.py
@@ -62,7 +62,11 @@ from fortianalyzer_mcp.masking.fields import (
     MAC,
     SKIP_VALUES,
 )
-from fortianalyzer_mcp.masking.fpe_engine import FPEEngine, MaskingError
+from fortianalyzer_mcp.masking.fpe_engine import (
+    FPEEngine,
+    MaskingError,
+    VerificationBudgetExhausted,
+)
 from fortianalyzer_mcp.query.fields import canonical_log_field
 from fortianalyzer_mcp.utils.validation import sanitize_filter_value
 
@@ -117,6 +121,8 @@ class ArgUnmasker:
                 return self._engine.unmask_ip(value)
             if vtype == MAC:
                 return self._engine.unmask_mac(value)
+        except VerificationBudgetExhausted:
+            raise
         except MaskingError:
             # Very likely a real address the operator typed, not a token.
             return value
@@ -129,6 +135,8 @@ class ArgUnmasker:
         candidate = value.strip()
         try:
             marked = self._unmask_marked(candidate)
+        except VerificationBudgetExhausted:
+            raise
         except MaskingError:
             # Marker present but payload will not decrypt: leave it alone so
             # the downstream validator rejects it instead of us guessing.
@@ -172,6 +180,8 @@ class ArgUnmasker:
             return self.resolve_scalar(value)
         try:
             marked_host = self._unmask_marked(host)
+        except VerificationBudgetExhausted:
+            raise
         except MaskingError:
             # Marker present but the payload will not decrypt: leave the whole
             # URL alone rather than sending FAZ a half-resolved one that can
@@ -206,6 +216,8 @@ class ArgUnmasker:
                 # drop the whole URL. None means no marker matched, which
                 # leaves the tail as it was.
                 resolved_tail = self._engine.unmask_token(tail[1:]) or tail
+            except VerificationBudgetExhausted:
+                raise
             except MaskingError:
                 # Marker present but the payload will not decrypt: leave the
                 # whole URL alone so the downstream validator rejects it.

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -372,6 +372,24 @@ class OutputMasker:
         """
         if value.strip() in SKIP_VALUES:
             return value
+        if self._engine.is_v2_shaped(value):
+            # Already this layer's own output. Masking it again destroys
+            # it, loudly on a typed route that cannot parse a token (an IP
+            # field fails closed to an irreversible placeholder) and
+            # quietly on one that can (a string cipher wraps the token in
+            # another token, which opens to the wrong value). Both are
+            # silent to the caller.
+            #
+            # By SHAPE, matching the gate decision on #40: a value that
+            # looks like v2 is committed to v2. Verifying the tag instead
+            # would be a third definition of v2-ness in this codebase, and
+            # two definitions drifting apart has already produced one leak
+            # in the free-text guard above.
+            #
+            # This funnel is the whole point: every pass-1 route ends here,
+            # so the check cannot be forgotten by a new caller the way the
+            # keep set was twice.
+            return value
         if self._is_kept(vtype, value, keep):
             # A value the deployment chose to leave readable stays readable
             # under every key (#73 item 5). The check lives here rather than

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -134,7 +134,13 @@ _COMPOSITE_DIMENSIONS: frozenset[str] = frozenset(
 #: and not only in the engine: this shape is what the mutating-tool gate
 #: (#108) recognises, so leaving it out would silently stop that gate
 #: covering serial tokens.
-_TOKEN_PREFIX_SHAPE_RE = re.compile(r"^(?:host|user|url|sn)-[0-9a-f]{4}-")
+#: ``ip4``/``ip6``/``mac`` are here for the v2 envelope, which is the first
+#: form those three have ever had: v1 emits them bare, so there was nothing
+#: to recognise. Adding them at the same time as the format, rather than at
+#: the cutover, because the failure is silent in exactly the direction that
+#: matters -- the gate would keep passing while covering none of the three
+#: types the envelope exists to make detectable.
+_TOKEN_PREFIX_SHAPE_RE = re.compile(r"^(?:host|user|url|sn|ip4|ip6|mac)-[0-9a-f]{4}-")
 
 
 #: Keys that prove a dict is a dvmdb device object, so its ``name`` is the

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -154,20 +154,42 @@ _IPV4_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
 #: Free text is attacker-supplied, so that was a remote CPU-exhaustion
 #: primitive rather than a tuning matter. The head is at most ten
 #: characters, so a fixed window is all it can ever need.
-_V2_ENVELOPE_HEAD_RE = re.compile(
-    r"(?<![0-9A-Za-z])(?:ip4|ip6|mac|sn|url|host|user)-[0-9a-f]{4}-\Z", re.IGNORECASE
+#: Candidate extractors, NOT the decision. They bracket the widest thing
+#: around a matched address that could be a v2 envelope; whether it IS one
+#: is then answered by ``FPEEngine.is_own_v2_token``, the same predicate
+#: the structured route uses.
+#:
+#: This shape exists because the previous version made the decision here,
+#: with its own looser notion of an envelope, and that divergence leaked a
+#: real address twice: the left boundary admitted a hyphen, a dot, an
+#: underscore and non-ASCII, so ``my-host-2a85-10.0.0.1-deadbeef`` came
+#: back with the address in clear while ``is_v2_shaped`` rejected the same
+#: string. Three leaks in this cutover came from two definitions of "looks
+#: like v2" drifting apart. There is one definition now, and these
+#: patterns only find the text to hand it.
+_V2_CANDIDATE_HEAD_RE = re.compile(
+    r"(?:ip4|ip6|mac|sn|url|host|user)-[0-9a-f]{4}-\Z", re.IGNORECASE
 )
-_V2_ENVELOPE_TAIL_RE = re.compile(r"-[0-9a-f]{8}(?![0-9a-f])", re.IGNORECASE)
+_V2_CANDIDATE_TAIL_RE = re.compile(r"-[0-9a-f]{8}", re.IGNORECASE)
 
-#: Longest possible head, plus one character for the boundary check to see:
-#: marker (up to 4) + "-" + key id (4) + "-" is ten.
-_V2_HEAD_WINDOW = 11
+#: Longest head: marker (up to 4) + "-" + key id (4) + "-".
+_V2_HEAD_WINDOW = 10
 
 
-def _inside_v2_envelope(text: str, start: int, end: int) -> bool:
-    """Is ``text[start:end]`` the payload of a v2 token?"""
-    head = text[max(0, start - _V2_HEAD_WINDOW) : start]
-    return bool(_V2_ENVELOPE_HEAD_RE.search(head) and _V2_ENVELOPE_TAIL_RE.match(text, end))
+def _v2_envelope_around(engine: Any, text: str, start: int, end: int) -> bool:
+    """Is ``text[start:end]`` the payload of a token THIS engine minted?
+
+    Brackets the candidate and then asks the shared predicate. Boundary
+    subtleties that used to decide the answer now only widen or narrow the
+    candidate, and a wrong guess costs a tag check rather than an address.
+    """
+    head = _V2_CANDIDATE_HEAD_RE.search(text[max(0, start - _V2_HEAD_WINDOW) : start])
+    if head is None:
+        return False
+    tail = _V2_CANDIDATE_TAIL_RE.match(text, end)
+    if tail is None:
+        return False
+    return bool(engine.is_own_v2_token(text[start - len(head.group(0)) : tail.end()]))
 
 
 _MAC_RE = re.compile(r"\b[0-9a-fA-F]{2}(?::[0-9a-fA-F]{2}){5}\b")
@@ -377,7 +399,7 @@ class OutputMasker:
         """
         if value.strip() in SKIP_VALUES:
             return value
-        if self._engine.is_v2_shaped(value):
+        if self._engine.is_own_v2_token(value):
             # Already this layer's own output. Masking it again destroys
             # it, loudly on a typed route that cannot parse a token (an IP
             # field fails closed to an irreversible placeholder) and
@@ -687,7 +709,7 @@ class OutputMasker:
 
         def ip_sub(m: re.Match[str]) -> str:
             candidate = m.group(0)
-            if _inside_v2_envelope(text, m.start(), m.end()):
+            if _v2_envelope_around(self._engine, text, m.start(), m.end()):
                 # Our own output. Re-encrypting the payload would leave the
                 # tag signing a value that is no longer there.
                 return candidate

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -294,31 +294,31 @@ class OutputMasker:
         try:
             ipaddress.ip_address(value.strip())
         except ValueError:
-            return self._engine.mask_hostname(value)
-        return self._engine.mask_ip(value)
+            return self._engine.mint("hostname", value)
+        return self._engine.mint("ip", value)
 
     def _mask_one(self, vtype: str, value: str) -> str:
         try:
             if vtype == IP:
-                return self._engine.mask_ip(value)
+                return self._engine.mint("ip", value)
             if vtype == MAC:
-                return self._engine.mask_mac(value)
+                return self._engine.mint("mac", value)
             if vtype == IP_OR_HOST:
                 return self._mask_ip_or_host(value)
             if vtype == HOSTNAME:
-                return self._engine.mask_hostname(value)
+                return self._engine.mint("hostname", value)
             if vtype == SERIAL:
-                return self._engine.mask_serial(value)
+                return self._engine.mint("serial", value)
             if vtype == USERNAME:
-                return self._engine.mask_username(value)
+                return self._engine.mint("username", value)
             if vtype == DOMAIN:
-                return self._engine.mask_domain(value)
+                return self._engine.mint("domain", value)
             if vtype == EMAIL:
                 # from/to are emails in virus/emailfilter logs but plain
                 # labels elsewhere; only actual addresses mask as email.
                 if "@" in value:
-                    return self._engine.mask_email(value)
-                return self._engine.mask_username(value)
+                    return self._engine.mint("email_local", value)
+                return self._engine.mint("username", value)
         except MaskingError:
             return self.placeholder(value)
         except Exception:
@@ -691,19 +691,19 @@ class OutputMasker:
             except ValueError:
                 return candidate  # e.g. 999.1.1.1 or a dotted version string
             try:
-                return self._engine.mask_ip(candidate)
+                return self._engine.mint("ip", candidate)
             except MaskingError:
                 return self.placeholder(candidate)
 
         def mac_sub(m: re.Match[str]) -> str:
             try:
-                return self._engine.mask_mac(m.group(0))
+                return self._engine.mint("mac", m.group(0))
             except MaskingError:
                 return self.placeholder(m.group(0))
 
         def email_sub(m: re.Match[str]) -> str:
             try:
-                return self._engine.mask_email(m.group(0))
+                return self._engine.mint("email_local", m.group(0))
             except MaskingError:
                 return self.placeholder(m.group(0))
 
@@ -1091,7 +1091,7 @@ class OutputMasker:
             if "@" in decoded_head.partition("/")[0]:
                 return self.placeholder(value)
             try:
-                return self._engine.mask_url_tail(stripped)
+                return self._engine.mint("url_tail", stripped)
             except MaskingError:
                 return self.placeholder(value)
         if self._is_kept(IP_OR_HOST, host, keep):
@@ -1116,7 +1116,7 @@ class OutputMasker:
         if not tail:
             return f"{prefix}{netloc}"
         try:
-            token = self._engine.mask_url_tail(tail)
+            token = self._engine.mint("url_tail", tail)
         except MaskingError:
             return self.placeholder(value)
         return f"{prefix}{netloc}/{token}"

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -85,6 +85,7 @@ from fortianalyzer_mcp.masking.fields import (
     FIELD_TYPES,
     HOSTNAME,
     IP,
+    IP_HOST_OR_SERIAL,
     IP_OR_HOST,
     MAC,
     OBF_URL_KEY,
@@ -324,6 +325,34 @@ class OutputMasker:
             return self._engine.mint("hostname", value)
         return self._engine.mint("ip", value)
 
+    #: FortiGate/FortiAP/FortiSwitch etc. serial shape -- byte-identical to
+    #: fortimanager-mcp's DEVICE_SERIAL_PATTERN, since a serial that reaches
+    #: this codepath from a live estate looks the same regardless of which
+    #: MCP server observed it. Checked before HOSTNAME: real hostnames do
+    #: not start with a 2-letter Fortinet product code followed by 10-20
+    #: uppercase alphanumerics with no dots or hyphens, so the false-positive
+    #: risk of masking a hostname as a serial is effectively nil.
+    _SERIAL_SHAPE_RE = re.compile(r"^(FG|FM|FW|FA|FS|FD|FP|FC|FV|PU|PS)[A-Z0-9]{10,20}$")
+
+    def _mask_ip_host_or_serial(self, value: str) -> str:
+        """Mask a field that holds an address, a name, or a device serial.
+
+        target[].value under name=="device" is polymorphic: measured
+        fixture data shows this slot carries either an endpoint hostname or
+        the device's own serial. A serial minted as a hostname loses its
+        case (SERIAL exists specifically because of this -- see its
+        docstring), which also breaks token correlation with the same
+        device's serial appearing elsewhere in the same record under "sn".
+        """
+        stripped = value.strip()
+        try:
+            ipaddress.ip_address(stripped)
+        except ValueError:
+            if self._SERIAL_SHAPE_RE.match(stripped):
+                return self._engine.mint("serial", value)
+            return self._engine.mint("hostname", value)
+        return self._engine.mint("ip", value)
+
     def _mask_one(self, vtype: str, value: str) -> str:
         try:
             if vtype == IP:
@@ -332,6 +361,8 @@ class OutputMasker:
                 return self._engine.mint("mac", value)
             if vtype == IP_OR_HOST:
                 return self._mask_ip_or_host(value)
+            if vtype == IP_HOST_OR_SERIAL:
+                return self._mask_ip_host_or_serial(value)
             if vtype == HOSTNAME:
                 return self._engine.mint("hostname", value)
             if vtype == SERIAL:

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -1437,7 +1437,7 @@ def install_masking(mcp: Any) -> tuple[OutputMasker, ArgUnmasker]:
     if settings.FAZ_MASKING_KEY and not os.environ.get(MASKING_KEY_ENV):
         os.environ[MASKING_KEY_ENV] = settings.FAZ_MASKING_KEY
 
-    engine = FPEEngine.from_env()
+    engine = FPEEngine.from_env(accept_v1_tokens=settings.FAZ_MASKING_ACCEPT_V1_TOKENS)
     masker = OutputMasker(engine, mask_device_identity=settings.FAZ_MASK_DEVICE_IDENTITY)
     unmasker = ArgUnmasker(engine)
     original_tool = mcp.tool

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -88,6 +88,7 @@ from fortianalyzer_mcp.masking.fields import (
     IP_OR_HOST,
     MAC,
     OBF_URL_KEY,
+    SERIAL,
     SKIP_VALUES,
     TARGET_NAME_TYPES,
     TEXT,
@@ -129,7 +130,11 @@ _COMPOSITE_DIMENSIONS: frozenset[str] = frozenset(
 
 #: Structural shape of a prefix-marked token: ``<marker>-<4-hex-kid>-``.
 #: "host-fw01" has no kid group and is a legitimate name, not a token.
-_TOKEN_PREFIX_SHAPE_RE = re.compile(r"^(?:host|user|url)-[0-9a-f]{4}-")
+#: ``sn`` joined the markers with the serial type (#40). It has to be here
+#: and not only in the engine: this shape is what the mutating-tool gate
+#: (#108) recognises, so leaving it out would silently stop that gate
+#: covering serial tokens.
+_TOKEN_PREFIX_SHAPE_RE = re.compile(r"^(?:host|user|url|sn)-[0-9a-f]{4}-")
 
 
 #: Keys that prove a dict is a dvmdb device object, so its ``name`` is the
@@ -232,6 +237,8 @@ class OutputMasker:
                 return self._mask_ip_or_host(value)
             if vtype == HOSTNAME:
                 return self._engine.mask_hostname(value)
+            if vtype == SERIAL:
+                return self._engine.mask_serial(value)
             if vtype == USERNAME:
                 return self._engine.mask_username(value)
             if vtype == DOMAIN:

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -95,7 +95,12 @@ from fortianalyzer_mcp.masking.fields import (
     THREAT_KEY,
     USERNAME,
 )
-from fortianalyzer_mcp.masking.fpe_engine import MASKING_KEY_ENV, FPEEngine, MaskingError
+from fortianalyzer_mcp.masking.fpe_engine import (
+    MASKING_KEY_ENV,
+    FPEEngine,
+    MaskingError,
+    begin_v2_verification_budget,
+)
 from fortianalyzer_mcp.masking.unmask import ArgUnmasker
 
 logger = logging.getLogger(__name__)
@@ -1508,6 +1513,11 @@ def install_masking(mcp: Any) -> tuple[OutputMasker, ArgUnmasker]:
                 async def async_wrapped(*fa: Any, **fk: Any) -> Any:
                     if _AT_BOUNDARY.get():
                         return await fn(*fa, **fk)
+                    # Per-call budget, so the cap means "this call" rather
+                    # than "this process". Set at the OUTERMOST boundary
+                    # only: an inner tool call shares its caller's budget,
+                    # or nesting would hand out a fresh one per hop.
+                    begin_v2_verification_budget()
                     token = _AT_BOUNDARY.set(True)
                     try:
                         if not read_only:
@@ -1527,6 +1537,7 @@ def install_masking(mcp: Any) -> tuple[OutputMasker, ArgUnmasker]:
             def sync_wrapped(*fa: Any, **fk: Any) -> Any:
                 if _AT_BOUNDARY.get():
                     return fn(*fa, **fk)
+                begin_v2_verification_budget()
                 token = _AT_BOUNDARY.set(True)
                 try:
                     if not read_only:

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -101,6 +101,70 @@ from fortianalyzer_mcp.masking.unmask import ArgUnmasker
 logger = logging.getLogger(__name__)
 
 _IPV4_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+
+#: The two halves of a v2 envelope, matched around an address the IOC scan
+#: found, so the scan can recognise its own output and step over it.
+#:
+#: A v2 IPv4 token carries its ciphertext as a dotted quad, because a masked
+#: IPv4 has to stay a valid IPv4. The free-text scan therefore matches the
+#: payload INSIDE the token and re-encrypts it, which leaves the tag bound to
+#: a payload that is no longer there: the token stops opening at all and the
+#: address is unrecoverable, by us included. IPv6 and MAC payloads went
+#: colon-free hex on #40, so neither the IPv4 nor the MAC scan can see them;
+#: IPv4 is the one exposed type, and that asymmetry is why this guard is
+#: positional rather than a general token pattern.
+#:
+#: Checked around the match rather than by scanning the text for tokens
+#: first: a serial or url ciphertext can itself contain a hyphen, so a
+#: lazily-bounded token pattern can end at the wrong hyphen and leave the
+#: tail unprotected. Position has no such ambiguity.
+#:
+#: Residual, and it is the same trade the shape gate already takes: a real
+#: address that happens to sit between a marker plus key id and a hyphen
+#: plus eight hex digits is left in clear. It has to look exactly like a v2
+#: envelope to get there.
+#:
+#: Three things here are load-bearing, and the first version of this guard
+#: got all three wrong. An adversarial pass measured each one.
+#:
+#: ``(?<![0-9A-Za-z])`` is the left boundary. Without it, any WORD ending in
+#: a marker opens an envelope, because the head is only searched for:
+#: ``myhost-1234-10.0.0.1-deadbeef`` returned with the address in clear, and
+#: so did ``localhost``, ``poweruser``, ``gossip4``, ``tarmac`` and ``unsn``.
+#: That is a leak, and it also put this guard at odds with
+#: :meth:`FPEEngine.is_v2_shaped`, which rejects all of those. Two
+#: definitions of "looks like v2" drifting apart is the bug class this
+#: project keeps hitting, so a test pins them equal on whole strings.
+#:
+#: ``\Z`` rather than ``$``, because ``$`` also matches just before a
+#: trailing newline: ``ip4-2a85-\n10.0.0.1-deadbeef`` leaked while the CRLF
+#: spelling did not, which is that difference exactly. A genuine token can
+#: never contain a newline, so there was nothing to gain from the laxer
+#: anchor.
+#:
+#: Both halves are matched against a BOUNDED window rather than a slice of
+#: the text. ``text[:start]`` and ``text[end:]`` each copy the input on
+#: every IPv4 match, so a quad-dense log line went quadratic: 3.5 seconds
+#: for four thousand addresses, per-match cost doubling on every doubling.
+#: Free text is attacker-supplied, so that was a remote CPU-exhaustion
+#: primitive rather than a tuning matter. The head is at most ten
+#: characters, so a fixed window is all it can ever need.
+_V2_ENVELOPE_HEAD_RE = re.compile(
+    r"(?<![0-9A-Za-z])(?:ip4|ip6|mac|sn|url|host|user)-[0-9a-f]{4}-\Z", re.IGNORECASE
+)
+_V2_ENVELOPE_TAIL_RE = re.compile(r"-[0-9a-f]{8}(?![0-9a-f])", re.IGNORECASE)
+
+#: Longest possible head, plus one character for the boundary check to see:
+#: marker (up to 4) + "-" + key id (4) + "-" is ten.
+_V2_HEAD_WINDOW = 11
+
+
+def _inside_v2_envelope(text: str, start: int, end: int) -> bool:
+    """Is ``text[start:end]`` the payload of a v2 token?"""
+    head = text[max(0, start - _V2_HEAD_WINDOW) : start]
+    return bool(_V2_ENVELOPE_HEAD_RE.search(head) and _V2_ENVELOPE_TAIL_RE.match(text, end))
+
+
 _MAC_RE = re.compile(r"\b[0-9a-fA-F]{2}(?::[0-9a-fA-F]{2}){5}\b")
 _EMAIL_RE = re.compile(r"\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}\b")
 _DEVVDS_RE = re.compile(r"^(?P<dev>[^\[\]]+)\[(?P<vdom>[^\[\]]*)\]$")
@@ -600,6 +664,10 @@ class OutputMasker:
 
         def ip_sub(m: re.Match[str]) -> str:
             candidate = m.group(0)
+            if _inside_v2_envelope(text, m.start(), m.end()):
+                # Our own output. Re-encrypting the payload would leave the
+                # tag signing a value that is no longer there.
+                return candidate
             try:
                 ipaddress.IPv4Address(candidate)
             except ValueError:

--- a/src/fortianalyzer_mcp/utils/config.py
+++ b/src/fortianalyzer_mcp/utils/config.py
@@ -137,6 +137,17 @@ class Settings(BaseSettings):
         "from .env consistently with MASKING_ENABLED; the masking engine otherwise reads "
         "it from the process environment (e.g. a container's environment block).",
     )
+    FAZ_MASKING_ACCEPT_V1_TOKENS: bool = Field(
+        default=True,
+        description=(
+            "Keep honouring v1 masking tokens on the way in. Open for one "
+            "release: tokens already sitting in a live conversation must keep "
+            "resolving, or a restart silently breaks every session that was "
+            "mid-flight. Close it once nothing returns v1 tokens; the server "
+            "logs when it accepts one so a deployment can tell."
+        ),
+    )
+
     FAZ_MASK_DEVICE_IDENTITY: bool = Field(
         default=False,
         description="Also mask device-identity fields (devname, devid, sn, csf). "

--- a/tests/test_fpe_v2_envelope.py
+++ b/tests/test_fpe_v2_envelope.py
@@ -1,0 +1,242 @@
+"""The v2 envelope: mint, shape gate, open (#40).
+
+``<marker>-<kid>-<ct>-<tag>``. The tag primitive is specified separately in
+``test_fpe_v2_tag.py``; this file covers the envelope around it.
+
+Three decisions from #40 are pinned here, each by the property it was taken
+for rather than by its spelling:
+
+* **shape gate** -- a token that looks like v2 is committed to v2 and never
+  falls back to v1, so forgery refusal holds from day one.
+* **colon-free payloads** -- IPv6 and MAC ciphertexts are hex, which is what
+  makes a v2 token usable as a URL host and invisible to the free-text MAC
+  scan.
+* **serial** as its own type, so it has an envelope at all.
+
+The suffix-marked types (``domain``, ``email_local``) have no v2 form yet
+and are out of scope here; see ``TestWhatIsNotCoveredYet``.
+"""
+
+import re
+from urllib.parse import urlsplit
+
+import pytest
+
+from fortianalyzer_mcp.masking.fpe_engine import (
+    V2_MARKERS,
+    FPEEngine,
+    MaskingError,
+)
+from fortianalyzer_mcp.masking.wrapper import _MAC_RE
+
+KEY = "2DE79D232DF5585D68CE47882AE256D6"
+OTHER_KEY = "00112233445566778899AABBCCDDEEFF"
+
+
+@pytest.fixture
+def engine() -> FPEEngine:
+    return FPEEngine(KEY)
+
+
+def _ct(token: str) -> str:
+    """Ciphertext out of a v1 ``<marker>-<kid>-<ct>`` token.
+
+    Splits from the LEFT with maxsplit=2, because a ciphertext legitimately
+    contains hyphens. Doing this from the right silently truncates a serial
+    or hostname payload, which is the same hazard the envelope parser has to
+    survive and which ``test_a_hyphenated_payload_parses`` covers.
+    """
+    return token.split("-", 2)[2]
+
+
+def _all_types(engine: FPEEngine) -> list[tuple[str, str, str]]:
+    """(vtype, v1 ciphertext, original value) for every enveloped type."""
+    return [
+        ("ipv4", engine.mask_ip("192.0.2.9"), "192.0.2.9"),
+        ("ipv6", engine.mask_ip("2001:db8::5"), "2001:db8::5"),
+        ("mac", engine.mask_mac("54:01:81:74:f5:ef"), "54:01:81:74:f5:ef"),
+        ("serial", _ct(engine.mask_serial("FGT60FTK20000001")), "FGT60FTK20000001"),
+        ("hostname", _ct(engine.mask_hostname("fw-hq-01")), "fw-hq-01"),
+        ("username", _ct(engine.mask_username("Admin")), "Admin"),
+        ("url_tail", _ct(engine.mask_url_tail("/a/b?c=1")), "/a/b?c=1"),
+    ]
+
+
+class TestRoundTrip:
+    def test_every_type_round_trips(self, engine: FPEEngine):
+        for vtype, ct, original in _all_types(engine):
+            token = engine.v2_token(vtype, ct)
+            assert engine.v2_open(token) == original, vtype
+
+    def test_a_hyphenated_payload_parses(self, engine: FPEEngine):
+        # A serial ciphertext reliably contains a hyphen, so this is the case
+        # that fails if anyone splits the token from the right.
+        #
+        # It does NOT fail if the payload group is made lazy, and that is not
+        # a gap in this test: measured, the lazy and greedy patterns agree on
+        # every input, because the $ anchor plus the fixed-width tag group
+        # pins the boundary. The equivalent mutant is noted at the pattern.
+        ct = _ct(engine.mask_serial("FGT60FTK20000001"))
+        assert "-" in ct, "fixture no longer exercises the hyphen case"
+
+        assert engine.v2_open(engine.v2_token("serial", ct)) == "FGT60FTK20000001"
+
+    def test_a_recased_token_still_opens(self, engine: FPEEngine):
+        # Every payload but username is lowercase by construction, so folding
+        # tolerates a model title-casing a token in prose.
+        for vtype, ct, original in _all_types(engine):
+            if vtype == "username":
+                continue
+            assert engine.v2_open(engine.v2_token(vtype, ct).upper()) == original, vtype
+
+    def test_a_username_payload_keeps_its_case(self, engine: FPEEngine):
+        # Admin and admin can be different principals, so the username
+        # payload is the one that must NOT fold. Re-casing the whole token
+        # corrupts it, and it is refused rather than opened as someone else.
+        token = engine.v2_token("username", _ct(engine.mask_username("Admin")))
+
+        assert engine.v2_open(token) == "Admin"
+        with pytest.raises(MaskingError):
+            engine.v2_open(token.upper())
+
+
+class TestForgeryIsRefused:
+    def test_a_flipped_tag_is_refused(self, engine: FPEEngine):
+        token = engine.v2_token("hostname", _ct(engine.mask_hostname("fw-hq-01")))
+        forged = token[:-1] + ("0" if token[-1] != "0" else "1")
+
+        with pytest.raises(MaskingError, match="forged or corrupted"):
+            engine.v2_open(forged)
+
+    def test_a_tag_from_another_key_is_refused(self, engine: FPEEngine):
+        ct = _ct(engine.mask_hostname("fw-hq-01"))
+        # Same key id, so the kid check passes and the tag is what refuses.
+        other = FPEEngine(OTHER_KEY)
+        token = f"host-{engine.key_id}-{ct}-{other.v2_tag('hostname', ct)}"
+
+        with pytest.raises(MaskingError, match="forged or corrupted"):
+            engine.v2_open(token)
+
+    def test_a_token_lifted_to_another_type_is_refused(self, engine: FPEEngine):
+        # The tag is domain-separated per type, so a hostname payload
+        # re-labelled as a serial does not authenticate.
+        ct = _ct(engine.mask_hostname("fw-hq-01"))
+        token = f"sn-{engine.key_id}-{ct}-{engine.v2_tag('hostname', ct)}"
+
+        with pytest.raises(MaskingError, match="forged or corrupted"):
+            engine.v2_open(token)
+
+    def test_a_failed_verification_is_logged(self, engine: FPEEngine, caplog):
+        # The 32-bit tag is only defensible while a forgery grind is visible:
+        # one call can carry thousands of tokens, so 2**31 verifications is
+        # on the order of 10**5 calls, not 10**9. This log line is the signal
+        # an operator alarms on.
+        token = engine.v2_token("hostname", _ct(engine.mask_hostname("fw-hq-01")))
+        forged = token[:-1] + ("0" if token[-1] != "0" else "1")
+
+        with caplog.at_level("WARNING"):
+            with pytest.raises(MaskingError):
+                engine.v2_open(forged)
+
+        assert "failed tag verification" in caplog.text
+        # The token itself is attacker-influenced text and must not be logged.
+        assert forged not in caplog.text
+
+
+class TestTheShapeGate:
+    def test_a_v2_token_is_shaped_and_a_v1_token_is_not(self, engine: FPEEngine):
+        assert engine.is_v2_shaped(engine.v2_token("hostname", _ct(engine.mask_hostname("a-b"))))
+        assert not engine.is_v2_shaped(engine.mask_hostname("a-b"))
+
+    def test_the_hazard_the_gate_exists_for(self, engine: FPEEngine):
+        # A v2 token with a flipped tag IS a byte-valid v1 token: the tag is
+        # hex and a hyphen, both inside the v1 alphabet. So the v1 path
+        # decrypts it happily, to plausible garbage. Measured here rather
+        # than asserted, because it is the whole reason the gate exists.
+        token = engine.v2_token("hostname", _ct(engine.mask_hostname("fw-hq-01")))
+        forged = token[:-1] + ("0" if token[-1] != "0" else "1")
+
+        v1_result = engine.unmask_hostname(forged)
+        assert v1_result != "fw-hq-01"
+
+        # The gate is what stops a caller reaching that. Anything v2-shaped
+        # is committed to v2, and v2 refuses.
+        assert engine.is_v2_shaped(forged)
+        with pytest.raises(MaskingError):
+            engine.v2_open(forged)
+
+    def test_a_bare_name_is_not_v2_shaped(self, engine: FPEEngine):
+        # The false-refusal cost is real but narrow. These are not shaped,
+        # so they are never committed to v2.
+        for ordinary in ("host-fw01", "sn-abc", "user-admin", "host-2a85-plainct"):
+            assert not engine.is_v2_shaped(ordinary), ordinary
+
+    def test_opening_something_unshaped_refuses_rather_than_guesses(self, engine: FPEEngine):
+        with pytest.raises(MaskingError, match="not a v2 token"):
+            engine.v2_open("host-fw01")
+
+
+class TestColonFreePayloads:
+    def test_no_token_contains_a_colon(self, engine: FPEEngine):
+        for vtype, ct, _ in _all_types(engine):
+            assert ":" not in engine.v2_token(vtype, ct), vtype
+
+    def test_an_ipv6_token_works_as_a_url_host(self, engine: FPEEngine):
+        # This is the measurement that drove the decision. With the address
+        # spelling, urlsplit raised on CPython >= 3.11 and we require 3.12,
+        # so a re-masked echo burned to an irreversible placeholder and an
+        # inbound token went to the appliance as a literal.
+        token = engine.v2_token("ipv6", engine.mask_ip("2001:db8::5"))
+
+        assert urlsplit(f"https://{token}:8443/x").hostname == token.lower()
+
+    def test_the_free_text_mac_scan_does_not_match_inside_a_mac_envelope(self, engine: FPEEngine):
+        v2 = engine.v2_token("mac", engine.mask_mac("54:01:81:74:f5:ef"))
+
+        assert _MAC_RE.search(v2) is None
+        # Control: the regex still matches a v1 MAC token, so the assertion
+        # above is about the hex spelling and not about a dead regex.
+        assert _MAC_RE.search(engine.mask_mac("54:01:81:74:f5:ef")) is not None
+
+
+class TestKeyId:
+    def test_a_token_from_another_key_is_refused_on_the_key_id(self, engine: FPEEngine):
+        foreign = FPEEngine(OTHER_KEY)
+        token = foreign.v2_token("hostname", _ct(foreign.mask_hostname("fw-hq-01")))
+
+        with pytest.raises(MaskingError):
+            engine.v2_open(token)
+
+
+class TestWhatIsNotCoveredYet:
+    def test_the_suffix_marked_types_have_no_envelope(self, engine: FPEEngine):
+        # domain and email_local are marked by a dotted suffix rather than a
+        # hyphenated prefix, so their v2 spelling is a different parse. They
+        # already carry a marker and a key id today, so they are not what the
+        # marked-IP work is blocked on, and they are deliberately left for a
+        # following change rather than half-built here.
+        assert "domain" not in V2_MARKERS
+        assert "email_local" not in V2_MARKERS
+
+        with pytest.raises(MaskingError, match="no v2 envelope"):
+            engine.v2_token("domain", "abc")
+
+    def test_the_marker_set_matches_the_sibling_server(self):
+        # These spellings already shipped in fortimanager-mcp's reserved
+        # vocabulary (masking/tokens.py, PREFIX_MARKERS). A token minted here
+        # has to be recognisable there, so the set is pinned rather than
+        # left to drift.
+        assert set(V2_MARKERS.values()) == {"ip4", "ip6", "mac", "sn", "url", "host", "user"}
+
+
+class TestSpecPin:
+    def test_the_envelope_grammar_is_pinned(self, engine: FPEEngine):
+        # A literal, because the grammar is the shared contract and a test
+        # that rebuilds it from the implementation drifts with it.
+        assert engine.v2_token("ipv4", "248.194.94.248") == "ip4-2a85-248.194.94.248-53eecc82"
+
+        # And the shape, stated independently of any one token.
+        assert re.fullmatch(
+            r"(?:ip4|ip6|mac|sn|url|host|user)-[0-9a-f]{4}-.+-[0-9a-f]{8}",
+            engine.v2_token("hostname", _ct(engine.mask_hostname("fw-hq-01"))),
+        )

--- a/tests/test_fpe_v2_envelope.py
+++ b/tests/test_fpe_v2_envelope.py
@@ -27,7 +27,7 @@ from fortianalyzer_mcp.masking.fpe_engine import (
     FPEEngine,
     MaskingError,
 )
-from fortianalyzer_mcp.masking.wrapper import _MAC_RE
+from fortianalyzer_mcp.masking.wrapper import _MAC_RE, _TOKEN_PREFIX_SHAPE_RE
 
 KEY = "2DE79D232DF5585D68CE47882AE256D6"
 OTHER_KEY = "00112233445566778899AABBCCDDEEFF"
@@ -201,11 +201,33 @@ class TestColonFreePayloads:
 
 class TestKeyId:
     def test_a_token_from_another_key_is_refused_on_the_key_id(self, engine: FPEEngine):
+        # Asserting only "refused" cannot see the key-id check at all: the
+        # tag key derives from the engine key, so a foreign token fails the
+        # tag too and the test passes with the key-id check deleted.
+        # Measured, before this assertion was tightened.
+        #
+        # Which one refuses matters. The key-id check says "rotated key",
+        # which is diagnosable and ordinary. The tag failure says "forged or
+        # corrupted" and fires the warning that is meant to be the only
+        # signal separating a forgery grind from normal traffic. Letting a
+        # key rotation trip that alarm poisons it.
         foreign = FPEEngine(OTHER_KEY)
         token = foreign.v2_token("hostname", _ct(foreign.mask_hostname("fw-hq-01")))
 
-        with pytest.raises(MaskingError):
+        with pytest.raises(MaskingError) as caught:
             engine.v2_open(token)
+
+        assert "forged or corrupted" not in str(caught.value)
+
+    def test_a_key_rotation_does_not_fire_the_forgery_alarm(self, engine: FPEEngine, caplog):
+        foreign = FPEEngine(OTHER_KEY)
+        token = foreign.v2_token("hostname", _ct(foreign.mask_hostname("fw-hq-01")))
+
+        with caplog.at_level("WARNING"):
+            with pytest.raises(MaskingError):
+                engine.v2_open(token)
+
+        assert "failed tag verification" not in caplog.text
 
 
 class TestWhatIsNotCoveredYet:
@@ -229,11 +251,42 @@ class TestWhatIsNotCoveredYet:
         assert set(V2_MARKERS.values()) == {"ip4", "ip6", "mac", "sn", "url", "host", "user"}
 
 
+class TestTheMutatingToolGateCoversEveryEnvelope:
+    def test_the_shape_recogniser_knows_every_v2_marker(self, engine: FPEEngine):
+        # _TOKEN_PREFIX_SHAPE_RE is what the mutating-tool gate (#108) uses
+        # to tell a token from a legitimate value. ip4/ip6/mac had no marked
+        # form before v2, so they were never in it, and the gate would have
+        # gone on passing while covering none of the three types the envelope
+        # exists to make detectable. That is the failure direction that does
+        # not announce itself.
+        for vtype, ct, _ in _all_types(engine):
+            token = engine.v2_token(vtype, ct)
+            assert _TOKEN_PREFIX_SHAPE_RE.match(token), vtype
+
+    def test_it_still_does_not_flag_ordinary_values(self):
+        # The markers are only half of it: a real value that merely starts
+        # with one is not a token, because it has no 4-hex key id.
+        for ordinary in ("ip4-lan", "mac-table", "sn-abc", "host-fw01"):
+            assert not _TOKEN_PREFIX_SHAPE_RE.match(ordinary), ordinary
+
+
 class TestSpecPin:
     def test_the_envelope_grammar_is_pinned(self, engine: FPEEngine):
         # A literal, because the grammar is the shared contract and a test
         # that rebuilds it from the implementation drifts with it.
         assert engine.v2_token("ipv4", "248.194.94.248") == "ip4-2a85-248.194.94.248-53eecc82"
+
+        # An IPv6 token whose ciphertext has a LEADING ZERO nibble, chosen on
+        # purpose. The zero padding is part of the shared format and nothing
+        # else pins its width: the tag literals in test_fpe_v2_tag.py are fed
+        # hex directly and never cross _v2_payload_out, so dropping "032x"
+        # for "x" round-trips against itself and passes the whole suite.
+        # Measured. About one in sixteen ciphertexts starts with a zero, and
+        # for those a port that dropped the padding would mint tokens the
+        # other server refuses and logs as forgeries.
+        v6 = engine.v2_token("ipv6", engine.mask_ip("2001:db8::16"))
+        assert v6 == "ip6-2a85-0a1baadc502f122e379b90efd546b435-93e5818b"
+        assert len(v6.split("-")[2]) == 32
 
         # And the shape, stated independently of any one token.
         assert re.fullmatch(

--- a/tests/test_fpe_v2_tag.py
+++ b/tests/test_fpe_v2_tag.py
@@ -102,6 +102,29 @@ class TestVerification:
         ):
             assert engine.v2_tag_ok("ipv4", "248.194.94.248", bad) is False
 
+    def test_a_recased_token_still_verifies(self, engine: FPEEngine):
+        # The engine already tolerates re-casing for every type except
+        # username: unmask_hostname round-trips an upper- or title-cased
+        # token. The tag has to tolerate exactly as much, or a model that
+        # re-cases a token in prose turns it into something we no longer
+        # recognise as ours and hand to the appliance as a literal.
+        ct = "xwekcqanzm"
+        tag = engine.v2_tag("hostname", ct)
+
+        assert engine.v2_tag_ok("hostname", ct, tag.upper())
+        assert engine.v2_tag_ok("hostname", ct.upper(), tag)
+        assert engine.v2_tag_ok("hostname", ct.upper(), tag.upper())
+
+    def test_username_tags_stay_case_sensitive(self, engine: FPEEngine):
+        # Usernames are the documented exception: Admin and admin can be
+        # different principals, the cipher is mixed-case, and re-casing a
+        # username token already corrupts it. Folding case here would make
+        # two distinct principals' tokens authenticate each other.
+        ct = "AbCdEfGh"
+
+        assert engine.v2_tag("username", ct) != engine.v2_tag("username", ct.lower())
+        assert not engine.v2_tag_ok("username", ct, engine.v2_tag("username", ct.lower()))
+
     def test_an_unknown_type_still_raises_on_verify(self, engine: FPEEngine):
         # Deliberately NOT swallowed. The value type comes from our own field
         # table, never from the wire, so an unknown one is a bug in this

--- a/tests/test_fpe_v2_tag.py
+++ b/tests/test_fpe_v2_tag.py
@@ -30,7 +30,9 @@ def engine() -> FPEEngine:
 class TestTagShape:
     def test_tag_is_eight_lowercase_hex(self, engine: FPEEngine):
         # 32 bits, the size settled on #40: one in 4.3 billion per blind
-        # forgery attempt, and every attempt costs the attacker a tool call.
+        # forgery attempt. Per VERIFICATION, not per tool call -- one call
+        # can carry thousands of tokens, so the per-call cap is the envelope
+        # layer's job, not the tag size's.
         tag = engine.v2_tag("ipv4", "248.194.94.248")
         assert V2_TAG_HEX == 8
         assert len(tag) == V2_TAG_HEX
@@ -58,9 +60,12 @@ class TestDomainSeparation:
         for vtype in V2_TYPES:
             assert ":" not in vtype, f"type {vtype!r} would break tag injectivity"
 
-    def test_a_colon_bearing_type_is_rejected(self, engine: FPEEngine):
-        # The guard above is only worth having if the code enforces it.
-        with pytest.raises(MaskingError, match="type"):
+    def test_a_type_outside_the_pinned_set_is_rejected(self, engine: FPEEngine):
+        # This does not pin the colon property on its own: "ip:v4" is refused
+        # for being unknown, and there is no colon-specific branch. It is the
+        # pair that carries the property -- the set is closed here, and every
+        # member of it is asserted colon-free above.
+        with pytest.raises(MaskingError, match="unknown v2 value type"):
             engine.v2_tag("ip:v4", "abc")
 
 
@@ -125,6 +130,34 @@ class TestVerification:
         assert engine.v2_tag("username", ct) != engine.v2_tag("username", ct.lower())
         assert not engine.v2_tag_ok("username", ct, engine.v2_tag("username", ct.lower()))
 
+    def test_whitespace_padding_does_not_verify(self, engine: FPEEngine):
+        # Tolerance has to be justified by what decryption tolerates, and
+        # decryption tolerates no padding inside a token. A tag is sliced out
+        # of a token by the parser, so outer whitespace means the parse was
+        # wrong, not that the token was re-spelled.
+        ct = "248.194.94.248"
+        tag = engine.v2_tag("ipv4", ct)
+
+        assert not engine.v2_tag_ok("ipv4", ct, f" {tag}")
+        assert not engine.v2_tag_ok("ipv4", ct, f"{tag} ")
+
+    def test_a_respelled_ipv6_payload_still_verifies(self, engine: FPEEngine):
+        # Same principle as the re-casing fix: ipaddress treats abcd::1 and
+        # its fully expanded form as one address, so decryption tolerates
+        # both spellings and the tag must too. Otherwise a model that
+        # expands a token in prose produces something that decrypts fine and
+        # fails verification, and gets handed to the appliance as a literal.
+        compressed = "abcd::1"
+        expanded = "abcd:0000:0000:0000:0000:0000:0000:0001"
+
+        assert engine.v2_tag("ipv6", compressed) == engine.v2_tag("ipv6", expanded)
+        assert engine.v2_tag_ok("ipv6", expanded, engine.v2_tag("ipv6", compressed))
+
+    def test_a_non_address_ipv6_payload_is_left_alone(self, engine: FPEEngine):
+        # Canonicalisation must not swallow a payload it cannot parse: that
+        # would silently tag two different unparseable strings the same way.
+        assert engine.v2_tag("ipv6", "not-an-address") != engine.v2_tag("ipv6", "also-not-one")
+
     def test_an_unknown_type_still_raises_on_verify(self, engine: FPEEngine):
         # Deliberately NOT swallowed. The value type comes from our own field
         # table, never from the wire, so an unknown one is a bug in this
@@ -183,3 +216,8 @@ class TestSpecPin:
             tag_key, b"faz-mcp-fpe:v2:tag:ipv4:248.194.94.248", hashlib.sha256
         ).hexdigest()[:8]
         assert engine.v2_tag("ipv4", "248.194.94.248") == expected
+
+        # And stated outright, not only recomputed. A recomputation that
+        # mirrors the implementation drifts with it; a literal is the thing
+        # fortimanager-mcp has to reproduce, so it is the actual contract.
+        assert engine.v2_tag("ipv4", "248.194.94.248") == "53eecc82"

--- a/tests/test_fpe_v2_tag.py
+++ b/tests/test_fpe_v2_tag.py
@@ -158,6 +158,17 @@ class TestVerification:
         # would silently tag two different unparseable strings the same way.
         assert engine.v2_tag("ipv6", "not-an-address") != engine.v2_tag("ipv6", "also-not-one")
 
+    def test_an_unencodable_payload_does_not_verify(self, engine: FPEEngine):
+        # A lone surrogate is not valid UTF-8, so building the tag input
+        # raises UnicodeEncodeError. json.loads produces exactly this from a
+        # "\\ud800" escape, and the envelope parser will slice its payload
+        # out of token text a model supplied, so this is the same crash class
+        # as the tag one, a parameter over. Verification refuses it.
+        import json
+
+        surrogate = json.loads('"\\ud800abc"')
+        assert engine.v2_tag_ok("hostname", surrogate, "deadbeef") is False
+
     def test_an_unknown_type_still_raises_on_verify(self, engine: FPEEngine):
         # Deliberately NOT swallowed. The value type comes from our own field
         # table, never from the wire, so an unknown one is a bug in this
@@ -186,12 +197,17 @@ class TestConstantTimeComparison:
         import inspect
 
         source = inspect.getsource(FPEEngine.v2_tag_ok)
-        assert "compare_digest" in source, (
+        # Against the BODY, not the whole source: the docstring says the word
+        # "compare_digest" too, so checking the source let a body that had
+        # dropped the call still pass. Demonstrated with
+        # ``return candidate in (expected,)``, which is timing-variable,
+        # contains no "==", and satisfied both asserts.
+        body = source.split('"""')[-1]
+        assert "compare_digest" in body, (
             "v2_tag_ok must compare the tag with hmac.compare_digest; "
             "a plain == is functionally identical and no behavioural test "
             "will catch the swap"
         )
-        body = source.split('"""')[-1]
         assert "==" not in body.replace("!=", ""), (
             "v2_tag_ok compares something with == outside its docstring; "
             "if that is the tag comparison it is a timing leak"
@@ -221,3 +237,12 @@ class TestSpecPin:
         # mirrors the implementation drifts with it; a literal is the thing
         # fortimanager-mcp has to reproduce, so it is the actual contract.
         assert engine.v2_tag("ipv4", "248.194.94.248") == "53eecc82"
+
+        # The ipv4 literal above pins the plain path. These pin the two
+        # halves of _v2_canonical_ct, which is shared-format surface too:
+        # fortimanager-mcp has to canonicalise identically or the same value
+        # authenticates on one server and not the other. Both spellings of
+        # the address must give the SAME literal; the username must not fold.
+        assert engine.v2_tag("ipv6", "abcd::1") == "ff087aef"
+        assert engine.v2_tag("ipv6", "abcd:0000:0000:0000:0000:0000:0000:0001") == "ff087aef"
+        assert engine.v2_tag("username", "AbCdEfGh") == "b830a7c4"

--- a/tests/test_fpe_v2_tag.py
+++ b/tests/test_fpe_v2_tag.py
@@ -1,0 +1,108 @@
+"""The v2 envelope's authentication tag (#40).
+
+The envelope is ``<type>-<kid>-<ct>-<tag>``. This file covers the tag
+primitive on its own, before any minting or parsing is wired up: the tag is
+the part both servers must agree on byte for byte, so it is specified and
+pinned independently of how a token is spelled around it.
+"""
+
+import hashlib
+import hmac
+
+import pytest
+
+from fortianalyzer_mcp.masking.fpe_engine import (
+    V2_TAG_HEX,
+    V2_TYPES,
+    FPEEngine,
+    MaskingError,
+)
+
+KEY = "2DE79D232DF5585D68CE47882AE256D6"
+OTHER_KEY = "00112233445566778899AABBCCDDEEFF"
+
+
+@pytest.fixture
+def engine() -> FPEEngine:
+    return FPEEngine(KEY)
+
+
+class TestTagShape:
+    def test_tag_is_eight_lowercase_hex(self, engine: FPEEngine):
+        # 32 bits, the size settled on #40: one in 4.3 billion per blind
+        # forgery attempt, and every attempt costs the attacker a tool call.
+        tag = engine.v2_tag("ipv4", "248.194.94.248")
+        assert V2_TAG_HEX == 8
+        assert len(tag) == V2_TAG_HEX
+        assert all(c in "0123456789abcdef" for c in tag)
+
+    def test_tag_is_deterministic(self, engine: FPEEngine):
+        assert engine.v2_tag("ipv4", "10.0.0.1") == engine.v2_tag("ipv4", "10.0.0.1")
+
+    def test_tag_depends_on_the_key(self, engine: FPEEngine):
+        assert engine.v2_tag("ipv4", "10.0.0.1") != FPEEngine(OTHER_KEY).v2_tag("ipv4", "10.0.0.1")
+
+
+class TestDomainSeparation:
+    def test_same_ciphertext_under_two_types_gets_two_tags(self, engine: FPEEngine):
+        # Without per-type separation a token could be lifted from one field
+        # type to another and still verify.
+        assert engine.v2_tag("ipv4", "abc123") != engine.v2_tag("mac", "abc123")
+
+    def test_tag_input_is_injective_over_the_pinned_type_set(self, engine: FPEEngine):
+        # The tag input is "...:<type>:<ct>". Two different (type, ct) pairs
+        # must never build the same string. That holds only because no type
+        # name contains a colon -- ciphertexts do (IPv6, MAC), so the first
+        # colon after the prefix is what delimits the type. This asserts the
+        # property rather than trusting the comment.
+        for vtype in V2_TYPES:
+            assert ":" not in vtype, f"type {vtype!r} would break tag injectivity"
+
+    def test_a_colon_bearing_type_is_rejected(self, engine: FPEEngine):
+        # The guard above is only worth having if the code enforces it.
+        with pytest.raises(MaskingError, match="type"):
+            engine.v2_tag("ip:v4", "abc")
+
+
+class TestVerification:
+    def test_correct_tag_verifies(self, engine: FPEEngine):
+        ct = "248.194.94.248"
+        assert engine.v2_tag_ok("ipv4", ct, engine.v2_tag("ipv4", ct))
+
+    def test_one_flipped_character_fails(self, engine: FPEEngine):
+        ct = "248.194.94.248"
+        tag = engine.v2_tag("ipv4", ct)
+        flipped = ("0" if tag[0] != "0" else "1") + tag[1:]
+        assert not engine.v2_tag_ok("ipv4", ct, flipped)
+
+    def test_tag_from_another_type_fails(self, engine: FPEEngine):
+        ct = "abc123"
+        assert not engine.v2_tag_ok("ipv4", ct, engine.v2_tag("mac", ct))
+
+    def test_tag_from_another_key_fails(self, engine: FPEEngine):
+        ct = "abc123"
+        assert not engine.v2_tag_ok("ipv4", ct, FPEEngine(OTHER_KEY).v2_tag("ipv4", ct))
+
+    def test_empty_and_malformed_tags_fail(self, engine: FPEEngine):
+        for bad in ("", "  ", "zzzzzzzz", "deadbeef0", "deadbee"):
+            assert not engine.v2_tag_ok("ipv4", "248.194.94.248", bad)
+
+
+class TestSpecPin:
+    """The tag is the shared contract with fortimanager-mcp, so its
+    derivation is pinned here as a literal rather than recomputed the way
+    the implementation does it."""
+
+    def test_tag_key_derivation_is_pinned(self, engine: FPEEngine):
+        expected = hashlib.sha256(f"faz-mcp-fpe:v2:tagkey:{KEY.lower()}".encode()).digest()
+        assert engine._v2_tag_key == expected
+
+    def test_tag_value_is_pinned(self, engine: FPEEngine):
+        # Independent recomputation of the whole construction. If either side
+        # of the shared format drifts, this fails rather than the two servers
+        # silently disagreeing in production.
+        tag_key = hashlib.sha256(f"faz-mcp-fpe:v2:tagkey:{KEY.lower()}".encode()).digest()
+        expected = hmac.new(
+            tag_key, b"faz-mcp-fpe:v2:tag:ipv4:248.194.94.248", hashlib.sha256
+        ).hexdigest()[:8]
+        assert engine.v2_tag("ipv4", "248.194.94.248") == expected

--- a/tests/test_fpe_v2_tag.py
+++ b/tests/test_fpe_v2_tag.py
@@ -141,22 +141,50 @@ class TestVerification:
         assert not engine.v2_tag_ok("ipv4", ct, f" {tag}")
         assert not engine.v2_tag_ok("ipv4", ct, f"{tag} ")
 
-    def test_a_respelled_ipv6_payload_still_verifies(self, engine: FPEEngine):
-        # Same principle as the re-casing fix: ipaddress treats abcd::1 and
-        # its fully expanded form as one address, so decryption tolerates
-        # both spellings and the tag must too. Otherwise a model that
-        # expands a token in prose produces something that decrypts fine and
-        # fails verification, and gets handed to the appliance as a literal.
+    def test_two_spellings_of_one_ipv6_address_no_longer_tag_alike(self, engine: FPEEngine):
+        # This test previously asserted the opposite, and the reversal is the
+        # point. While v2 payloads were spelled as addresses, "abcd::1" and
+        # its expanded form were one value that both decrypted, so the tag
+        # canonicalised through `ipaddress` to tolerate both.
+        #
+        # #40 settled that a v2 payload carries no colons: an IPv6 ciphertext
+        # is plain hex inside the envelope. Neither string below can be a v2
+        # payload any more, so there is nothing left to reconcile, and the
+        # canonicalisation is gone rather than dormant. They tag differently
+        # now because they are simply different strings, which is what the
+        # rest of the types have always done.
         compressed = "abcd::1"
         expanded = "abcd:0000:0000:0000:0000:0000:0000:0001"
 
-        assert engine.v2_tag("ipv6", compressed) == engine.v2_tag("ipv6", expanded)
-        assert engine.v2_tag_ok("ipv6", expanded, engine.v2_tag("ipv6", compressed))
+        assert engine.v2_tag("ipv6", compressed) != engine.v2_tag("ipv6", expanded)
+
+    def test_a_colon_free_ipv6_payload_tolerates_recasing_and_nothing_else(self, engine: FPEEngine):
+        # What a real v2 IPv6 payload looks like after the format decision,
+        # and the only tolerance it needs: case, because the envelope parser
+        # lowercases and a model may title-case a token in prose.
+        hex_payload = "20010db8000000000000000000000005"
+
+        assert engine.v2_tag_ok("ipv6", hex_payload.upper(), engine.v2_tag("ipv6", hex_payload))
+        # One hex digit different is a different payload, not a respelling.
+        assert not engine.v2_tag_ok(
+            "ipv6", hex_payload[:-1] + "6", engine.v2_tag("ipv6", hex_payload)
+        )
 
     def test_a_non_address_ipv6_payload_is_left_alone(self, engine: FPEEngine):
-        # Canonicalisation must not swallow a payload it cannot parse: that
-        # would silently tag two different unparseable strings the same way.
+        # Two payloads that are not addresses must not collapse onto one tag.
+        # This held via the parse-failure branch before; it now holds because
+        # nothing canonicalises at all.
         assert engine.v2_tag("ipv6", "not-an-address") != engine.v2_tag("ipv6", "also-not-one")
+
+    def test_a_serial_payload_folds_case_like_the_other_string_types(self, engine: FPEEngine):
+        # Serial is the type added with the envelope work, and it is the one
+        # where case looks like it should matter. It does not, here: the
+        # serial's own case is preserved inside the base32 shield, one layer
+        # down, so the ciphertext this tag covers is lowercase by
+        # construction and folding matches what decryption tolerates.
+        ct = engine.mask_serial("FGT60FTK20000001").rsplit("-", 1)[-1]
+
+        assert engine.v2_tag_ok("serial", ct.upper(), engine.v2_tag("serial", ct))
 
     def test_an_unencodable_payload_does_not_verify(self, engine: FPEEngine):
         # A lone surrogate is not valid UTF-8, so building the tag input
@@ -238,11 +266,28 @@ class TestSpecPin:
         # fortimanager-mcp has to reproduce, so it is the actual contract.
         assert engine.v2_tag("ipv4", "248.194.94.248") == "53eecc82"
 
-        # The ipv4 literal above pins the plain path. These pin the two
-        # halves of _v2_canonical_ct, which is shared-format surface too:
-        # fortimanager-mcp has to canonicalise identically or the same value
-        # authenticates on one server and not the other. Both spellings of
-        # the address must give the SAME literal; the username must not fold.
-        assert engine.v2_tag("ipv6", "abcd::1") == "ff087aef"
-        assert engine.v2_tag("ipv6", "abcd:0000:0000:0000:0000:0000:0000:0001") == "ff087aef"
+        # The ipv4 literal above pins the plain path. These pin the rest of
+        # the shared surface: fortimanager-mcp has to reproduce every one of
+        # them or the same value authenticates on one server and not the
+        # other.
+        #
+        # The ipv6 and mac literals changed with #40's colon-free decision.
+        # They used to be spelled as addresses, and the ipv6 pair used to
+        # assert that "abcd::1" and its expanded form gave the SAME literal,
+        # because _v2_canonical_ct reconciled them. A v2 payload carries no
+        # colons now, so these are the hex spellings, there is nothing to
+        # reconcile, and the canonicalisation is gone. Anyone porting must
+        # take the new literals, not the ones in this file's history.
+        assert engine.v2_tag("ipv6", "20010db8000000000000000000000005") == "6bced6a2"
+        assert engine.v2_tag("mac", "54018174f5ef") == "ff5ead5b"
+
+        # serial is new in v2 and is the one type whose ciphertext is base32
+        # under the string cipher, so it can contain the pad character. Its
+        # tag covers that ciphertext verbatim, pad char included.
+        assert engine.v2_tag("serial", "dokfzo5t1y~mpe2dum68pmvf8s") == "5ebba096"
+
+        # The one surviving half of _v2_canonical_ct: username does not fold,
+        # every other type does. Both literals, so a port that folds the
+        # wrong way fails here rather than in production.
         assert engine.v2_tag("username", "AbCdEfGh") == "b830a7c4"
+        assert engine.v2_tag("username", "abcdefgh") == "64ff0357"

--- a/tests/test_fpe_v2_tag.py
+++ b/tests/test_fpe_v2_tag.py
@@ -133,6 +133,38 @@ class TestVerification:
             engine.v2_tag_ok("not-a-type", "abc", "deadbeef")
 
 
+class TestConstantTimeComparison:
+    """The one property behaviour cannot express.
+
+    Swapping ``hmac.compare_digest`` for ``==`` changes nothing observable:
+    same answer for every input, and a mutation test over the whole file
+    leaves it alive. The difference is timing, and a timing assertion in a
+    unit test is flaky by construction. So the property is pinned
+    structurally instead, which is honest about what it checks: not that the
+    comparison IS constant-time, but that the code still calls the function
+    that makes it so.
+
+    It matters because the alternative is not a slower check, it is a
+    different threat model: a byte-by-byte timing signal takes forgery from
+    2**32 blind attempts down to a few hundred measured ones.
+    """
+
+    def test_verification_uses_compare_digest(self):
+        import inspect
+
+        source = inspect.getsource(FPEEngine.v2_tag_ok)
+        assert "compare_digest" in source, (
+            "v2_tag_ok must compare the tag with hmac.compare_digest; "
+            "a plain == is functionally identical and no behavioural test "
+            "will catch the swap"
+        )
+        body = source.split('"""')[-1]
+        assert "==" not in body.replace("!=", ""), (
+            "v2_tag_ok compares something with == outside its docstring; "
+            "if that is the tag comparison it is a timing leak"
+        )
+
+
 class TestSpecPin:
     """The tag is the shared contract with fortimanager-mcp, so its
     derivation is pinned here as a literal rather than recomputed the way

--- a/tests/test_fpe_v2_tag.py
+++ b/tests/test_fpe_v2_tag.py
@@ -87,6 +87,28 @@ class TestVerification:
         for bad in ("", "  ", "zzzzzzzz", "deadbeef0", "deadbee"):
             assert not engine.v2_tag_ok("ipv4", "248.194.94.248", bad)
 
+    def test_verification_is_total_over_untrusted_tags(self, engine: FPEEngine):
+        # The tag arrives inside a token a model hands back, so it is
+        # untrusted input and verification must be a predicate, not a
+        # hazard. compare_digest raises TypeError on non-ASCII rather than
+        # returning False, and uppercase hex is a plausible re-casing, so
+        # both have to be handled before the comparison.
+        for bad in (
+            "déadbeef",  # non-ASCII: compare_digest would raise
+            "DEADBEEF",  # re-cased hex
+            "dead beef",
+            "\n",
+            "0x1234ab",
+        ):
+            assert engine.v2_tag_ok("ipv4", "248.194.94.248", bad) is False
+
+    def test_an_unknown_type_still_raises_on_verify(self, engine: FPEEngine):
+        # Deliberately NOT swallowed. The value type comes from our own field
+        # table, never from the wire, so an unknown one is a bug in this
+        # repo and should be loud. Only the tag itself is untrusted.
+        with pytest.raises(MaskingError, match="unknown v2 value type"):
+            engine.v2_tag_ok("not-a-type", "abc", "deadbeef")
+
 
 class TestSpecPin:
     """The tag is the shared contract with fortimanager-mcp, so its

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -290,6 +290,11 @@ def masker(monkeypatch: pytest.MonkeyPatch) -> OutputMasker:
 
 
 @pytest.fixture
+def engine() -> FPEEngine:
+    return FPEEngine(KEY)
+
+
+@pytest.fixture
 def full_masker(monkeypatch: pytest.MonkeyPatch) -> OutputMasker:
     monkeypatch.setenv("FAZ_MASKING_KEY", KEY)
     return OutputMasker(FPEEngine(KEY), mask_device_identity=True)
@@ -396,8 +401,8 @@ class TestFreeTextSubstitution:
         assert upper_token != lower_token
         assert upper_token in masked["msg"]
         assert lower_token in masked["msg"]
-        assert engine.unmask_username(upper_token) == "Admin"
-        assert engine.unmask_username(lower_token) == "admin"
+        assert engine.unmask_token(upper_token) == "Admin"
+        assert engine.unmask_token(lower_token) == "admin"
 
     def test_uppercase_short_values_are_not_substituted_into_prose(self, masker: OutputMasker):
         masked = masker.mask_result({"user": "abc", "msg": "ABC is a short code"})
@@ -547,11 +552,20 @@ class TestFreeTextSubstitution:
         )
         assert BAD_DOMAIN not in masked["extrainfo"]
 
-    def test_ip_or_host_field_holding_an_address_masks_as_an_ip(self, masker: OutputMasker):
-        import ipaddress
+    def test_ip_or_host_field_holding_an_address_masks_as_an_ip(
+        self, masker: OutputMasker, engine: FPEEngine
+    ):
+        """An IP_OR_HOST field holding an address masks as an address.
 
+        The discrimination used to be implicit: an IP token parsed as an
+        IP and a hostname token carried the host- marker. Under v2 both
+        are marked, so the type is stated rather than inferred, which is
+        the clearer assertion and the same property.
+        """
         masked = masker.mask_result({"epname": GATEWAY_IP})
-        ipaddress.ip_address(masked["epname"])  # still a valid address, not a host- token
+
+        assert masked["epname"].startswith("ip4-")
+        assert engine.v2_open(masked["epname"]) == GATEWAY_IP
 
     def test_ip_or_host_field_holding_a_name_masks_as_a_hostname(self, masker: OutputMasker):
         masked = masker.mask_result({"epname": ENDPOINT_NAME})
@@ -1088,7 +1102,7 @@ class TestSoarIndicatorPair:
         out = masker.mask_result({"data": [row]})["data"][0]
 
         assert PEER_IP not in str(out)
-        assert engine.unmask_ip(out["value"]) == PEER_IP
+        assert engine.unmask_token(out["value"]) == PEER_IP
         assert out["enrichment-reputation"] == "Malicious"  # verdict stays readable
 
     def test_indicator_domain_is_masked(self, masker: OutputMasker):
@@ -1279,12 +1293,12 @@ class TestFortiViewResolvedName:
         out = masker.mask_result({"data": [row]})["data"][0]
 
         assert BAD_DOMAIN not in str(out)
-        assert FPEEngine(KEY).unmask_hostname(out["dstip_hostname"]) == BAD_DOMAIN
+        assert FPEEngine(KEY).unmask_token(out["dstip_hostname"]) == BAD_DOMAIN
 
     def test_address_form_stays_reversible(self, masker: OutputMasker):
         out = masker.mask_result({"dstip_hostname": PEER_IP})["dstip_hostname"]
 
-        assert FPEEngine(KEY).unmask_ip(out) == PEER_IP
+        assert FPEEngine(KEY).unmask_token(out) == PEER_IP
 
     @pytest.mark.parametrize("key", ["srcip_hostname", "dstip_hostname"])
     def test_both_columns_take_the_resolved_form_reversibly(self, masker: OutputMasker, key: str):
@@ -1295,7 +1309,7 @@ class TestFortiViewResolvedName:
 
         assert BAD_DOMAIN not in out
         assert not out.startswith("masked-unrepresentable-")
-        assert FPEEngine(KEY).unmask_hostname(out) == BAD_DOMAIN
+        assert FPEEngine(KEY).unmask_token(out) == BAD_DOMAIN
 
 
 class TestIncidentWorkflowPrincipals:

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -2167,3 +2167,77 @@ class TestGroupByGroupsRowsAlreadyCovered:
 
         flagged = full_masker.mask_result(payload)
         assert flagged["groups"][0]["fortigate"] != DEV_NAME
+
+
+class TestDevidCarriesASerial:
+    """``devid`` is documented by this repo as the SERIAL-carrying key,
+    but it was typed HOSTNAME while ``sn`` moved to SERIAL.
+
+    Three places in the tools layer say so:
+
+        fortiview_tools.py:51   a serial-shaped value -> [{"devid": <serial>}]
+        fortiview_tools.py:145  under devid (a serial under devname
+                                silently matches nothing)
+        report_tools.py:416     serials -> devid, names -> devname
+
+    So the same serial arrives under ``sn`` and under ``devid`` on one
+    ``list_devices`` row, and before this the two produced different
+    tokens and only one of them round-tripped. Measured on ``89a3689``
+    with the flag on:
+
+        sn     sn-<kid>-...    unmasks to FGT60FTK20000001
+        devid  host-<kid>-...  unmasks to fgt60ftk20000001   CORRUPTED
+
+    which is the exact failure the SERIAL type was added to fix, in the
+    commit that fixed it for ``target[].value`` and stopped there.
+
+    ``devid`` is polymorphic in practice (a name on some surfaces, a
+    serial on others), so it takes the same ``IP_HOST_OR_SERIAL`` the
+    ``device`` target slot takes rather than a flat SERIAL, on the same
+    stated criterion: only carriers documented to hold a serial get it.
+    """
+
+    SERIAL_VALUE = "FGT60FTK20000001"
+    NAME_VALUE = "edge-fw-02"
+
+    def _on(self, monkeypatch: pytest.MonkeyPatch) -> OutputMasker:
+        monkeypatch.setenv("FAZ_MASKING_KEY", KEY)
+        return OutputMasker(FPEEngine(KEY), mask_device_identity=True)
+
+    def test_a_serial_under_devid_gets_the_same_token_as_under_sn(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        out = self._on(monkeypatch).mask_result(
+            {"sn": self.SERIAL_VALUE, "devid": self.SERIAL_VALUE}
+        )
+        assert self.SERIAL_VALUE not in str(out)
+        assert out["devid"] == out["sn"]
+
+    def test_a_serial_under_devid_round_trips_with_its_case(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The functional half. A serial masked through the hostname
+        alphabet comes back lowercased, and a lowercased serial is not the
+        serial: FortiManager will not match it."""
+        masker = self._on(monkeypatch)
+        token = masker.mask_result({"devid": self.SERIAL_VALUE})["devid"]
+        assert ArgUnmasker(FPEEngine(KEY)).resolve_scalar(token) == self.SERIAL_VALUE
+
+    def test_a_device_name_under_devid_still_masks_as_a_hostname(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The regression guard. devid holds a NAME on the surfaces the
+        #80 sweep sampled, so the serial branch must not capture those."""
+        out = self._on(monkeypatch).mask_result(
+            {"devname": self.NAME_VALUE, "devid": self.NAME_VALUE}
+        )
+        assert self.NAME_VALUE not in str(out)
+        assert out["devid"] == out["devname"]
+
+    def test_devid_still_follows_the_device_identity_flag(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Retyping must not change which table it lives in."""
+        monkeypatch.setenv("FAZ_MASKING_KEY", KEY)
+        off = OutputMasker(FPEEngine(KEY), mask_device_identity=False)
+        assert off.mask_result({"devid": self.SERIAL_VALUE})["devid"] == self.SERIAL_VALUE

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -767,6 +767,33 @@ class TestTargetDeviceIdentityConsistency:
         assert masked["target"][4]["value"] == masked["devid"]  # same identifier, same token
         assert DEV_SERIAL not in str(masked)
 
+    def test_a_real_shaped_serial_masks_with_the_sn_token_not_as_a_hostname(
+        self, full_masker: OutputMasker
+    ):
+        """TARGET_NAME_TYPES["device"] was IP_OR_HOST, which has no serial
+        branch: a real FortiGate-shaped serial masked as a lowercased
+        hostname token instead of the case-preserving serial one, breaking
+        correlation with the identical value under "sn" (masks reversibly
+        via SERIAL) and losing case on unmask. DEV_SERIAL above predates
+        this fix and does not have the real serial shape, so it never
+        exercised this branch -- this uses one that does."""
+        serial = "FGT60FTK20000001"
+        masked = full_masker.mask_result(
+            {"sn": serial, "target": [{"name": "device", "value": serial}]}
+        )
+        assert serial not in str(masked)
+        assert masked["target"][0]["value"] == masked["sn"]  # same identifier, same token
+        assert masked["sn"].startswith("sn-")
+
+    def test_an_endpoint_shaped_device_target_still_masks_as_a_hostname(
+        self, full_masker: OutputMasker
+    ):
+        """The polymorphic device slot must not regress the far more common
+        hostname/endpoint-name case while gaining serial detection."""
+        masked = full_masker.mask_result({"target": [{"name": "device", "value": ENDPOINT_NAME}]})
+        assert ENDPOINT_NAME not in str(masked)
+        assert masked["target"][0]["value"].startswith("host-")
+
 
 class TestUrlHostMasking:
     """``http_url``: the URL's HOST component masks in place; scheme, path

--- a/tests/test_masking_serial.py
+++ b/tests/test_masking_serial.py
@@ -1,0 +1,121 @@
+"""Device serials mask as their own type, not as hostnames (#40).
+
+The reason is a round-trip bug rather than taxonomy. The string alphabet is
+lowercase, so a serial masked as a hostname comes back lowercased and is no
+longer the serial. ``test_the_bug_this_type_exists_to_fix`` pins that, so if
+anyone ever proposes folding serial back into HOSTNAME the cost is stated in
+the suite rather than rediscovered.
+
+Serial keys live in ``DEVICE_IDENTITY_TYPES``, so they only mask when the
+identity flag is on. That flag is a CONSTRUCTOR ARGUMENT, not an environment
+variable read inside the masker, and every test here drives the real
+constructor. Each flag comparison carries ``devname`` as a control: it must
+change when the flag flips, or the comparison is measuring nothing.
+"""
+
+import pytest
+
+from fortianalyzer_mcp.masking.fields import DEVICE_IDENTITY_TYPES, SERIAL
+from fortianalyzer_mcp.masking.fpe_engine import FPEEngine
+from fortianalyzer_mcp.masking.wrapper import _TOKEN_PREFIX_SHAPE_RE, OutputMasker
+
+KEY = "2DE79D232DF5585D68CE47882AE256D6"
+
+#: Invented, but real in shape: a plain appliance serial and the hyphenated
+#: VM form. Both uppercase, which is the entire point -- the keep-check bug
+#: on #113 shipped because every test value was lowercase.
+PLAIN_SERIAL = "FGT60FTK20000001"
+VM_SERIAL = "FAZ-VMTM00000000"
+
+
+@pytest.fixture
+def engine() -> FPEEngine:
+    return FPEEngine(KEY)
+
+
+@pytest.fixture
+def masker(engine: FPEEngine, monkeypatch: pytest.MonkeyPatch) -> OutputMasker:
+    monkeypatch.setenv("FAZ_MASKING_KEY", KEY)
+    return OutputMasker(engine)
+
+
+@pytest.fixture
+def full_masker(engine: FPEEngine, monkeypatch: pytest.MonkeyPatch) -> OutputMasker:
+    monkeypatch.setenv("FAZ_MASKING_KEY", KEY)
+    return OutputMasker(engine, mask_device_identity=True)
+
+
+class TestTheReasonThisTypeExists:
+    def test_the_bug_this_type_exists_to_fix(self, engine: FPEEngine):
+        # Masked as a hostname, a serial round-trips to a DIFFERENT string.
+        # Not cosmetic: the value that comes back is not the serial, so it
+        # cannot be used to identify the appliance it came from.
+        for serial in (PLAIN_SERIAL, VM_SERIAL):
+            assert engine.unmask_hostname(engine.mask_hostname(serial)) != serial
+
+    def test_the_serial_type_round_trips_byte_exact(self, engine: FPEEngine):
+        for serial in (PLAIN_SERIAL, VM_SERIAL):
+            assert engine.unmask_serial(engine.mask_serial(serial)) == serial
+
+    def test_a_recased_serial_token_still_resolves(self, engine: FPEEngine):
+        # A model may title-case a token in prose. Every string type but
+        # username tolerates that, and serial has to as well or a re-cased
+        # token stops being recognised as ours and goes to the appliance
+        # as a literal.
+        token = engine.mask_serial(PLAIN_SERIAL)
+
+        assert engine.unmask_token(token.upper()) == PLAIN_SERIAL
+
+
+class TestTheFlagStillGatesIt:
+    def test_serials_stay_clear_with_the_flag_off(self, masker: OutputMasker):
+        record = {"devname": "FW-HQ-01", "sn": PLAIN_SERIAL, "serialno": VM_SERIAL}
+
+        out = masker.mask_result(dict(record))
+
+        assert out == record, "device identity must stay clear by default"
+
+    def test_serials_mask_with_the_flag_on(self, full_masker: OutputMasker):
+        record = {"devname": "FW-HQ-01", "sn": PLAIN_SERIAL, "serialno": VM_SERIAL}
+
+        out = full_masker.mask_result(dict(record))
+
+        # The control. If devname does not move, the flag did not take and
+        # the two assertions below prove nothing.
+        assert out["devname"] != record["devname"]
+        assert out["devname"].startswith("host-")
+
+        assert out["sn"].startswith("sn-")
+        assert out["serialno"].startswith("sn-")
+        assert PLAIN_SERIAL not in repr(out)
+        assert VM_SERIAL not in repr(out)
+
+    def test_the_masked_serial_round_trips_through_the_real_path(
+        self, engine: FPEEngine, full_masker: OutputMasker
+    ):
+        out = full_masker.mask_result({"sn": PLAIN_SERIAL, "serialno": VM_SERIAL})
+
+        assert engine.unmask_token(out["sn"]) == PLAIN_SERIAL
+        assert engine.unmask_token(out["serialno"]) == VM_SERIAL
+
+
+class TestTheTypeTable:
+    def test_every_serial_carrying_key_takes_the_serial_type(self):
+        # csf is deliberately excluded: the Security Fabric name is an
+        # operator label, not a serial.
+        assert DEVICE_IDENTITY_TYPES["sn"] == SERIAL
+        assert DEVICE_IDENTITY_TYPES["serialno"] == SERIAL
+        assert DEVICE_IDENTITY_TYPES["sndetected"] == SERIAL
+        assert DEVICE_IDENTITY_TYPES["snclosest"] == SERIAL
+        assert DEVICE_IDENTITY_TYPES["csf"] != SERIAL
+
+    def test_the_token_shape_recogniser_knows_sn_tokens(self, engine: FPEEngine):
+        # This regex is what the mutating-tool gate (#108) uses to tell a
+        # token from a legitimate value. If it does not know sn-, that gate
+        # silently stops covering serial tokens.
+        token = engine.mask_serial(PLAIN_SERIAL)
+
+        assert _TOKEN_PREFIX_SHAPE_RE.match(token)
+        # And it still does not mistake a plausible real name for a token:
+        # no 4-hex key-id group.
+        assert not _TOKEN_PREFIX_SHAPE_RE.match("sn-abc")

--- a/tests/test_masking_serial.py
+++ b/tests/test_masking_serial.py
@@ -103,11 +103,25 @@ class TestTheTypeTable:
     def test_every_serial_carrying_key_takes_the_serial_type(self):
         # csf is deliberately excluded: the Security Fabric name is an
         # operator label, not a serial.
-        assert DEVICE_IDENTITY_TYPES["sn"] == SERIAL
-        assert DEVICE_IDENTITY_TYPES["serialno"] == SERIAL
-        assert DEVICE_IDENTITY_TYPES["sndetected"] == SERIAL
-        assert DEVICE_IDENTITY_TYPES["snclosest"] == SERIAL
+        #
+        # detectkey is here because the first pass missed it. It was typed
+        # HOSTNAME while this very table's comment on it read "serial of the
+        # detecting appliance", so it kept the round-trip bug the type was
+        # added to fix. Matching on the sn- spelling was not enough.
+        for key in ("sn", "serialno", "sndetected", "snclosest", "detectkey"):
+            assert DEVICE_IDENTITY_TYPES[key] == SERIAL, key
         assert DEVICE_IDENTITY_TYPES["csf"] != SERIAL
+
+    # There is deliberately NO automated check that a key whose comment says
+    # "serial" is typed SERIAL, though detectkey is exactly the miss such a
+    # check would be for. One was written and thrown away: it reported devid,
+    # whose entry has no comment at all, because \s* matched a newline into
+    # the next entry's comment block; and once that was fixed it reported
+    # csf, whose comment reads "a label rather than a serial". Two runs, two
+    # fabricated findings. A grep over prose cannot tell an assertion from a
+    # negation, and a self-check that invents findings costs more than the
+    # one real miss it would have caught. Review caught detectkey; the
+    # explicit list above is what holds the line.
 
     def test_the_token_shape_recogniser_knows_sn_tokens(self, engine: FPEEngine):
         # This regex is what the mutating-tool gate (#108) uses to tell a

--- a/tests/test_masking_unmask.py
+++ b/tests/test_masking_unmask.py
@@ -699,3 +699,65 @@ class TestResolveNeverRaises:
 
         with pytest.raises(RuntimeError, match="orchestration failure"):
             unmasker.resolve_scalar(value)
+
+
+class TestBudgetExhaustionDoesNotDowngradeTheWriteRefusal:
+    """``contains_marked`` caught every ``MaskingError``, including the
+    one that is not a decrypt failure.
+
+    ``VerificationBudgetExhausted`` is its own type precisely so the
+    boundary can treat it differently: exhaustion means "we could not
+    check", and resolving part of a response and passing the rest through
+    as literals is the outcome this engine's own history calls worse than
+    refusing. Caught as an ordinary decrypt failure it fell to a shape
+    test instead, which answers a different question.
+
+    Measured before the fix: no live bypass, because the shape regex
+    alternation and ``V2_MARKERS`` happen to list the same seven markers.
+    That is the whole problem. Two independently maintained definitions
+    of "is this one of ours" agreeing today is the same structure that
+    produced three separate leaks in this repo, so the second test here
+    stops it being a coincidence.
+    """
+
+    def test_the_marker_set_and_the_shape_regex_cannot_diverge(self) -> None:
+        """The durable half. Any marker added to V2_MARKERS without the
+        regex learning it becomes a hole the moment a decrypt fails."""
+        from fortianalyzer_mcp.masking.fpe_engine import V2_MARKERS
+        from fortianalyzer_mcp.masking.wrapper import _TOKEN_PREFIX_SHAPE_RE
+
+        alternation = set(_TOKEN_PREFIX_SHAPE_RE.pattern.split("(?:")[1].split(")")[0].split("|"))
+        assert set(V2_MARKERS.values()) == alternation
+
+    @pytest.mark.asyncio
+    async def test_exhaustion_still_refuses_a_marked_write_argument(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The behavioural half, driven through the real boundary: a write
+        tool handed a marked token must be refused whether the tag check
+        ran or ran out."""
+        from mcp.server.mcpserver import MCPServer
+
+        from fortianalyzer_mcp.masking.fpe_engine import VerificationBudgetExhausted
+
+        monkeypatch.setenv("FAZ_MASKING_KEY", KEY)
+        mcp = MCPServer("test")
+        masker, _ = install_masking(mcp)
+        token = FPEEngine(KEY).mint("ip", "192.0.2.102")
+
+        called: dict[str, object] = {}
+
+        @mcp.tool()
+        async def fake_write(srcip: str) -> dict:
+            called["srcip"] = srcip
+            return {"ok": True}
+
+        def boom(_value: str) -> object:
+            raise VerificationBudgetExhausted("budget spent")
+
+        monkeypatch.setattr(masker._engine, "unmask_token", boom)
+
+        result = await fake_write(srcip=token)
+        assert "srcip" not in called, "the write body ran on a marked argument"
+        assert isinstance(result, dict)
+        assert result.get("status") == "error" or "refus" in str(result).lower()

--- a/tests/test_masking_unmask.py
+++ b/tests/test_masking_unmask.py
@@ -342,7 +342,11 @@ class TestRoundTrip:
             seen["srcip"] = srcip  # what the tool body (and validators) observe
             return {"logs": [{"srcip": srcip}]}
 
-        token = engine.mask_ip("192.0.2.102")
+        # Minted the way the server mints, so the assertion below is a real
+        # round trip rather than a comparison against a format nothing
+        # emits. A v1 bare address still resolves inbound, by field
+        # context, but it is not what comes back out any more.
+        token = engine.mint("ip", "192.0.2.102")
         result = await fake_search(srcip=token)
         assert seen["srcip"] == "192.0.2.102"  # unmasked before the body ran
         assert result["logs"][0]["srcip"] == token  # re-masked on the way out

--- a/tests/test_masking_v2_inbound_gate.py
+++ b/tests/test_masking_v2_inbound_gate.py
@@ -1,0 +1,140 @@
+"""Forgery refusal, wired to the paths a caller actually reaches.
+
+The v2 envelope was built as format only: ``is_v2_shaped`` and ``v2_open``
+existed and were tested, and nothing consulted them. So the property the
+whole design is for did not hold in the running server. A v2 token with a
+flipped tag is a byte-valid v1 token, because the tag is hex and a hyphen
+and both are inside the v1 alphabet, so the v1 path decrypted it happily
+to plausible garbage.
+
+Ordering IS the gate. A v2 hostname token also starts with ``host-``, so
+checking the shape after the prefix dispatch would never run. Both entry
+points therefore have to ask the shape question first:
+``FPEEngine.unmask_token`` and ``ArgUnmasker``, which delegates to it.
+
+Committed means committed: something v2-shaped is never retried on the v1
+path, whatever v2 says about it. Falling back would hand the forger the
+exact decrypt the gate exists to refuse.
+"""
+
+import pytest
+
+from fortianalyzer_mcp.masking.fpe_engine import FPEEngine, MaskingError
+from fortianalyzer_mcp.masking.unmask import ArgUnmasker
+
+KEY = "2DE79D232DF5585D68CE47882AE256D6"
+OTHER_KEY = "00112233445566778899AABBCCDDEEFF"
+
+
+@pytest.fixture
+def engine() -> FPEEngine:
+    return FPEEngine(KEY)
+
+
+@pytest.fixture
+def unmasker(engine: FPEEngine) -> ArgUnmasker:
+    return ArgUnmasker(engine)
+
+
+def _ct(token: str) -> str:
+    """Bare ciphertext out of a v1 ``<marker>-<kid>-<ct>`` token."""
+    return token.split("-", 2)[2]
+
+
+def _flip_tag(token: str) -> str:
+    return token[:-1] + ("0" if token[-1] != "0" else "1")
+
+
+class TestTheGateRunsBeforeThePrefixDispatch:
+    def test_a_v2_hostname_token_resolves_through_v2(self, engine: FPEEngine) -> None:
+        token = engine.v2_token("hostname", _ct(engine.mask_hostname("fw-hq-01")))
+
+        assert engine.unmask_token(token) == "fw-hq-01"
+
+    def test_a_forged_v2_token_is_refused_not_decrypted(self, engine: FPEEngine) -> None:
+        """The property the format was built for, at the boundary.
+
+        Before the gate this returned plausible garbage instead of
+        raising, because `host-` matched first.
+        """
+        forged = _flip_tag(engine.v2_token("hostname", _ct(engine.mask_hostname("fw-hq-01"))))
+
+        assert engine.is_v2_shaped(forged)
+        with pytest.raises(MaskingError):
+            engine.unmask_token(forged)
+
+    def test_a_token_minted_under_another_key_is_refused(self, engine: FPEEngine) -> None:
+        foreign = FPEEngine(OTHER_KEY)
+        token = foreign.v2_token("hostname", _ct(foreign.mask_hostname("fw-hq-01")))
+
+        with pytest.raises(MaskingError):
+            engine.unmask_token(token)
+
+    @pytest.mark.parametrize(
+        ("vtype", "value"),
+        [("ipv4", "192.0.2.9"), ("ipv6", "2001:db8::5"), ("mac", "54:01:81:74:f5:ef")],
+    )
+    def test_the_unmarked_types_now_resolve_too(
+        self, engine: FPEEngine, vtype: str, value: str
+    ) -> None:
+        """v1 IP and MAC tokens carry no marker, so unmask_token skipped
+        them and left resolution to field context. Their v2 forms DO carry
+        one, so the gate is also the first time these resolve by
+        self-identification."""
+        ct = engine.mask_mac(value) if vtype == "mac" else engine.mask_ip(value)
+
+        assert engine.unmask_token(engine.v2_token(vtype, ct)) == value
+
+
+class TestTheV1PathIsUntouched:
+    """The gate must only capture what is v2-shaped."""
+
+    def test_a_v1_hostname_token_still_resolves(self, engine: FPEEngine) -> None:
+        assert engine.unmask_token(engine.mask_hostname("fw-hq-01")) == "fw-hq-01"
+
+    def test_a_v1_username_keeps_its_case(self, engine: FPEEngine) -> None:
+        assert engine.unmask_token(engine.mask_username("Admin")) == "Admin"
+
+    def test_a_v1_domain_still_resolves(self, engine: FPEEngine) -> None:
+        assert engine.unmask_token(engine.mask_domain("example.com")) == "example.com"
+
+    @pytest.mark.parametrize(
+        "ordinary", ["host-fw01", "sn-abc", "user-admin", "host-2a85-plainct", "plain-value"]
+    )
+    def test_an_unshaped_value_is_not_committed_to_v2(
+        self, engine: FPEEngine, ordinary: str
+    ) -> None:
+        """Either it resolves on the v1 path or it returns None.
+
+        What it must never do is raise, because that would mean an
+        ordinary argument was captured by the gate.
+        """
+        assert not engine.is_v2_shaped(ordinary)
+        try:
+            engine.unmask_token(ordinary)
+        except MaskingError:
+            pass  # a v1 marker that fails to decrypt is the v1 path's own business
+
+
+class TestTheArgumentBoundary:
+    """ArgUnmasker delegates to unmask_token, so it inherits the gate.
+
+    Asserted rather than assumed: the delegation is one line today and a
+    future refactor that reintroduces a prefix check here would reopen the
+    hole silently.
+    """
+
+    def test_a_forged_token_in_an_argument_does_not_resolve_to_garbage(
+        self, engine: FPEEngine, unmasker: ArgUnmasker
+    ) -> None:
+        forged = _flip_tag(engine.v2_token("hostname", _ct(engine.mask_hostname("fw-hq-01"))))
+
+        with pytest.raises(MaskingError):
+            unmasker._unmask_marked(forged)
+
+    def test_a_genuine_token_in_an_argument_resolves(
+        self, engine: FPEEngine, unmasker: ArgUnmasker
+    ) -> None:
+        token = engine.v2_token("hostname", _ct(engine.mask_hostname("fw-hq-01")))
+
+        assert unmasker._unmask_marked(token) == "fw-hq-01"

--- a/tests/test_masking_v2_mint_and_window.py
+++ b/tests/test_masking_v2_mint_and_window.py
@@ -1,0 +1,164 @@
+"""The mint point and the v1 deprecation window.
+
+Two halves of the same switch. ``mint`` is where the emitted format is
+decided, in one place rather than at each of the seven primitives, and
+``accept_v1_tokens`` is how a deployment stops honouring the old format
+once nothing returns it any more.
+
+Nothing here changes what the server emits yet: the wrapper still calls
+the v1 primitives. This is the substrate under that change, tested on its
+own so the switch that follows is one wiring commit rather than a wiring
+commit plus a format commit.
+"""
+
+import logging
+
+import pytest
+
+from fortianalyzer_mcp.masking.fpe_engine import V2_MARKERS, FPEEngine, MaskingError
+
+KEY = "2DE79D232DF5585D68CE47882AE256D6"
+
+
+@pytest.fixture
+def engine() -> FPEEngine:
+    return FPEEngine(KEY)
+
+
+VALUES = {
+    "ipv4": "192.0.2.9",
+    "ipv6": "2001:db8::5",
+    "mac": "54:01:81:74:f5:ef",
+    "serial": "FGT60FTK20000001",
+    "hostname": "fw-hq-01",
+    "username": "Admin",
+    "url_tail": "/a/b?c=1",
+}
+
+
+class TestMint:
+    @pytest.mark.parametrize("vtype", sorted(VALUES))
+    def test_every_enveloped_type_mints_v2_and_round_trips(
+        self, engine: FPEEngine, vtype: str
+    ) -> None:
+        token = engine.mint(vtype, VALUES[vtype])
+
+        assert engine.is_v2_shaped(token), vtype
+        assert token.startswith(f"{V2_MARKERS[vtype]}-"), vtype
+        assert engine.v2_open(token) == VALUES[vtype], vtype
+
+    def test_mint_covers_exactly_the_enveloped_types(self, engine: FPEEngine) -> None:
+        """If a v2 marker is added later, this fails until mint knows it."""
+        assert set(VALUES) == set(V2_MARKERS)
+
+    def test_a_username_keeps_its_case_through_the_envelope(self, engine: FPEEngine) -> None:
+        assert engine.v2_open(engine.mint("username", "Admin")) == "Admin"
+
+    def test_minting_is_deterministic(self, engine: FPEEngine) -> None:
+        """The correlation property the whole layer exists for."""
+        assert engine.mint("ipv4", "192.0.2.9") == engine.mint("ipv4", "192.0.2.9")
+
+    @pytest.mark.parametrize("vtype", ["domain", "email_local"])
+    def test_the_suffix_marked_types_stay_v1_by_decision(
+        self, engine: FPEEngine, vtype: str
+    ) -> None:
+        """Not an omission. They are suffix-marked, so a v2 spelling is a
+        different parse rather than a different envelope, and #40 left
+        them for later."""
+        value = "example.com" if vtype == "domain" else "user@example.com"
+
+        token = engine.mint(vtype, value)
+
+        assert not engine.is_v2_shaped(token)
+        assert token.endswith(engine.mask_suffix)
+
+    def test_an_unknown_type_refuses_rather_than_returning_the_value(
+        self, engine: FPEEngine
+    ) -> None:
+        with pytest.raises(MaskingError):
+            engine.mint("not_a_type", "whatever")
+
+    def test_the_v1_primitives_are_untouched(self, engine: FPEEngine) -> None:
+        """Golden vectors shared with fortimanager-mcp pin these, so mint
+        must be additive rather than a change of format at the source."""
+        assert engine.mask_hostname("fw-hq-01").startswith("host-")
+        assert not engine.is_v2_shaped(engine.mask_hostname("fw-hq-01"))
+
+
+class TestTheDeprecationWindow:
+    def test_v1_resolves_while_the_window_is_open(self, engine: FPEEngine) -> None:
+        assert engine.unmask_token(engine.mask_hostname("fw-hq-01")) == "fw-hq-01"
+
+    def test_v1_is_refused_once_the_window_closes(self) -> None:
+        minting = FPEEngine(KEY)
+        closed = FPEEngine(KEY, accept_v1_tokens=False)
+
+        with pytest.raises(MaskingError, match="deprecation window is closed"):
+            closed.unmask_token(minting.mask_hostname("fw-hq-01"))
+
+    def test_the_suffix_forms_are_refused_too(self) -> None:
+        """domain and email are the forms that stay v1 the longest, so the
+        window has to reach them or closing it means nothing."""
+        minting = FPEEngine(KEY)
+        closed = FPEEngine(KEY, accept_v1_tokens=False)
+
+        with pytest.raises(MaskingError, match="deprecation window is closed"):
+            closed.unmask_token(minting.mask_domain("example.com"))
+
+    def test_a_direct_primitive_call_cannot_route_around_the_window(self) -> None:
+        """The reason the check sits on the key-id split.
+
+        ``ArgUnmasker`` resolves a URL tail by calling ``unmask_url_tail``
+        directly rather than going through ``unmask_token``, so a check on
+        the dispatch would miss it entirely.
+        """
+        minting = FPEEngine(KEY)
+        closed = FPEEngine(KEY, accept_v1_tokens=False)
+
+        with pytest.raises(MaskingError, match="deprecation window is closed"):
+            closed.unmask_url_tail(minting.mask_url_tail("/a/b?c=1"))
+
+    def test_v2_still_resolves_with_the_window_closed(self) -> None:
+        """Closing the window must retire v1, not masking."""
+        closed = FPEEngine(KEY, accept_v1_tokens=False)
+
+        assert closed.v2_open(closed.mint("hostname", "fw-hq-01")) == "fw-hq-01"
+        assert closed.unmask_token(closed.mint("hostname", "fw-hq-01")) == "fw-hq-01"
+
+    def test_the_unmarked_forms_are_unaffected(self) -> None:
+        """A masked IP carries no key id and is not a v1 *token*; it is a
+        value resolved by field context, so there is nothing to refuse and
+        refusing it would break resolution outright."""
+        closed = FPEEngine(KEY, accept_v1_tokens=False)
+
+        assert closed.unmask_ip(closed.mask_ip("192.0.2.9")) == "192.0.2.9"
+        assert closed.unmask_mac(closed.mask_mac("54:01:81:74:f5:ef")) == "54:01:81:74:f5:ef"
+
+    def test_the_open_window_says_so_once(
+        self, engine: FPEEngine, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The flag is only useful if an operator can tell when to close it.
+
+        Once at INFO rather than per token, because one response can carry
+        thousands and a per-token line would bury the signal it exists to
+        give.
+        """
+        with caplog.at_level(logging.INFO, logger="fortianalyzer_mcp.masking.fpe_engine"):
+            engine.unmask_token(engine.mask_hostname("fw-hq-01"))
+            engine.unmask_token(engine.mask_hostname("fw-hq-02"))
+
+        lines = [r for r in caplog.records if "deprecation window is open" in r.message]
+        assert len(lines) == 1
+
+    def test_the_log_line_carries_no_payload(
+        self, engine: FPEEngine, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Standing rule in this module: never log a value or a token."""
+        token = engine.mask_hostname("fw-hq-01")
+
+        with caplog.at_level(logging.DEBUG, logger="fortianalyzer_mcp.masking.fpe_engine"):
+            engine.unmask_token(token)
+
+        blob = " ".join(r.getMessage() for r in caplog.records)
+        assert "fw-hq-01" not in blob
+        assert token not in blob

--- a/tests/test_masking_v2_mint_and_window.py
+++ b/tests/test_masking_v2_mint_and_window.py
@@ -96,14 +96,33 @@ class TestTheDeprecationWindow:
         with pytest.raises(MaskingError, match="deprecation window is closed"):
             closed.unmask_token(minting.mask_hostname("fw-hq-01"))
 
-    def test_the_suffix_forms_are_refused_too(self) -> None:
-        """domain and email are the forms that stay v1 the longest, so the
-        window has to reach them or closing it means nothing."""
+    def test_the_suffix_forms_are_not_refused(self) -> None:
+        """This used to assert the opposite, and the reasoning was wrong.
+
+        It said domain and email "stay v1 the longest, so the window has to
+        reach them or closing it means nothing". They do not stay v1 the
+        longest -- they stay v1 permanently, because they have no v2
+        envelope by decision (#40). So the window reaching them did not make
+        closing it mean more, it made closing it impossible: the same engine
+        minted a domain token and then refused it, in one process with one
+        key. Closing the window broke domain and email masking outright.
+
+        The window retires an encoding that has a replacement. The suffix
+        form has none, so there is nothing to retire it to.
+
+        Asserted through ``unmask_token`` on purpose, which is the route the
+        old test used and the route production uses: ``ArgUnmasker``
+        resolves a marked token by calling ``unmask_token``, not the
+        primitive. Going straight to ``unmask_domain`` here would leave the
+        dispatch unguarded -- re-adding a window check on the suffix branch
+        of the dispatch passes the whole suite otherwise, while breaking
+        domain and email on the only path that matters.
+        """
         minting = FPEEngine(KEY)
         closed = FPEEngine(KEY, accept_v1_tokens=False)
 
-        with pytest.raises(MaskingError, match="deprecation window is closed"):
-            closed.unmask_token(minting.mask_domain("example.com"))
+        assert closed.unmask_token(minting.mask_domain("example.com")) == "example.com"
+        assert closed.unmask_token(minting.mask_email("alice@example.com")) == "alice@example.com"
 
     def test_a_direct_primitive_call_cannot_route_around_the_window(self) -> None:
         """The reason the check sits on the key-id split.
@@ -162,3 +181,69 @@ class TestTheDeprecationWindow:
         blob = " ".join(r.getMessage() for r in caplog.records)
         assert "fw-hq-01" not in blob
         assert token not in blob
+
+
+class TestClosingTheWindowDoesNotRefuseOurOwnOutput:
+    """Closing the window must not break the types that have no v2 form.
+
+    domain and email_local are suffix-marked and have no v2 envelope by
+    decision (#40). Their suffix token is therefore not a legacy encoding
+    waiting to be retired, it is the only encoding they have ever had.
+    Gating the suffix key-id split on the v1 window made this build refuse
+    a token it had just minted, which made the window unclosable: closing
+    it broke domain and email masking outright.
+    """
+
+    @pytest.fixture
+    def closed(self) -> FPEEngine:
+        return FPEEngine(KEY, accept_v1_tokens=False)
+
+    def test_a_domain_round_trips_with_the_window_closed(self, closed: FPEEngine) -> None:
+        token = closed.mask_domain("corp.example.com")
+        assert closed.unmask_domain(token) == "corp.example.com"
+
+    def test_an_email_round_trips_with_the_window_closed(self, closed: FPEEngine) -> None:
+        token = closed.mask_email("alice@corp.example.com")
+        assert closed.unmask_email(token) == "alice@corp.example.com"
+
+    @pytest.mark.parametrize("vtype", ["domain", "email_local"])
+    def test_mint_and_resolve_agree_with_the_window_closed(
+        self, closed: FPEEngine, vtype: str
+    ) -> None:
+        """The self-consistency the old behaviour broke: whatever mint emits,
+        this same engine must be able to read back."""
+        value = "example.com" if vtype == "domain" else "user@example.com"
+        token = closed.mint(vtype, value)
+
+        if vtype == "domain":
+            assert closed.unmask_domain(token) == value
+        else:
+            assert closed.unmask_email(token) == value
+
+    def test_a_prefix_form_v1_token_is_still_refused(self, closed: FPEEngine) -> None:
+        """The exemption is scoped to the suffix form. The prefix forms do
+        have a v2 envelope, so their v1 spelling is genuinely legacy and
+        closing the window still has to refuse it."""
+        open_engine = FPEEngine(KEY, accept_v1_tokens=True)
+        v1_hostname = open_engine.mask_hostname("fw01")
+
+        with pytest.raises(MaskingError, match="deprecation window is closed"):
+            closed.unmask_hostname(v1_hostname)
+
+    def test_the_exemption_is_not_a_blanket_off_switch(self, closed: FPEEngine) -> None:
+        """Guards against 'fixing' this by disabling the window everywhere.
+
+        Asserts behaviour rather than the constructor flag. Reading
+        ``_accept_v1_tokens`` proved nothing: exempting the prefix split as
+        well leaves the flag False and the attribute assertion green while
+        the window stops refusing anything at all.
+        """
+        minting = FPEEngine(KEY)
+
+        for v1_token in (
+            minting.mask_hostname("fw01"),
+            minting.mask_username("admin"),
+            minting.mask_url_tail("/a/b?c=1"),
+        ):
+            with pytest.raises(MaskingError, match="deprecation window is closed"):
+                closed.unmask_token(v1_token)

--- a/tests/test_masking_v2_pass1_passthrough.py
+++ b/tests/test_masking_v2_pass1_passthrough.py
@@ -125,17 +125,19 @@ class TestRealValuesStillMask:
         assert out["dstip"] != "198.51.100.99"
 
     def test_masking_a_response_twice_is_now_a_fixed_point(self, masker: OutputMasker) -> None:
-        """The property the whole item buys, once minting is v2.
+        """The property the whole item buys, now that minting is v2.
 
-        Not true today for the v1 tokens this still produces, so it is
-        asserted on the structured route only, where the second pass sees
-        whatever the first pass emitted.
+        This assertion was inverted until the emission switch landed, and
+        deliberately so: while the wrapper still minted v1, a masked IP was
+        an ordinary valid IP with no envelope, so a second pass could not
+        tell it from a real one and masked it again. Nothing about the
+        second pass changed. The envelope did, and that is the whole point
+        of it.
         """
         once = masker.mask_result({"srcip": "198.51.100.99"})
-        # A v1 token is not v2-shaped, so this documents current behaviour
-        # rather than asserting idempotence the format cannot yet give.
         twice = masker.mask_result(once)
-        assert twice["srcip"] != once["srcip"]
+
+        assert twice["srcip"] == once["srcip"]
 
 
 class TestV1TokensAreNotSkipped:

--- a/tests/test_masking_v2_pass1_passthrough.py
+++ b/tests/test_masking_v2_pass1_passthrough.py
@@ -1,0 +1,157 @@
+"""Pass 1 must not re-mask a token it already minted.
+
+The other half of the hazard the free-text guard closed, on the structured
+route rather than the prose one. A v2 token arriving in a typed field is
+this layer's own output, and masking it again destroys it:
+
+* an IP-typed field cannot parse a token as an address, so it fails closed
+  to an irreversible placeholder and the value is gone for good
+* a hostname-typed field CAN encrypt the token as a string, so it comes
+  back as a token of a token, which opens to the wrong thing
+
+Both are silent. Neither is reachable from a tool today, because nothing
+in the server mints v2 yet, and both become near-certain the moment it
+does. That is exactly why this goes in before the mint switch rather than
+after it.
+
+The check is by shape, matching the gate decision from #40: a value that
+looks like v2 is committed to v2. Verifying the tag instead would be a
+third definition of v2-ness in the codebase, and two definitions drifting
+apart has already produced one leak here.
+"""
+
+import pytest
+
+from fortianalyzer_mcp.masking.fpe_engine import FPEEngine
+from fortianalyzer_mcp.masking.wrapper import OutputMasker
+
+KEY = "2DE79D232DF5585D68CE47882AE256D6"
+
+
+@pytest.fixture
+def engine() -> FPEEngine:
+    return FPEEngine(KEY)
+
+
+@pytest.fixture
+def masker(engine: FPEEngine) -> OutputMasker:
+    return OutputMasker(engine)
+
+
+def _ct(token: str) -> str:
+    """Bare ciphertext out of a v1 ``<marker>-<kid>-<ct>`` token.
+
+    The string types come out of the engine already wrapped in a v1
+    envelope, and ``v2_token`` takes a bare ciphertext. Passing the whole
+    v1 token as the payload builds a token that opens to garbage, which is
+    what my first draft of this file did. Split from the LEFT, because a
+    ciphertext legitimately contains hyphens.
+    """
+    return token.split("-", 2)[2]
+
+
+class TestATypedFieldLeavesItsOwnTokenAlone:
+    def test_an_ip_field_does_not_placeholder_a_v2_token(
+        self, engine: FPEEngine, masker: OutputMasker
+    ) -> None:
+        """The destructive case: a token cannot parse as an address.
+
+        Measured before the fix: srcip came back as
+        ``masked-unrepresentable-…`` and the address was unrecoverable.
+        """
+        token = engine.v2_token("ipv4", engine.mask_ip("192.0.2.9"))
+
+        out = masker.mask_result({"srcip": token})
+
+        assert out["srcip"] == token
+        assert engine.v2_open(out["srcip"]) == "192.0.2.9"
+
+    def test_a_hostname_field_does_not_wrap_a_token_in_a_token(
+        self, engine: FPEEngine, masker: OutputMasker
+    ) -> None:
+        """The quieter case: a string cipher will happily encrypt a token.
+
+        No placeholder, no error, and the value still opens -- to the wrong
+        thing. Worse than the loud failure because nothing looks wrong.
+        """
+        token = engine.v2_token("hostname", _ct(engine.mask_hostname("fw-hq-01")))
+
+        out = masker.mask_result({"hostname": token})
+
+        assert out["hostname"] == token
+        assert engine.v2_open(out["hostname"]) == "fw-hq-01"
+
+    @pytest.mark.parametrize(
+        ("field", "vtype", "value"),
+        [
+            ("srcip", "ipv4", "192.0.2.9"),
+            ("dstip", "ipv4", "198.51.100.4"),
+            ("mac", "mac", "54:01:81:74:f5:ef"),
+        ],
+    )
+    def test_every_typed_route_funnels_through_the_same_check(
+        self, engine: FPEEngine, masker: OutputMasker, field: str, vtype: str, value: str
+    ) -> None:
+        ct = engine.mask_mac(value) if vtype == "mac" else engine.mask_ip(value)
+        token = engine.v2_token(vtype, ct)
+
+        out = masker.mask_result({field: token})
+
+        assert out[field] == token, field
+
+    def test_nesting_does_not_bypass_it(self, engine: FPEEngine, masker: OutputMasker) -> None:
+        token = engine.v2_token("ipv4", engine.mask_ip("203.0.113.7"))
+
+        out = masker.mask_result({"data": [{"srcip": token}]})
+
+        assert out["data"][0]["srcip"] == token
+
+
+class TestRealValuesStillMask:
+    """Skipping our own output must not switch masking off."""
+
+    def test_a_real_address_in_the_same_field_still_masks(self, masker: OutputMasker) -> None:
+        out = masker.mask_result({"srcip": "198.51.100.99"})
+        assert out["srcip"] != "198.51.100.99"
+
+    def test_a_token_and_a_real_value_side_by_side(
+        self, engine: FPEEngine, masker: OutputMasker
+    ) -> None:
+        token = engine.v2_token("ipv4", engine.mask_ip("192.0.2.9"))
+
+        out = masker.mask_result({"srcip": token, "dstip": "198.51.100.99"})
+
+        assert out["srcip"] == token
+        assert out["dstip"] != "198.51.100.99"
+
+    def test_masking_a_response_twice_is_now_a_fixed_point(self, masker: OutputMasker) -> None:
+        """The property the whole item buys, once minting is v2.
+
+        Not true today for the v1 tokens this still produces, so it is
+        asserted on the structured route only, where the second pass sees
+        whatever the first pass emitted.
+        """
+        once = masker.mask_result({"srcip": "198.51.100.99"})
+        # A v1 token is not v2-shaped, so this documents current behaviour
+        # rather than asserting idempotence the format cannot yet give.
+        twice = masker.mask_result(once)
+        assert twice["srcip"] != once["srcip"]
+
+
+class TestV1TokensAreNotSkipped:
+    """Same scope decision as the free-text guard, asserted not assumed.
+
+    v1 is being retired and the shape gate is what separates the two. A
+    v1 token reaching a typed field is still re-masked, and whoever closes
+    the deprecation window should find this failing rather than inherit it
+    silently.
+    """
+
+    def test_a_v1_token_in_a_typed_field_is_still_remasked(
+        self, engine: FPEEngine, masker: OutputMasker
+    ) -> None:
+        v1 = f"ip4-{engine.key_id}-{engine.mask_ip('192.0.2.9')}"
+
+        out = masker.mask_result({"srcip": v1})
+
+        assert out["srcip"] != v1

--- a/tests/test_masking_v2_text_passthrough.py
+++ b/tests/test_masking_v2_text_passthrough.py
@@ -190,14 +190,19 @@ class TestTheGuardDoesNotOverMatch:
         out = masker.mask_text("ip4-2a85-\n10.0.0.1-deadbeef", {})
         assert "10.0.0.1" not in out
 
-    def test_the_guard_agrees_with_the_shape_gate_on_whole_strings(
+    def test_the_guard_protects_exactly_what_this_engine_minted(
         self, engine: FPEEngine, masker: OutputMasker
     ) -> None:
-        """The invariant that actually matters.
+        """The invariant that actually matters, corrected.
 
-        Two definitions of "looks like v2" drifting apart is the bug class
-        this project keeps hitting. For a whole string, the guard must
-        protect exactly what `is_v2_shaped` would commit to v2.
+        This test used to assert the guard agreed with ``is_v2_shaped``,
+        and in doing so it pinned the very conflation that leaked twice:
+        shape is the inbound question, ownership is the outbound one. A
+        string can be shaped and not ours, and the last case below is
+        exactly that, so the old assertion demanded the leak.
+
+        Note it passed while the guard was wrong, because both sides of
+        the comparison were the same mistaken notion.
         """
         cases = [
             _v2_ipv4(engine, "192.0.2.9"),
@@ -207,7 +212,7 @@ class TestTheGuardDoesNotOverMatch:
         ]
         for case in cases:
             protected = masker.mask_text(case, {}) == case
-            assert protected == engine.is_v2_shaped(case), case
+            assert protected == engine.is_own_v2_token(case), case
 
 
 class TestTheGuardStaysLinear:
@@ -236,3 +241,70 @@ class TestTheGuardStaysLinear:
         # The bound is here to catch a return to quadratic, not to police
         # cipher throughput on a slow runner.
         assert elapsed < 1.5, f"{elapsed:.2f}s for 4000 addresses looks quadratic again"
+
+
+class TestShapeIsNotOwnership:
+    """The root cause of three leaks in this cutover, pinned.
+
+    Two questions were being conflated. "Does this LOOK like a v2
+    envelope" is the right question inbound, where a shaped token must be
+    committed to v2 rather than retried on v1. Outbound it is the wrong
+    question, because a real value can be shaped like a token and the
+    shape regex accepts any key id, not only ours.
+
+    Every skip on the output side now asks ``is_own_v2_token``, which adds
+    the key id and the tag. These cases all leaked before that change.
+    """
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            "host-ab12-web-01-cafe0123",
+            "user-1234-svc-deadbeef",
+            "sn-0000-FGT60F-12345678",
+        ],
+    )
+    def test_a_real_value_shaped_like_a_token_is_still_masked(
+        self, masker: OutputMasker, engine: FPEEngine, value: str
+    ) -> None:
+        assert engine.is_v2_shaped(value)  # shaped...
+        assert not engine.is_own_v2_token(value)  # ...but not ours
+        assert masker.mask_result({"hostname": value})["hostname"] != value
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "my-host-2a85-10.0.0.1-deadbeef",
+            "src_ip4-2a85-10.0.0.1-deadbeef",
+            "sub.host-2a85-10.0.0.1-deadbeef",
+            "ip4-2a85-10.0.0.1-deadbeefzz",
+            "ip4-2a85-10.0.0.1-deadbeef-cafe",
+        ],
+    )
+    def test_a_near_envelope_in_prose_does_not_shelter_an_address(
+        self, masker: OutputMasker, text: str
+    ) -> None:
+        """The boundary cases that made the old positional guard laxer
+        than the shape predicate. They no longer decide anything: they
+        only widen the candidate, and the tag settles it."""
+        assert "10.0.0.1" not in masker.mask_text(text, {})
+
+    def test_a_foreign_key_id_is_not_ours(self, engine: FPEEngine) -> None:
+        """The shape regex takes any four hex, so a token minted under
+        another key is shaped but must never be treated as our output."""
+        foreign = FPEEngine("00112233445566778899AABBCCDDEEFF")
+        token = foreign.mint("ipv4", "192.0.2.9")
+
+        assert engine.is_v2_shaped(token)
+        assert not engine.is_own_v2_token(token)
+
+    def test_our_own_token_is_recognised_everywhere(
+        self, masker: OutputMasker, engine: FPEEngine
+    ) -> None:
+        """The other direction: the tightened check must not start
+        re-masking real output on any route."""
+        token = engine.mint("ipv4", "192.0.2.9")
+
+        assert engine.is_own_v2_token(token)
+        assert masker.mask_text(token, {}) == token
+        assert masker.mask_result({"srcip": token})["srcip"] == token

--- a/tests/test_masking_v2_text_passthrough.py
+++ b/tests/test_masking_v2_text_passthrough.py
@@ -1,0 +1,238 @@
+"""The free-text scan must not chew on tokens it already minted.
+
+``mask_text`` runs the IOC scan over prose: every dotted quad becomes a
+masked IPv4, every MAC becomes a masked MAC. A v2 IPv4 token carries its
+ciphertext as a **dotted quad**, so the scan matches the address *inside*
+the token and re-encrypts it. The envelope survives, the payload does
+not, and the tag no longer verifies the payload beside it, so the token
+is destroyed rather than merely double-masked.
+
+IPv6 and MAC v2 payloads went colon-free hex on #40, which is what makes
+them invisible to this scan. IPv4 stayed dotted because a masked IPv4 has
+to remain a valid IPv4, so it is the one type exposed. That asymmetry is
+the whole reason this file exists.
+
+Same class as the ``_AT_BOUNDARY`` re-entrancy work: a layer that reads
+its own output has to recognise it.
+"""
+
+import pytest
+
+from fortianalyzer_mcp.masking.fpe_engine import FPEEngine
+from fortianalyzer_mcp.masking.wrapper import OutputMasker
+
+KEY = "2DE79D232DF5585D68CE47882AE256D6"
+
+
+@pytest.fixture
+def engine() -> FPEEngine:
+    return FPEEngine(KEY)
+
+
+@pytest.fixture
+def masker(engine: FPEEngine) -> OutputMasker:
+    return OutputMasker(engine)
+
+
+def _v2_ipv4(engine: FPEEngine, address: str = "192.0.2.9") -> str:
+    return engine.v2_token("ipv4", engine.mask_ip(address))
+
+
+class TestAV2TokenSurvivesTheFreeTextScan:
+    def test_a_bare_v2_ipv4_token_is_left_alone(
+        self, engine: FPEEngine, masker: OutputMasker
+    ) -> None:
+        token = _v2_ipv4(engine)
+
+        out = masker.mask_text(token, {})
+
+        assert out == token
+        assert engine.v2_open(out) == "192.0.2.9"
+
+    def test_a_v2_token_embedded_in_prose_is_left_alone(
+        self, engine: FPEEngine, masker: OutputMasker
+    ) -> None:
+        """The shape a log line actually has."""
+        token = _v2_ipv4(engine, "198.51.100.23")
+
+        out = masker.mask_text(f"denied traffic from {token} to port 443", {})
+
+        assert token in out
+        embedded = out.split("from ")[1].split(" to")[0]
+        assert engine.v2_open(embedded) == "198.51.100.23"
+
+    def test_a_real_address_beside_a_token_still_gets_masked(
+        self, engine: FPEEngine, masker: OutputMasker
+    ) -> None:
+        """Skipping tokens must not switch the scan off for real values."""
+        token = _v2_ipv4(engine, "203.0.113.7")
+
+        out = masker.mask_text(f"{token} talked to 198.51.100.99", {})
+
+        assert token in out
+        assert "198.51.100.99" not in out
+
+    @pytest.mark.parametrize("vtype,value", [("ipv6", "2001:db8::5"), ("mac", "54:01:81:74:f5:ef")])
+    def test_the_hex_payload_types_were_already_safe(
+        self, engine: FPEEngine, masker: OutputMasker, vtype: str, value: str
+    ) -> None:
+        """Pins WHY ipv4 is the exposed one, so the reason is not lost.
+
+        These pass before the fix. They are here so that a later change
+        making an IPv6 or MAC payload colon-bearing again fails loudly
+        rather than silently reopening this hole for two more types.
+        """
+        ct = engine.mask_ip(value) if vtype == "ipv6" else engine.mask_mac(value)
+        token = engine.v2_token(vtype, ct)
+
+        out = masker.mask_text(f"saw {token} on the wire", {})
+
+        assert token in out
+        assert engine.v2_open(token) == value
+
+
+class TestTheTokenIsDestroyedNotJustDoubleMasked:
+    def test_the_tag_no_longer_verifies_after_a_rescan(
+        self, engine: FPEEngine, masker: OutputMasker
+    ) -> None:
+        """Names the actual damage, so nobody reads this as cosmetic.
+
+        Re-encrypting the payload leaves the tag bound to the payload that
+        was there before, so the token stops opening at all. The original
+        address is not recoverable from it by anyone, including us.
+        """
+        token = _v2_ipv4(engine, "192.0.2.42")
+
+        out = masker.mask_text(token, {})
+
+        assert engine.v2_open(out) == "192.0.2.42"
+
+    def test_the_token_survives_repeated_scans(
+        self, engine: FPEEngine, masker: OutputMasker
+    ) -> None:
+        """A response can carry the same text through more than one path.
+
+        Scoped to the token on purpose. The first draft asserted the whole
+        string was a fixed point and failed against correct code, because
+        the bare address beside the token is NOT stable: pass 1 masks it
+        into a valid-looking IPv4, and a later scan masks that again, since
+        a masked IPv4 with no envelope around it cannot be told from a real
+        one. That is inherent to v1 and is the argument for v2 envelopes,
+        not a defect this guard should paper over. Kept as a note because
+        the difference between "the token is stable" and "the text is
+        stable" is exactly what v2 buys.
+        """
+        token = _v2_ipv4(engine, "192.0.2.11")
+        text = f"src {token} dst 198.51.100.4"
+
+        once = masker.mask_text(text, {})
+        twice = masker.mask_text(once, {})
+
+        assert token in once
+        assert token in twice
+        assert engine.v2_open(token) == "192.0.2.11"
+
+
+class TestV1TokensAreNotProtectedByThis:
+    """Scope marker, deliberately asserting the current behaviour.
+
+    A v1 IPv4 token is also a dotted quad in an envelope, so the scan
+    chews it the same way. That is not fixed here: the v1 path is being
+    retired, the shape gate is what tells the two apart, and widening
+    this to v1 would change behaviour during the deprecation window
+    rather than only protecting the new format.
+
+    Written as a test rather than a comment so that whoever closes the
+    window finds a failing assertion pointing at this decision instead of
+    silently inheriting it.
+    """
+
+    def test_a_v1_ipv4_token_is_still_rewritten(
+        self, engine: FPEEngine, masker: OutputMasker
+    ) -> None:
+        v1 = f"ip4-{engine.key_id}-{engine.mask_ip('192.0.2.9')}"
+
+        out = masker.mask_text(v1, {})
+
+        assert out != v1
+
+
+class TestTheGuardDoesNotOverMatch:
+    """Over-matching here is a leak, so it is worse than under-matching.
+
+    The first version of the guard anchored the envelope head with `$` and
+    searched an unbounded prefix, with no boundary on the left. Both ends
+    of that were wrong, and an adversarial pass measured all of it.
+    """
+
+    @pytest.mark.parametrize(
+        "prefix",
+        ["myhost", "localhost", "poweruser", "gossip4", "tarmac", "unsn"],
+    )
+    def test_a_word_merely_ending_in_a_marker_is_not_an_envelope(
+        self, masker: OutputMasker, prefix: str
+    ) -> None:
+        """`myhost-` ends with `host-`, and a bare `search` accepted that.
+
+        Measured leak before the fix: `myhost-1234-10.0.0.1-deadbeef` came
+        back verbatim with the address in clear.
+        """
+        out = masker.mask_text(f"{prefix}-1234-10.0.0.1-deadbeef", {})
+        assert "10.0.0.1" not in out
+
+    def test_a_newline_does_not_terminate_the_envelope_head(self, masker: OutputMasker) -> None:
+        """Python's `$` also matches just before a trailing newline.
+
+        A genuine token can never contain one, so this was pure
+        over-match. Measured: the LF form leaked, the CRLF form did not,
+        which is exactly the signature of `$` rather than `\\Z`.
+        """
+        out = masker.mask_text("ip4-2a85-\n10.0.0.1-deadbeef", {})
+        assert "10.0.0.1" not in out
+
+    def test_the_guard_agrees_with_the_shape_gate_on_whole_strings(
+        self, engine: FPEEngine, masker: OutputMasker
+    ) -> None:
+        """The invariant that actually matters.
+
+        Two definitions of "looks like v2" drifting apart is the bug class
+        this project keeps hitting. For a whole string, the guard must
+        protect exactly what `is_v2_shaped` would commit to v2.
+        """
+        cases = [
+            _v2_ipv4(engine, "192.0.2.9"),
+            "myhost-1234-10.0.0.1-deadbeef",
+            "localhost-cafe-10.0.0.1-deadbeef",
+            "ip4-2a85-10.0.0.1-deadbeef",
+        ]
+        for case in cases:
+            protected = masker.mask_text(case, {}) == case
+            assert protected == engine.is_v2_shaped(case), case
+
+
+class TestTheGuardStaysLinear:
+    """The guard runs per IPv4 match; it must not read the whole string.
+
+    Slicing `text[:start]` and `text[end:]` copies the input on every
+    match, so a quad-dense log line went quadratic: measured 3.5 s for
+    4000 addresses, with per-match cost doubling on every doubling of n.
+    Free text is attacker-supplied, so that is a remote CPU-exhaustion
+    primitive rather than a tuning matter.
+
+    The envelope head is at most ten characters, so the check needs a
+    bounded window, never the whole prefix.
+    """
+
+    def test_a_quad_dense_line_does_not_blow_up(self, masker: OutputMasker) -> None:
+        import time
+
+        text = " ".join(f"10.0.{i // 256}.{i % 256}" for i in range(4000))
+
+        start = time.perf_counter()
+        masker.mask_text(text, {})
+        elapsed = time.perf_counter() - start
+
+        # Generous: measured ~3.5s quadratic before, well under 0.2s after.
+        # The bound is here to catch a return to quadratic, not to police
+        # cipher throughput on a slow runner.
+        assert elapsed < 1.5, f"{elapsed:.2f}s for 4000 addresses looks quadratic again"

--- a/tests/test_masking_v2_verify_budget.py
+++ b/tests/test_masking_v2_verify_budget.py
@@ -1,0 +1,135 @@
+"""The per-call verification budget and the forgery alarm.
+
+The 32-bit tag is one in 4.3 billion per blind guess, which only sounds
+sufficient until the unit is counted properly. The bound is per
+VERIFICATION, not per call, and one call can carry thousands of tokens: a
+``filters`` list with 5000 entries resolves 5000 of them independently.
+At that density 2**31 expected verifications is on the order of 10**5
+calls rather than 10**9, so an online grind is a day of traffic rather
+than a geological era.
+
+Capping the count per call is what restores the exponent, and it costs
+nothing legitimate because no real call comes near the cap. The tag width
+was argued on #40 on the explicit basis that this would exist, so these
+tests are what makes that argument true rather than intended.
+"""
+
+import logging
+
+import pytest
+
+from fortianalyzer_mcp.masking.fpe_engine import (
+    V2_FAILURE_ALARM,
+    V2_VERIFY_BUDGET,
+    FPEEngine,
+    MaskingError,
+    begin_v2_verification_budget,
+)
+
+KEY = "2DE79D232DF5585D68CE47882AE256D6"
+
+
+@pytest.fixture
+def engine() -> FPEEngine:
+    return FPEEngine(KEY)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_budget() -> None:
+    begin_v2_verification_budget()
+
+
+class TestTheBudget:
+    def test_a_normal_call_never_notices_it(self, engine: FPEEngine) -> None:
+        token = engine.mint("ipv4", "192.0.2.9")
+        for _ in range(100):
+            assert engine.v2_open(token) == "192.0.2.9"
+
+    def test_the_budget_is_spent_by_verifications_not_successes(self, engine: FPEEngine) -> None:
+        """A grind pays for attempts. Counting only successes would let a
+        forger try for free, which is the opposite of the point."""
+        forged = engine.mint("ipv4", "192.0.2.9")[:-1] + "0"
+
+        for _ in range(V2_VERIFY_BUDGET):
+            with pytest.raises(MaskingError):
+                engine.v2_open(forged)
+
+        with pytest.raises(MaskingError, match="budget for this call is exhausted"):
+            engine.v2_open(forged)
+
+    def test_a_genuine_token_is_refused_once_the_budget_is_gone(self, engine: FPEEngine) -> None:
+        """Fails closed. Past the cap nothing resolves, valid or not."""
+        token = engine.mint("ipv4", "192.0.2.9")
+        for _ in range(V2_VERIFY_BUDGET):
+            engine.v2_open(token)
+
+        with pytest.raises(MaskingError, match="budget for this call is exhausted"):
+            engine.v2_open(token)
+
+    def test_the_budget_resets_per_call(self, engine: FPEEngine) -> None:
+        """Otherwise the cap is a process lifetime limit, and a long-lived
+        server stops resolving anything after one busy call."""
+        token = engine.mint("ipv4", "192.0.2.9")
+        for _ in range(V2_VERIFY_BUDGET):
+            engine.v2_open(token)
+
+        begin_v2_verification_budget()
+
+        assert engine.v2_open(token) == "192.0.2.9"
+
+    def test_exhaustion_is_reported_once_not_per_token(
+        self, engine: FPEEngine, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        token = engine.mint("ipv4", "192.0.2.9")
+        for _ in range(V2_VERIFY_BUDGET):
+            engine.v2_open(token)
+
+        with caplog.at_level(logging.ERROR, logger="fortianalyzer_mcp.masking.fpe_engine"):
+            for _ in range(5):
+                with pytest.raises(MaskingError):
+                    engine.v2_open(token)
+
+        assert len([r for r in caplog.records if "budget" in r.message]) == 1
+
+
+class TestTheForgeryAlarm:
+    def test_repeated_failures_escalate_to_an_alarm(
+        self, engine: FPEEngine, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """One failure is a corrupted token echoed back. Several in a
+        single call is someone trying tags, and the two should not read
+        the same in a log."""
+        forged = engine.mint("hostname", "fw-hq-01")[:-1] + "0"
+
+        with caplog.at_level(logging.WARNING, logger="fortianalyzer_mcp.masking.fpe_engine"):
+            for _ in range(V2_FAILURE_ALARM):
+                with pytest.raises(MaskingError):
+                    engine.v2_open(forged)
+
+        assert any(r.levelno == logging.ERROR and "forgery" in r.message for r in caplog.records)
+
+    def test_a_single_failure_does_not_raise_the_alarm(
+        self, engine: FPEEngine, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        forged = engine.mint("hostname", "fw-hq-01")[:-1] + "0"
+
+        with caplog.at_level(logging.WARNING, logger="fortianalyzer_mcp.masking.fpe_engine"):
+            with pytest.raises(MaskingError):
+                engine.v2_open(forged)
+
+        assert not [r for r in caplog.records if r.levelno == logging.ERROR]
+
+    def test_no_token_or_value_reaches_the_log(
+        self, engine: FPEEngine, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Attacker-influenced text, and the standing rule of this module."""
+        forged = engine.mint("hostname", "fw-hq-01")[:-1] + "0"
+
+        with caplog.at_level(logging.DEBUG, logger="fortianalyzer_mcp.masking.fpe_engine"):
+            for _ in range(V2_FAILURE_ALARM):
+                with pytest.raises(MaskingError):
+                    engine.v2_open(forged)
+
+        blob = " ".join(r.getMessage() for r in caplog.records)
+        assert forged not in blob
+        assert "fw-hq-01" not in blob

--- a/tests/test_masking_wrapper.py
+++ b/tests/test_masking_wrapper.py
@@ -5,9 +5,6 @@ duality, list-valued fields, free-text IOC scanning, response echo keys,
 fail-closed placeholders, and the mcp.tool registration patch.
 """
 
-import ipaddress
-import re
-
 import pytest
 
 from fortianalyzer_mcp.masking.fields import DOMAIN, EMAIL, FIELD_TYPES, TEXT
@@ -102,19 +99,22 @@ class TestStructureWalk:
         assert masked["logs"][0]["action"] == "deny"
         assert masked["logs"][0]["bytes"] == 42
         assert masked["logs"][0]["srcip"] != "192.0.2.102"
-        ipaddress.IPv4Address(masked["logs"][0]["srcip"])
-        assert engine.unmask_ip(masked["logs"][0]["srcip"]) == "192.0.2.102"
+        # A masked IPv4 used to BE an IPv4. Under the v2 envelope it is a
+        # marked token whose payload is one, which is what lets the layer
+        # recognise its own output instead of re-masking it.
+        assert engine.is_v2_shaped(masked["logs"][0]["srcip"])
+        assert engine.unmask_token(masked["logs"][0]["srcip"]) == "192.0.2.102"
         assert masked["logs"][0]["user"].startswith("user-")
         assert masked["logs"][1]["srcmac"] != "00:1a:2b:3c:4d:5e"
         assert masked["nested"]["event_details"]["src_ip"] != "192.0.2.7"
         assert masked["nested"]["event_details"]["host_name"].startswith("host-")
 
-    def test_list_valued_ip_field(self, masker: OutputMasker):
+    def test_list_valued_ip_field(self, masker: OutputMasker, engine: FPEEngine):
         masked = masker.mask_result({"ipaddr": ["192.0.2.1", "192.0.2.2"]})
         assert len(masked["ipaddr"]) == 2
-        for item in masked["ipaddr"]:
-            assert item not in ("192.0.2.1", "192.0.2.2")
-            ipaddress.IPv4Address(item)
+        for item, original in zip(masked["ipaddr"], ("192.0.2.1", "192.0.2.2"), strict=True):
+            assert item != original
+            assert engine.v2_open(item) == original
 
     def test_comma_joined_ip_string(self, masker: OutputMasker, engine: FPEEngine):
         # Live FAZ packs dns answers into one comma-joined string.
@@ -122,8 +122,8 @@ class TestStructureWalk:
         parts = masked["ipaddr"].split(",")
         assert len(parts) == 3
         assert "192.0.2.1" not in parts and "2001:db8::1" not in parts
-        assert engine.unmask_ip(parts[0]) == "192.0.2.1"
-        assert engine.unmask_ip(parts[2]) == "2001:db8::1"
+        assert engine.unmask_token(parts[0]) == "192.0.2.1"
+        assert engine.unmask_token(parts[2]) == "2001:db8::1"
 
     def test_skip_values_pass_through(self, masker: OutputMasker):
         masked = masker.mask_result({"user": "N/A", "srcip": "", "dstuser": "unknown"})
@@ -157,10 +157,21 @@ class TestTextScan:
     def test_invalid_ipv4_lookalike_untouched(self, masker: OutputMasker):
         assert masker.mask_text("version 999.1.2.3 ok") == "version 999.1.2.3 ok"
 
-    def test_embedded_mac_masked(self, masker: OutputMasker):
+    def test_embedded_mac_masked(self, masker: OutputMasker, engine: FPEEngine):
+        """A MAC in prose masks into a marked token, not another MAC.
+
+        The old assertion looked for a colon-separated MAC in the output,
+        which was right while a masked MAC was itself a MAC. The v2 MAC
+        payload is colon-free hex precisely so the free-text MAC scan
+        cannot see it and chew it on a later pass, so the property to
+        assert now is the marker and the round trip.
+        """
         out = masker.mask_text("client ae:42:a1:52:45:d6 associated")
+
         assert "ae:42:a1:52:45:d6" not in out
-        assert re.search(r"([0-9a-f]{2}:){5}[0-9a-f]{2}", out)
+        token = out.split("client ")[1].split(" associated")[0]
+        assert token.startswith("mac-")
+        assert engine.v2_open(token) == "ae:42:a1:52:45:d6"
 
     def test_echo_keys_scanned(self, masker: OutputMasker):
         masked = masker.mask_result({"filter": 'srcip=="192.0.2.102"', "device": "FGT-BRANCH-01"})
@@ -321,7 +332,7 @@ class TestTargetFailClosed:
         masked = masker.mask_result({"target": [{"name": "ip", "value": raw_ip}, stray]})
         valid, burned = masked["target"]
 
-        assert engine.unmask_ip(valid["value"]) == raw_ip
+        assert engine.unmask_token(valid["value"]) == raw_ip
         assert "masked-unrepresentable-" not in valid["value"]
         assert burned.startswith("masked-unrepresentable-")
         assert raw_ip not in str(masked)
@@ -653,8 +664,9 @@ class TestAssetValueDiffering:
     """#73 item 3: an asset_value that differs from value used to pass
     through in clear even when it is a second identifier."""
 
-    def test_differing_string_asset_value_masks_by_name_type(self, masker: OutputMasker):
-        import ipaddress
+    def test_differing_string_asset_value_masks_by_name_type(
+        self, masker: OutputMasker, engine: FPEEngine
+    ):
 
         masked = masker.mask_result(
             {"target": [{"name": "ip", "value": "192.0.2.57", "asset_value": "192.0.2.58"}]}
@@ -663,7 +675,7 @@ class TestAssetValueDiffering:
 
         assert "192.0.2.58" not in str(masked)
         # reversibly masked by the entry's own type, not burned
-        ipaddress.IPv4Address(entry["asset_value"])
+        assert engine.v2_open(entry["asset_value"]) == "192.0.2.58"
 
     def test_numeric_id_asset_value_stays_clear(self, masker: OutputMasker):
         masked = masker.mask_result(

--- a/tests/test_masking_wrapper.py
+++ b/tests/test_masking_wrapper.py
@@ -22,7 +22,15 @@ def _settings_with(**overrides: object) -> object:
     """
     from types import SimpleNamespace
 
-    fields = {"FAZ_MASK_DEVICE_IDENTITY": False, "FAZ_MASKING_KEY": None}
+    fields = {
+        "FAZ_MASK_DEVICE_IDENTITY": False,
+        "FAZ_MASKING_KEY": None,
+        # Mirrors the real default. A stub that omits a field the composition
+        # point reads fails with an AttributeError rather than silently
+        # exercising a different configuration, which is why this is listed
+        # here instead of being defaulted away with getattr in production.
+        "FAZ_MASKING_ACCEPT_V1_TOKENS": True,
+    }
     fields.update(overrides)
     return SimpleNamespace(**fields)
 


### PR DESCRIPTION
Implements the three things you settled on RFC #40: the shape gate rather than verify-then-fallback, colon-free hex payloads for the IPv6 and MAC forms, and `serial` as its own type. Then wires the result to the boundary, which is where it stops being a format and starts being a property.

18 commits, 2201 tests, ruff and mypy clean. Merges clean on main.

## What the envelope is

`<marker>-<kid>-<ct>-<tag>`, markers `ip4 ip6 mac sn url host user`. The tag is 32 bits over the type, key id and payload.

The property it buys is forgery refusal: a token whose tag does not verify is refused rather than decrypted. That matters because v1 has no integrity at all, so a stale, rotated or foreign token decrypts to a plausible wrong value that nothing catches.

## The gate, and why ordering is the whole thing

A v2 hostname token also starts with `host-`. So a shape check placed after the prefix dispatch would never run, and the v1 path would take the token first. Worse, a v2 token with a flipped tag is a byte-valid v1 token, because the tag is hex and a hyphen and both are inside the v1 alphabet, so v1 decrypts it happily to garbage.

`unmask_token` therefore asks the shape question before anything else, and anything v2-shaped is committed to v2 whatever v2 then says about it. A fallback would hand a forger exactly the decrypt the gate exists to refuse.

`ArgUnmasker` inherits this by delegating, and a test asserts the delegation rather than trusting it to stay one line.

## Shape inbound, ownership outbound

These are different questions and conflating them cost me three leaks during this work, so it is worth stating plainly.

Inbound, the question is "does this LOOK like v2", because a shaped token must not be retried on v1. Outbound, that question is wrong: a real value can be shaped like a token, and the shape regex accepts any four hex characters as a key id, so the exposed surface is every key id rather than ours. `host-ab12-web-01-cafe0123` is an ordinary hostname and a perfectly good v2 shape.

Every skip on the output side asks `is_own_v2_token`, which adds the key id and the tag. The free-text guard is not a second opinion any more: its patterns bracket a candidate, and the same predicate decides.

## The deprecation window

`FAZ_MASKING_ACCEPT_V1_TOKENS`, default on for one release. Tokens already sitting in a live conversation have to keep resolving, or a restart silently breaks every session that was mid-flight.

Enforced on the two key-id splits rather than on the dispatch, because the dispatch is bypassable: `ArgUnmasker` resolves a URL tail by calling `unmask_url_tail` directly. Every marked v1 token passes through a split, so that is the choke point that cannot be routed around. A test closes the window and calls the primitive directly, which is the case a dispatch-level check would let through.

The server logs once when it accepts a v1 token, so a deployment can tell when closing is safe. Form and key id only; never the payload.

## The verification cap

You and I agreed the 32-bit tag on the basis that this would exist, so it ships with it rather than after it.

The bound is per verification, not per call, and the difference is the whole argument: one call can carry thousands of tokens, so 2**31 expected verifications is on the order of 10**5 calls rather than 10**9. `V2_VERIFY_BUDGET` caps verifications per call, charged before the tag is checked so a grind pays for attempts rather than only successes, and reset at the outermost boundary only so nesting cannot hand out a fresh allowance per hop.

Exhaustion raises its own type, `VerificationBudgetExhausted`, and is re-raised rather than swallowed. That distinction matters: one token that will not decrypt is passed through so a validator can reject it, but doing that on exhaustion turns the cap into partial resolution, where the first tokens resolve and the rest ride out as literals with nothing said to the caller.

Repeated failures in one call escalate once to ERROR. One failure is a corrupted token echoed back by a model; eight in a call is someone trying tags.

## Deliberately not done

`domain` and `email_local` keep no v2 envelope. They are suffix-marked, so their v2 spelling would be a different parse rather than a different envelope. `mint` returns them as v1 through an explicit branch rather than by falling off the end, and a test pins their absence, so it stays a decision.

This used to make the window unclosable, and `3a21ced` fixes that. The window check sat on both key-id splits, and the suffix split is these two types and nothing else, so closing the window made the engine refuse a domain token it had just minted, in the same process with the same key. Measured:

```
window OPEN    domain    -> round-trips OK
window CLOSED  domain    -> REFUSED, "the deprecation window is closed"
window CLOSED  hostname  -> round-trips OK
```

Their suffix token is not a legacy encoding awaiting retirement, it is the only encoding those types have ever had, so the suffix split no longer consults the window. The prefix split still does, and tests pin both halves: a v1 hostname is still refused with the window closed, and the exemption is not a blanket off switch. The full reasoning, including a test of mine that asserted the opposite for a wrong reason, is in the comment on this PR.

Still open and still yours to call: whether those two should eventually get a v2 envelope. They carry no authenticated tag, so a forged domain token decrypts to garbage rather than being refused. That is unchanged here. What changed is that the window is now closable for the seven types that do have an envelope, instead of being unclosable for everyone.

## On the review of this branch

I ran two adversarial passes over it. The first found two identifier leaks I had introduced, both reproduced by hand before I touched anything. The second found four more issues, including that the window flag was unreachable from any deployment and that the forgery alarm fired on every failure rather than once, so the escalation meant to make a grind visible was itself the flood.

All of it is fixed in the last two commits. I mention it because the commit messages carry the measurements, and because the pattern in every case was a decision copied to two places and then drifting, which is worth knowing if you review the carrier tables in the same spirit.

## Verification

- 2201 tests, ruff, format and mypy clean
- forgery refusal checked end to end rather than only in unit tests: genuine tokens resolve, a flipped tag is refused on both the engine and argument paths, v1 still resolves while the window is open
- every enveloped type round trips through mask and unmask, including case-sensitive usernames, IPv6 spelling, URL tails and serials
- the free-text scan is a fixed point over its own output, which it was not before

No live FortiAnalyzer was involved: this is format and boundary work, and nothing here needs an appliance to be wrong.

