### PR TITLE
fix(masking): a composite container must keep its key context (#73)

### DIFF
--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -522,6 +522,39 @@ class OutputMasker:
             }
         return value
 
+    def _mask_composite_container(
+        self, key: str, value: Any, mapping: dict[str, str], keep: frozenset[str]
+    ) -> Any:
+        """Re-enter ``_mask_entry`` under the SAME key for every element.
+
+        For these kinds the key is the only thing that can type the
+        payload, so a container must not be handed to ``_mask_structured``:
+        that route walks by allowlist, knows none of these inner names,
+        and has already lost the key by the time it sees the value. That
+        is how a list under ``devvds`` returned device names in clear with
+        ``FAZ_MASK_DEVICE_IDENTITY`` on, and the map form had no arm at
+        all so it reached the same route (#73 item 1).
+
+        Recursing rather than burning is what keeps the flag honest: the
+        per-kind handlers already decide what the deployment is entitled
+        to read (``_mask_device_vdom`` returns its argument untouched with
+        the flag off), while ``_burn_strings`` would mask an estate name
+        the flag-off deployment sees in clear under the string form of the
+        same key. It also means each kind's own dict policy still applies
+        one level down, so a map inside a list under ``url`` still burns.
+
+        Keys are masked as well as values: no later pass ever scans a key,
+        so a map keyed by the identifier hands it over as the key itself.
+        """
+        if isinstance(value, list | tuple):
+            return [self._mask_entry(key, item, mapping, keep) for item in value]
+        return {
+            self._mask_entry(key, inner_key, mapping, keep): self._mask_entry(
+                key, item, mapping, keep
+            )
+            for inner_key, item in value.items()
+        }
+
     def _mask_composite_map(self, value: Any, mapping: dict[str, str], keep: frozenset[str]) -> Any:
         """Mask a map under a composite key: allowlist what it knows, burn the rest.
 
@@ -1135,37 +1168,22 @@ class OutputMasker:
             return self._mask_composite_map(value, mapping, keep)
         if lowered in COMPOSITE_JSON and isinstance(value, str):
             return self._mask_json_blob(value, mapping, keep)
-        if lowered in COMPOSITE_JSON and isinstance(value, list):
-            # same list convention the other composites handle -- a list
-            # value here previously fell through every typed branch to
+        if lowered in COMPOSITE_JSON and isinstance(value, list | dict):
+            # A list value here used to fall through every typed branch to
             # _mask_structured with no key context, which cannot identify
-            # bare strings as JSON blobs and returned them verbatim.
-            return [
-                self._mask_json_blob(item, mapping, keep)
-                if isinstance(item, str)
-                else self._mask_structured(item, mapping, keep)
-                for item in value
-            ]
+            # bare strings as JSON blobs and returned them verbatim. The
+            # map form had no arm at all and reached the same route.
+            return self._mask_composite_container(lowered, value, mapping, keep)
         if lowered in COMPOSITE_URL_HOST and isinstance(value, str):
             return self._mask_url_host(value, mapping, keep)
         if lowered in COMPOSITE_URL_HOST and isinstance(value, list):
             # same list convention the typed fields handle below
-            return [
-                self._mask_url_host(item, mapping, keep)
-                if isinstance(item, str)
-                else self._mask_structured(item, mapping, keep)
-                for item in value
-            ]
+            return self._mask_composite_container(lowered, value, mapping, keep)
         if lowered in COMPOSITE_URL_FULL and isinstance(value, str):
             return self._mask_url_full(value, mapping, keep)
         if lowered in COMPOSITE_URL_FULL and isinstance(value, list):
             # same list convention the typed fields handle below
-            return [
-                self._mask_url_full(item, mapping, keep)
-                if isinstance(item, str)
-                else self._mask_structured(item, mapping, keep)
-                for item in value
-            ]
+            return self._mask_composite_container(lowered, value, mapping, keep)
         if (lowered in COMPOSITE_URL_HOST or lowered in COMPOSITE_URL_FULL) and isinstance(
             value, dict
         ):
@@ -1189,17 +1207,12 @@ class OutputMasker:
             return self._burn_strings(value, keep)
         if lowered in COMPOSITE_DEVICE_VDOM and isinstance(value, str):
             return self._mask_device_vdom(value, mapping, keep)
-        if lowered in COMPOSITE_DEVICE_VDOM and isinstance(value, list):
+        if lowered in COMPOSITE_DEVICE_VDOM and isinstance(value, list | dict):
             # same gap as COMPOSITE_JSON above: a list of device[vdom]
             # strings fell through to _mask_structured with no key
             # context and returned every device name verbatim, even with
-            # mask_device_identity on.
-            return [
-                self._mask_device_vdom(item, mapping, keep)
-                if isinstance(item, str)
-                else self._mask_structured(item, mapping, keep)
-                for item in value
-            ]
+            # mask_device_identity on. The map form had no arm at all.
+            return self._mask_composite_container(lowered, value, mapping, keep)
         if lowered in COMPOSITE_BREAKDOWNS and isinstance(value, dict):
             return self._mask_breakdowns(value, mapping, keep)
 

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -2284,3 +2284,99 @@ class TestCompositeMapShapes:
         away is the same mismatch the keep set exists to prevent."""
         out = masker.mask_result({"devname": "fw-paris-01", "groupby1": {"unknown": "fw-paris-01"}})
         assert out["groupby1"]["unknown"] == "fw-paris-01"
+
+
+class TestCompositeContainerShapesKeepKeyContext:
+    """A composite key must keep deciding the type at every depth.
+
+    Each composite kind dispatches on the key, then on the value's shape.
+    The shapes with no arm fall to the generic tail, which walks by
+    allowlist and knows none of these inner names, so the payload rides
+    out in clear. The list arms had the same hole one level down: they
+    delegated a non-string element to ``_mask_structured``, which is the
+    route that strips the key context the value can only be typed by.
+
+    Measured on ``1f60904`` before the fix, RFC 5737 / RFC 2606 values:
+
+        {"devvds": {"a": "fw-oslo-01[root]"}}       LEAK, flag ON
+        {"devvds": {"fw-oslo-01[root]": 5}}         LEAK, flag ON, in the key
+        {"devvds": [["fw-oslo-01[root]"]]}          LEAK, flag ON
+        {"grpby": {"a": '{"dstendpoint": "<ip>"}'}} LEAK
+        {"grpby": {"<ip>": ...}}                    LEAK, in the key
+        {"grpby": [['{"dstendpoint": "<ip>"}']]}    LEAK
+        {"http_url": [["https://bad.example.com/x"]]} LEAK
+        {"url":      [["https://bad.example.com/x"]]} LEAK
+
+    Reachable rather than observed: no live surface sampled in the #80
+    sweep emitted a composite under a map or a nested list. The same was
+    true of ``groupby3`` and of the map shapes #116 closed.
+    """
+
+    IP = "192.0.2.90"
+    DEV = "fw-oslo-01[root]"
+    DEV_NAME = "fw-oslo-01"
+    HOST = "bad.example.com"
+    URL = "https://bad.example.com/x"
+
+    def _blob(self) -> str:
+        return f'{{"dstendpoint": "{self.IP}"}}'
+
+    # ---- devvds: the device-identity flag must survive every shape ----
+
+    def test_a_devvds_map_value_does_not_leak(self, full_masker: OutputMasker) -> None:
+        out = full_masker.mask_result({"devvds": {"a": self.DEV}})
+        assert self.DEV_NAME not in str(out)
+
+    def test_a_devvds_map_keyed_by_the_device_does_not_leak(
+        self, full_masker: OutputMasker
+    ) -> None:
+        """No later pass ever scans a key, so the map form hands the
+        device name over as the key itself."""
+        out = full_masker.mask_result({"devvds": {self.DEV: 5}})
+        assert self.DEV_NAME not in str(out)
+
+    def test_a_devvds_nested_list_does_not_leak(self, full_masker: OutputMasker) -> None:
+        out = full_masker.mask_result({"devvds": [[self.DEV]]})
+        assert self.DEV_NAME not in str(out)
+
+    def test_a_devvds_map_stays_readable_with_the_flag_off(self, masker: OutputMasker) -> None:
+        """The counterpart pin. Device identity is clear by design unless
+        the deployment opts in, so the container shapes must not be closed
+        by burning -- that would mask an estate name the flag-off
+        deployment is entitled to read, under a key whose string form
+        hands it back in clear two rows away."""
+        out = masker.mask_result({"devvds": {"a": self.DEV}})
+        assert out["devvds"]["a"] == self.DEV
+
+    # ---- grpby: a JSON blob under a container ----
+
+    def test_a_grpby_map_value_does_not_leak(self, masker: OutputMasker) -> None:
+        out = masker.mask_result({"grpby": {"a": self._blob()}})
+        assert self.IP not in str(out)
+
+    def test_a_grpby_map_keyed_by_the_identifier_does_not_leak(self, masker: OutputMasker) -> None:
+        out = masker.mask_result({"grpby": {self.IP: self._blob()}})
+        assert self.IP not in str(out)
+
+    def test_a_grpby_nested_list_does_not_leak(self, masker: OutputMasker) -> None:
+        out = masker.mask_result({"grpby": [[self._blob()]]})
+        assert self.IP not in str(out)
+
+    # ---- the URL composites, one level down from the arm that works ----
+
+    @pytest.mark.parametrize("key", ["http_url", "url", "referralurl", "link"])
+    def test_a_url_nested_list_does_not_leak(self, masker: OutputMasker, key: str) -> None:
+        out = masker.mask_result({key: [[self.URL]]})
+        assert self.HOST not in str(out)
+
+    # ---- the shapes that already worked keep working ----
+
+    def test_the_shapes_that_already_worked_are_untouched(
+        self, masker: OutputMasker, full_masker: OutputMasker
+    ) -> None:
+        assert self.DEV_NAME not in str(full_masker.mask_result({"devvds": self.DEV}))
+        assert self.DEV_NAME not in str(full_masker.mask_result({"devvds": [self.DEV]}))
+        assert self.IP not in str(masker.mask_result({"grpby": self._blob()}))
+        assert self.IP not in str(masker.mask_result({"grpby": [self._blob()]}))
+        assert self.HOST not in str(masker.mask_result({"http_url": self.URL}))
+        assert self.HOST not in str(masker.mask_result({"http_url": [self.URL]}))


### PR DESCRIPTION
Closes the rest of #73 item 1, and it is the pin I offered on #116 turned into the fix it would have caught.

**Stacked on #116** (`1f60904`). It will shrink to one commit once that lands.

## Why there was more to find

Your `1f60904` fixed the two composite kinds whose list arm was missing. Rather than take the fix at face value I converted the question into a matrix and ran every composite key against every shape, both settings of `FAZ_MASK_DEVICE_IDENTITY`. That is where the remaining holes were: the map form of the same two kinds, the key side of a map, and one level deeper in the list arms of all four.

Measured on `1f60904`, RFC 5737 / RFC 2606 values:

| Payload | Flag | Result |
|---|---|---|
| `{"devvds": {"a": "fw-oslo-01[root]"}}` | on | leaked verbatim |
| `{"devvds": {"fw-oslo-01[root]": 5}}` | on | leaked, in the key |
| `{"devvds": [["fw-oslo-01[root]"]]}` | on | leaked verbatim |
| `{"grpby": {"a": "{\"dstendpoint\": \"<ip>\"}"}}` | either | leaked verbatim |
| `{"grpby": {"<ip>": ...}}` | either | leaked, in the key |
| `{"grpby": [["{\"dstendpoint\": \"<ip>\"}"]]}` | either | leaked verbatim |
| `{"http_url": [["https://bad.example.com/x"]]}` | either | leaked verbatim |
| `{"url": [["https://bad.example.com/x"]]}` | either | leaked verbatim |

The `devvds` rows are the sharp ones, for the same reason yours were: they leaked with `FAZ_MASK_DEVICE_IDENTITY` **on**, so the flag whose entire job is protecting estate names was set and the name still went out.

The key-side rows are their own class. `_burn_strings` already carries the note that a map can hold the identifier in the key and that no later pass ever scans one. Nothing was applying that to these kinds.

## The fix

One helper, `_mask_composite_container`, which re-enters `_mask_entry` under the **same key** for every element, at every depth, across keys as well as values. The four list arms now call it instead of open-coding a comprehension, so the change removes more lines than it adds.

**Recursing rather than burning is the load-bearing choice**, and it is what keeps the device-identity flag honest:

- `_mask_device_vdom` already returns its argument untouched with the flag off, so recursion inherits that for free. There is a pin for it: `test_a_devvds_map_stays_readable_with_the_flag_off`.
- `_burn_strings` does not consult the flag. A burn policy would mask an estate name that the same deployment reads in clear under the string form of the same key, which is the mismatch the keep set exists to prevent.
- Recursion also leaves each kind's own dict policy in force one level down, so a map inside a list under `url` still burns rather than acquiring a new route.

## Standing of the finding

**Reachable rather than observed.** No surface sampled in the #80 live sweep emitted a composite under a map or a nested list. Same standing as `groupby3` and as the map shapes #116 closed, and I would rather label it than imply traffic I did not see.

## Deliberately not fixed

`breakdowns` as a bare string or as a list still rides through, because that key has only a dict arm:

```
{"breakdowns": "srcip:192.0.2.90"}                          verbatim
{"breakdowns": [{"srcip": [{"value": "192.0.2.90"}]}]}      verbatim
```

Both shapes are built by this server's own tools from a caller's `sample_by`, and FortiAnalyzer does not emit either, so there is no producer that can make one. Guarding a shape nothing sends would cost the `breakdowns` docstring its deliberate pass-through for unknown dimensions. Stated here rather than left for someone to rediscover.

Also unchanged: `groupby1`/`groupby2` keep `_mask_composite_map` for their dict form. That handler masks known inner keys reversibly and burns the rest, which is strictly better for a real group-by map than treating each entry as another `groupby1` string. The matrix confirms every `groupby1` shape already fails closed.

## Verification

- 10 new tests red first, then green. The 2 that passed from the start are the flag-off pin and the already-working shapes, both there to catch an over-correction.
- Green control 283, then 8 mutants, all killed: dict keys unmasked, dict values unmasked, list arm dropped back to `_mask_structured`, each of the four arms reverted individually, and the container returning its argument verbatim. Each checked for a real behaviour change, not just a textual diff.
- 2094 tests pass. ruff and mypy clean.
