### PR TITLE
fix(masking): a group-by map must not ride through the allowlist walk (#73)

### DIFF
--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -1135,6 +1135,17 @@ class OutputMasker:
             return self._mask_composite_map(value, mapping, keep)
         if lowered in COMPOSITE_JSON and isinstance(value, str):
             return self._mask_json_blob(value, mapping, keep)
+        if lowered in COMPOSITE_JSON and isinstance(value, list):
+            # same list convention the other composites handle -- a list
+            # value here previously fell through every typed branch to
+            # _mask_structured with no key context, which cannot identify
+            # bare strings as JSON blobs and returned them verbatim.
+            return [
+                self._mask_json_blob(item, mapping, keep)
+                if isinstance(item, str)
+                else self._mask_structured(item, mapping, keep)
+                for item in value
+            ]
         if lowered in COMPOSITE_URL_HOST and isinstance(value, str):
             return self._mask_url_host(value, mapping, keep)
         if lowered in COMPOSITE_URL_HOST and isinstance(value, list):
@@ -1178,6 +1189,17 @@ class OutputMasker:
             return self._burn_strings(value, keep)
         if lowered in COMPOSITE_DEVICE_VDOM and isinstance(value, str):
             return self._mask_device_vdom(value, mapping, keep)
+        if lowered in COMPOSITE_DEVICE_VDOM and isinstance(value, list):
+            # same gap as COMPOSITE_JSON above: a list of device[vdom]
+            # strings fell through to _mask_structured with no key
+            # context and returned every device name verbatim, even with
+            # mask_device_identity on.
+            return [
+                self._mask_device_vdom(item, mapping, keep)
+                if isinstance(item, str)
+                else self._mask_structured(item, mapping, keep)
+                for item in value
+            ]
         if lowered in COMPOSITE_BREAKDOWNS and isinstance(value, dict):
             return self._mask_breakdowns(value, mapping, keep)
 

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -475,6 +475,100 @@ class OutputMasker:
             }
         return value
 
+    #: Every key the schema knows, independent of the device-identity flag.
+    #: ``self._field_types`` is the wrong table for the "do we recognise
+    #: this name" question: it only gains DEVICE_IDENTITY_TYPES when the
+    #: flag is on, so flag-off the name ``devname`` read as unknown and its
+    #: KEY burned while its value stayed readable via the keep set. That is
+    #: mangled schema on the majority configuration, for no gain.
+    _SCHEMA_KEYS: frozenset[str] = frozenset(FIELD_TYPES) | frozenset(DEVICE_IDENTITY_TYPES)
+
+    @staticmethod
+    def _typeable(value: Any) -> bool:
+        """Can ``_mask_entry`` actually type this shape?
+
+        Its typed and composite branches are all gated on ``str`` or on a
+        list of them. Anything else reaches the ``_mask_structured`` tail,
+        which is the allowlist walk this whole function exists to avoid
+        trusting.
+        """
+        if isinstance(value, str):
+            return True
+        return isinstance(value, list) and all(isinstance(item, str) for item in value)
+
+    def _burn_and_record(self, value: Any, mapping: dict[str, str], keep: frozenset[str]) -> Any:
+        """Burn, and record what was burned so pass 2 can follow it.
+
+        ``_burn_strings`` takes no mapping, so a burned value's twin in a
+        free-text field rode out in clear: measured, ``{"groupby1":
+        {"srcuser": "walter.white"}, "msg": "blocked walter.white"}`` burned
+        the map and left the name in ``msg``. Recording raw -> placeholder
+        lets the pass-2 substitution replace it there too, which is the
+        same principle ``_mask_scalar`` already documents.
+        """
+        if isinstance(value, str):
+            burned = self._burn_strings(value, keep)
+            if isinstance(burned, str) and burned != value:
+                mapping.setdefault(value, burned)
+            return burned
+        if isinstance(value, list | tuple):
+            return [self._burn_and_record(item, mapping, keep) for item in value]
+        if isinstance(value, dict):
+            return {
+                self._burn_and_record(key, mapping, keep): self._burn_and_record(
+                    item, mapping, keep
+                )
+                for key, item in value.items()
+            }
+        return value
+
+    def _mask_composite_map(self, value: Any, mapping: dict[str, str], keep: frozenset[str]) -> Any:
+        """Mask a map under a composite key: allowlist what it knows, burn the rest.
+
+        A dict-shaped group-by used to fall through to the plain allowlist
+        walk, on the reasoning that the walk would type it by its inner
+        keys. That holds only when those keys happen to be allowlisted.
+        Measured on 2.13.0 (``cfc2585``), same engine, RFC 5737 values:
+
+            {"groupby1": {"srcip": "192.0.2.90"}}     -> masked
+            {"groupby1": {"a": "srcip:192.0.2.90"}}   -> LEAK, verbatim
+            {"groupby1": {"a": "192.0.2.90"}}         -> LEAK, verbatim
+            {"groupby1": [{"a": "srcip:192.0.2.90"}]} -> LEAK, verbatim
+            {"groupby1": {"192.0.2.90": 5}}           -> LEAK, in the key
+
+        Recognising the key is not enough on its own. ``_mask_entry``'s
+        branches are shape-gated, so a known key holding a CONTAINER fell
+        straight back into the walk: ``{"srcip": {"nested": "192.0.2.90"}}``
+        leaked verbatim. A known key is therefore only handed on when its
+        value is a shape ``_mask_entry`` can actually type.
+
+        The working half is kept and everything else fails closed, rather
+        than burning the whole map the way the URL composites and ``target``
+        do. Those have no slot their handler can type at all; a group-by map
+        does for the keys the allowlist covers, and burning those would cost
+        a reversible mask for nothing.
+        """
+        if not isinstance(value, dict):
+            return self._burn_and_record(value, mapping, keep)
+        out: dict[Any, Any] = {}
+        for key, item in value.items():
+            known = isinstance(key, str) and (
+                key.lower() in self._SCHEMA_KEYS or key.lower() in _COMPOSITE_DIMENSIONS
+            )
+            if known and self._typeable(item):
+                out[key] = self._mask_entry(key, item, mapping, keep)
+            elif known:
+                # Name recognised, shape not. Keep the name, burn the value.
+                out[key] = self._burn_and_record(item, mapping, keep)
+            else:
+                # Unknown key: neither it nor its value can be typed, so
+                # both burn. The key burns too because a group-by map can
+                # carry the identifier there ({"192.0.2.90": 5}).
+                out[self._burn_and_record(key, mapping, keep)] = self._burn_and_record(
+                    item, mapping, keep
+                )
+        return out
+
     def _mask_target(
         self, value: list[Any], mapping: dict[str, str], keep: frozenset[str] = frozenset()
     ) -> list[Any]:
@@ -1031,14 +1125,14 @@ class OutputMasker:
         if lowered in COMPOSITE_PREFIXED and isinstance(value, list):
             # list-valued group-bys are a normal FAZ variation (#73): each
             # element gets the same prefixed treatment the string form gets.
-            # A dict-shaped groupby stays with the allowlist walk below,
-            # which types it by its inner keys.
             return [
                 self._mask_prefixed(item, mapping, keep)
                 if isinstance(item, str)
-                else self._mask_structured(item, mapping, keep)
+                else self._mask_composite_map(item, mapping, keep)
                 for item in value
             ]
+        if lowered in COMPOSITE_PREFIXED and isinstance(value, dict):
+            return self._mask_composite_map(value, mapping, keep)
         if lowered in COMPOSITE_JSON and isinstance(value, str):
             return self._mask_json_blob(value, mapping, keep)
         if lowered in COMPOSITE_URL_HOST and isinstance(value, str):

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -2212,6 +2212,26 @@ class TestCompositeMapShapes:
         assert self.IP not in str(out)
         assert not str(out["groupby1"]["srcip"]).startswith("['masked-unrepresentable")
 
+    def test_a_devvds_list_does_not_leak_device_identity(self, full_masker: OutputMasker) -> None:
+        """_typeable() claims every composite branch handles a list of
+        strings, but COMPOSITE_DEVICE_VDOM only had a str arm in
+        _mask_entry -- a list value was waved through _mask_composite_map
+        as "known and typeable", then fell through every typed branch
+        (list is not str) straight to _mask_structured with no key
+        context, which cannot identify bare strings as device[vdom]
+        pairs. Leaked real device names verbatim even with
+        mask_device_identity on."""
+        device = "fw-paris-01[root]"
+        out = full_masker.mask_result({"groupby1": {"devvds": [device, "fw-lyon-02[root]"]}})
+        assert device not in str(out)
+
+    def test_a_grpby_list_does_not_leak_an_embedded_identifier(self, masker: OutputMasker) -> None:
+        """Same gap as devvds above, for COMPOSITE_JSON: a list of JSON
+        blob strings under "grpby" fell through to _mask_structured with
+        no key context and returned the embedded IP verbatim."""
+        out = masker.mask_result({"groupby1": {"grpby": [f'{{"dstendpoint": "{self.IP}"}}']}})
+        assert self.IP not in str(out)
+
     def test_a_burned_value_is_recorded_so_its_twin_in_prose_follows(
         self, masker: OutputMasker
     ) -> None:

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -2126,3 +2126,141 @@ class TestGroupByGroupsRowsAlreadyCovered:
 
         flagged = full_masker.mask_result(payload)
         assert flagged["groups"][0]["fortigate"] != DEV_NAME
+
+
+class TestCompositeMapShapes:
+    """A map under a group-by key must not ride through in clear.
+
+    A dict-shaped group-by used to fall through to the plain allowlist
+    walk, on the reasoning that the walk would type it by its inner keys.
+    That holds only when those keys happen to be allowlisted. Measured on
+    2.13.0 (``cfc2585``) before the fix, with RFC 5737 values:
+
+        {"groupby1": {"srcip": "192.0.2.90"}}     masked
+        {"groupby1": {"a": "srcip:192.0.2.90"}}   LEAK, verbatim
+        {"groupby1": {"a": "192.0.2.90"}}         LEAK, verbatim
+        {"groupby1": [{"a": "srcip:192.0.2.90"}]} LEAK, verbatim
+        {"groupby1": {"192.0.2.90": 5}}           LEAK, in the key
+
+    upstream #73 item 1.
+    """
+
+    IP = "192.0.2.90"
+
+    @pytest.mark.parametrize("key", ["groupby1", "groupby2"])
+    def test_an_unknown_inner_key_does_not_leak_its_value(
+        self, masker: OutputMasker, key: str
+    ) -> None:
+        out = masker.mask_result({key: {"a": f"srcip:{self.IP}"}})
+        assert self.IP not in str(out)
+
+    def test_an_unknown_inner_key_holding_a_bare_address_does_not_leak(
+        self, masker: OutputMasker
+    ) -> None:
+        out = masker.mask_result({"groupby1": {"a": self.IP}})
+        assert self.IP not in str(out)
+
+    def test_an_identifier_used_as_the_key_does_not_leak(self, masker: OutputMasker) -> None:
+        """The allowlist walk never masks a key, so a group-by keyed by the
+        identifier handed it over as the key itself."""
+        out = masker.mask_result({"groupby1": {self.IP: 5}})
+        assert self.IP not in str(out)
+
+    def test_a_map_nested_in_a_list_does_not_leak(self, masker: OutputMasker) -> None:
+        out = masker.mask_result({"groupby1": [{"a": f"srcip:{self.IP}"}]})
+        assert self.IP not in str(out)
+
+    def test_an_allowlisted_inner_key_still_masks_reversibly(self, masker: OutputMasker) -> None:
+        """The half that worked is kept: burning the whole map would throw
+        away a reversible mask, which is why this is not the blanket burn
+        the URL composites and ``target`` use."""
+        out = masker.mask_result({"groupby1": {"srcip": self.IP}})
+        assert self.IP not in str(out)
+        assert "srcip" in out["groupby1"]
+        assert not str(out["groupby1"]["srcip"]).startswith("masked-unrepresentable")
+
+    def test_known_and_unknown_keys_are_handled_separately(self, masker: OutputMasker) -> None:
+        out = masker.mask_result({"groupby1": {"srcip": self.IP, "a": "192.0.2.91"}})
+        rendered = str(out)
+        assert self.IP not in rendered
+        assert "192.0.2.91" not in rendered
+        assert "srcip" in out["groupby1"]
+
+    def test_the_string_form_is_untouched(self, masker: OutputMasker) -> None:
+        """The shape that already worked keeps working."""
+        out = masker.mask_result({"groupby1": f"srcip:{self.IP}"})
+        assert self.IP not in str(out)
+        assert str(out["groupby1"]).startswith("srcip:")
+
+    def test_a_known_key_holding_a_container_does_not_leak(self, masker: OutputMasker) -> None:
+        """Recognising the key is not enough. _mask_entry's branches are
+        shape-gated to strings, so a known key holding a container fell
+        back into the allowlist walk this function exists to distrust."""
+        for payload in (
+            {"groupby1": {"srcip": {"nested": self.IP}}},
+            {"groupby1": {"srcip": [{"nested": self.IP}]}},
+            {"groupby1": [{"srcip": [{"nested": self.IP}]}]},
+            {"groupby1": {"devvds": {"x": self.IP}}},
+            {"groupby1": {"grpby": {"x": self.IP}}},
+        ):
+            assert self.IP not in str(masker.mask_result(payload)), payload
+
+    def test_a_known_key_holding_a_list_of_strings_still_masks(self, masker: OutputMasker) -> None:
+        """The shape _mask_entry can type is still handed to it, so
+        narrowing the known branch does not burn what worked."""
+        out = masker.mask_result({"groupby1": {"srcip": [self.IP]}})
+        assert self.IP not in str(out)
+        assert not str(out["groupby1"]["srcip"]).startswith("['masked-unrepresentable")
+
+    def test_a_burned_value_is_recorded_so_its_twin_in_prose_follows(
+        self, masker: OutputMasker
+    ) -> None:
+        """_burn_strings takes no mapping, so a burned value's twin in a
+        free-text field rode out in clear beside its own burned copy."""
+        out = masker.mask_result(
+            {"groupby1": {"srcuser": "walter.white"}, "msg": "blocked walter.white today"}
+        )
+        assert "walter.white" not in str(out)
+
+    def test_a_masked_value_is_recorded_so_its_twin_in_prose_follows(
+        self, masker: OutputMasker
+    ) -> None:
+        """The known branch has to keep feeding the shared mapping. Dropping
+        its result on the floor left the map masked and the same name in
+        clear two keys away, with the whole suite green."""
+        out = masker.mask_result(
+            {"groupby1": {"user": "walter.white"}, "msg": "blocked walter.white today"}
+        )
+        assert "walter.white" not in str(out)
+
+    def test_a_device_identity_key_keeps_its_name_with_the_flag_off(
+        self, masker: OutputMasker
+    ) -> None:
+        """The "is this name known" question is flag-independent. Asking
+        the flag-mutated table made devname read as unknown with the flag
+        off, so the KEY burned while the value stayed readable: mangled
+        schema on the majority configuration, for no gain."""
+        out = masker.mask_result({"groupby1": {"devname": "fw-paris-01"}})
+        assert "devname" in out["groupby1"]
+
+    def test_a_device_identity_key_still_masks_with_the_flag_on(
+        self, full_masker: OutputMasker
+    ) -> None:
+        out = full_masker.mask_result({"groupby1": {"devname": "fw-paris-01"}})
+        assert "devname" in out["groupby1"]
+        assert "fw-paris-01" not in str(out)
+
+    def test_a_known_key_is_matched_case_insensitively(self, masker: OutputMasker) -> None:
+        """FortiAnalyzer surfaces do not agree on case. Matching the key
+        verbatim would burn a dimension that masks reversibly today."""
+        out = masker.mask_result({"groupby1": {"SrcIP": self.IP}})
+        assert self.IP not in str(out)
+        assert "SrcIP" in out["groupby1"]
+        assert not str(out["groupby1"]["SrcIP"]).startswith("masked-unrepresentable")
+
+    def test_a_kept_value_is_not_burned_inside_the_map(self, masker: OutputMasker) -> None:
+        """A value the deployment chose to leave readable stays readable
+        under every key. Burning it here while devname shows it two keys
+        away is the same mismatch the keep set exists to prevent."""
+        out = masker.mask_result({"devname": "fw-paris-01", "groupby1": {"unknown": "fw-paris-01"}})
+        assert out["groupby1"]["unknown"] == "fw-paris-01"


### PR DESCRIPTION
Works #73 item 1, and trims the rest of the issue against current main.

## Re-measured first, because the issue is a month old

Half of what #73 lists has closed since it was written, mostly by #113 and the list branches. Measured on `cfc2585` before writing anything, RFC 5737 values:

| shape | on `cfc2585` |
|---|---|
| `{"groupby1": {"srcip": "192.0.2.90"}}` | masked |
| `{"groupby1": {"a": "srcip:192.0.2.90"}}` | **LEAK, verbatim** |
| `{"groupby1": {"a": "192.0.2.90"}}` | **LEAK, verbatim** |
| `{"groupby1": [{"a": "srcip:192.0.2.90"}]}` | **LEAK, verbatim** |
| `{"groupby1": {"192.0.2.90": 5}}` | **LEAK, in the key** |

The last row is the sharper half. The allowlist walk never masks a KEY, so a group-by keyed by the identifier hands it straight over.

Already closed, so worth striking from the issue rather than carrying: list-shaped group-bys mask, list-shaped `http_url` masks, a dict under a URL key already fails closed, and `{"groupby1": 12345}` passes through because an int carries no maskable string.

## The fix, and the hole in my first attempt

`_mask_composite_map` masks an inner key the schema knows and burns everything else, key included.

Recognising the key turned out not to be sufficient, which an adversarial pass caught before this was proposed. `_mask_entry`'s typed and composite branches are all gated on `str` or a list of them, so a known key holding a container fell straight back into the walk:

```
{"groupby1": {"srcip": {"nested": "192.0.2.90"}}}    LEAK, verbatim
{"groupby1": {"devvds": {"x": "192.0.2.90"}}}        LEAK, verbatim
```

Pre-existing rather than introduced, but my first version claimed to "fail the rest closed" while those stood, and that claim was simply false: the known branch failed open. A known key is now handed on only when its value is a shape `_mask_entry` can type.

Two more from the same pass:

**Burning without recording.** `_burn_strings` takes no mapping, so a burned value's twin in a free-text field rode out in clear beside its own burned copy. `{"groupby1": {"srcuser": "walter.white"}, "msg": "blocked walter.white"}` burned the map and left the name in `msg`. It records `raw -> placeholder` now, so the pass-2 substitution follows it.

**The wrong table for "is this name known".** `self._field_types` only gains `DEVICE_IDENTITY_TYPES` when the flag is on, so with the flag off `devname` read as unknown and its KEY burned while its value stayed readable through the keep set. That is mangled schema on the majority configuration for no gain. Recognition is flag-independent; the flag decides whether a value masks, not whether a name is known.

## Why not the blanket burn

`COMPOSITE_URL_HOST`/`FULL` and `target` burn this shape whole. They have no slot their handler can type at all. A group-by map does, for the keys the allowlist covers, and burning those would cost a working reversible mask for nothing. Both directions are pinned.

## Left alone on purpose

A scheme-less `http_url` returns its domain in clear, while an IP host is still caught by the pattern-based free-text scan. `"bad.example.com:80/x"` is the same class, since `urlsplit` reads the domain as a scheme.

I had a fix and dropped it. Making `urlsplit` see the host means re-splitting the value, and reassembling from that parse rewrote the field. Nothing in the repo or in any payload I have shows FortiAnalyzer emitting that shape, and `_mask_url_host`'s own docstring says live alerts carry full URLs. It stays an observation for the #80 audit to settle with real data rather than a speculative rewrite of a field.

## Evidence

Eight mutants, each confirmed to change behaviour rather than only text, against a verified green control:

| mutant | |
|---|---|
| revert the dict branch to the allowlist walk | KILLED, 5 |
| drop the result of the known branch | KILLED, 8 |
| drop the `_typeable` narrowing | KILLED, 1 |
| `_typeable` accepts any list | KILLED, 1 |
| burn without recording | KILLED, 1 |
| back to the flag-mutated table | KILLED, 1 |
| match the key verbatim instead of case-folded | KILLED, 1 |
| burn ignoring the keep set | KILLED, 1 |

`2080 passed`, ruff and mypy clean.

Note on ordering: this touches `wrapper.py`, as does #115. Whichever lands second takes a small conflict; not worth engineering around.