### PR TITLE
fix(masking): cover four of the five leaks the live sweep confirmed (#80)

### DIFF
--- a/src/fortianalyzer_mcp/masking/fields.py
+++ b/src/fortianalyzer_mcp/masking/fields.py
@@ -202,6 +202,11 @@ FIELD_TYPES: dict[str, str] = {
     "domainctrlname": HOSTNAME,
     # --- username carriers
     "user": USERNAME,
+    # fortiview-sources ships this beside the covered "unauthuser"; the
+    # live sweep measured 5 of 5 payload shapes riding out verbatim
+    # (username, email, DOMAIN\\user, hostname, IPv4) while the twin two
+    # keys away masked the identical literal (#80).
+    "f_user": USERNAME,
     "dstuser": USERNAME,
     "unauthuser": USERNAME,
     "xauthuser": USERNAME,
@@ -397,7 +402,10 @@ FIELD_NAME_ARGS = ("fields", "group_by", "sample_by", "sort_by", "view_name")
 #:   grpby              JSON, e.g. '[{"dstendpoint": "192.0.2.1"}]'
 #:   target             [{"name": "ip", "value": "192.0.2.1"}, ...]
 COMPOSITE_PREFIXED = ("groupby1", "groupby2")
-COMPOSITE_JSON = ("grpby",)
+#: ``auto_raise_grpby`` is the incident-surface twin of ``grpby`` and
+#: carries the identical JSON payload; it was uncovered while its twin
+#: masked, measured on the live estate (#80).
+COMPOSITE_JSON = ("grpby", "auto_raise_grpby")
 COMPOSITE_TARGET = ("target",)
 
 #: ``analyze_policy_traffic`` and ``query_logs(sample_by=...)``:
@@ -461,6 +469,28 @@ OBF_URL_KEY = "obf_url"
 #: whole string fails closed to an irreversible placeholder. Follows
 #: ``FAZ_MASK_DEVICE_IDENTITY`` like the flat device keys below.
 COMPOSITE_DEVICE_VDOM = ("devvds",)
+
+#: fortiview-sources aggregates: ``"<identifier>,<devtype>"``, where the
+#: tail is an OS or product string (``"DSM 7.3-86009"``, ``"Ubuntu
+#: 22.04.5"``). Each maps to the type its own head carries, which is the
+#: type the covered flat spelling of the same value already uses:
+#: ``mac_devtype_agg`` beside ``mac``/``dstmac``, ``dev_src_agg`` beside
+#: ``hostname``/``srcname``/``device``.
+#:
+#: A flat ``FIELD_TYPES`` entry is the wrong fix and was rejected: it would
+#: hand the whole ``"<identifier>,<devtype>"`` string to a scalar handler,
+#: which fails closed to an irreversible placeholder and burns the devtype
+#: with it. Same reason ``devvds`` has a handler rather than a type.
+#:
+#: NOT gated on ``FAZ_MASK_DEVICE_IDENTITY``, unlike the neighbouring
+#: ``COMPOSITE_DEVICE_VDOM``. These carry endpoint identity, not estate
+#: identity: their covered twins are ``FIELD_TYPES`` entries that mask with
+#: the flag off, and masking one spelling while its twin stays readable in
+#: the same record is what publishes the mapping (#80).
+COMPOSITE_ID_DEVTYPE: dict[str, str] = {
+    "mac_devtype_agg": MAC,
+    "dev_src_agg": HOSTNAME,
+}
 
 #: Estate identity, not personal data. Masked only when the deployment
 #: opts in via ``FAZ_MASK_DEVICE_IDENTITY``; see the module docstring.

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -74,6 +74,7 @@ from fortianalyzer_mcp.masking.fields import (
     COMPOSITE_BREAKDOWNS,
     COMPOSITE_DEVICE_VDOM,
     COMPOSITE_FILTER_ENTRIES,
+    COMPOSITE_ID_DEVTYPE,
     COMPOSITE_JSON,
     COMPOSITE_PREFIXED,
     COMPOSITE_TARGET,
@@ -122,6 +123,7 @@ _COMPOSITE_DIMENSIONS: frozenset[str] = frozenset(
         *COMPOSITE_URL_HOST,
         *COMPOSITE_URL_FULL,
         *COMPOSITE_DEVICE_VDOM,
+        *COMPOSITE_ID_DEVTYPE,
         *COMPOSITE_PREFIXED,
         *COMPOSITE_JSON,
     )
@@ -368,6 +370,37 @@ class OutputMasker:
             device = self._mask_scalar(HOSTNAME, match.group("dev"), mapping, keep=keep)
             out.append(f"{device}[{match.group('vdom')}]")
         return ",".join(out)
+
+    def _mask_id_devtype(
+        self, key: str, value: str, mapping: dict[str, str], keep: frozenset[str]
+    ) -> str:
+        """``"<identifier>,<devtype>"`` (fortiview-sources aggregates).
+
+        The head is masked by the type this key maps to, which is the type
+        its covered flat twin already uses. The devtype tail is an OS or
+        product string, the same class as ``srchwvendor`` and ``catdesc``
+        that ``fields.py`` declines by name, so it stays readable.
+
+        The tail goes through ``mask_text`` rather than back verbatim.
+        These are aggregating fields: a row covering several endpoints
+        comma-joins them, so a verbatim tail would hand back every
+        identifier after the first. ``mask_text`` catches the IPv4, MAC
+        and email shapes there. A second HOSTNAME in a tail is not
+        recoverable this way, since no hostname regex exists and adding
+        one would burn ordinary prose.
+
+        No comma means a shape we have not seen, so the whole value is
+        masked rather than returned untyped, matching what
+        ``_mask_device_vdom`` does with a bare device name.
+        """
+        if not value:
+            return value
+        vtype = COMPOSITE_ID_DEVTYPE[key]
+        head, sep, tail = value.partition(",")
+        if not sep:
+            return self._mask_scalar(vtype, value, mapping, keep=keep)
+        masked_head = self._mask_scalar(vtype, head, mapping, keep=keep)
+        return f"{masked_head},{self.mask_text(tail, mapping, keep)}"
 
     def _mask_breakdowns(self, value: Any, mapping: dict[str, str], keep: frozenset[str]) -> Any:
         """``{dimension: [{"value": ..., "hits": N}, ...]}`` (#98).
@@ -1205,6 +1238,10 @@ class OutputMasker:
             # happens to cover. The cost is real: a container whose keys
             # are allowlisted was masked reversibly before and now burns.
             return self._burn_strings(value, keep)
+        if lowered in COMPOSITE_ID_DEVTYPE and isinstance(value, str):
+            return self._mask_id_devtype(lowered, value, mapping, keep)
+        if lowered in COMPOSITE_ID_DEVTYPE and isinstance(value, list | dict):
+            return self._mask_composite_container(lowered, value, mapping, keep)
         if lowered in COMPOSITE_DEVICE_VDOM and isinstance(value, str):
             return self._mask_device_vdom(value, mapping, keep)
         if lowered in COMPOSITE_DEVICE_VDOM and isinstance(value, list | dict):

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -374,33 +374,49 @@ class OutputMasker:
     def _mask_id_devtype(
         self, key: str, value: str, mapping: dict[str, str], keep: frozenset[str]
     ) -> str:
-        """``"<identifier>,<devtype>"`` (fortiview-sources aggregates).
+        """``"<identifier>,<devtype>,<identifier>,<devtype>,..."``
+        (fortiview-sources aggregates).
 
-        The head is masked by the type this key maps to, which is the type
-        its covered flat twin already uses. The devtype tail is an OS or
-        product string, the same class as ``srchwvendor`` and ``catdesc``
-        that ``fields.py`` declines by name, so it stays readable.
+        Each identifier is masked by the type this key maps to, which is
+        the type its covered flat twin already uses. Each devtype is an OS
+        or product string, the same class as ``srchwvendor`` and
+        ``catdesc`` that ``fields.py`` declines by name, so it stays
+        readable -- run through ``mask_text`` rather than back verbatim
+        only to catch an identifier accidentally embedded in it, same as
+        any other free-text field.
 
-        The tail goes through ``mask_text`` rather than back verbatim.
         These are aggregating fields: a row covering several endpoints
-        comma-joins them, so a verbatim tail would hand back every
-        identifier after the first. ``mask_text`` catches the IPv4, MAC
-        and email shapes there. A second HOSTNAME in a tail is not
-        recoverable this way, since no hostname regex exists and adding
-        one would burn ordinary prose.
+        comma-joins their pairs, per this field's own docstring in
+        ``fields.py``. Only typing the first pair and handing the rest to
+        ``mask_text`` -- the previous shape of this function -- caught a
+        repeated MAC by accident (``mask_text`` has a MAC regex) but never
+        a repeated HOSTNAME (no hostname regex exists, nor should one:
+        scanning arbitrary prose for anything hostname-shaped burns
+        ordinary text). Walking every pair explicitly and typing each
+        identifier by position sidesteps that entirely -- it never needs a
+        hostname regex, because it is never guessing which substring is an
+        identifier; the comma-delimited shape already says so.
 
         No comma means a shape we have not seen, so the whole value is
         masked rather than returned untyped, matching what
-        ``_mask_device_vdom`` does with a bare device name.
+        ``_mask_device_vdom`` does with a bare device name. An odd number
+        of parts (a trailing identifier with no devtype) is the same
+        situation for its last pair, so that lone identifier is masked
+        as one too rather than left readable or dropped.
         """
         if not value:
             return value
         vtype = COMPOSITE_ID_DEVTYPE[key]
-        head, sep, tail = value.partition(",")
-        if not sep:
+        parts = value.split(",")
+        if len(parts) < 2:
             return self._mask_scalar(vtype, value, mapping, keep=keep)
-        masked_head = self._mask_scalar(vtype, head, mapping, keep=keep)
-        return f"{masked_head},{self.mask_text(tail, mapping, keep)}"
+        masked_parts = [
+            self._mask_scalar(vtype, part, mapping, keep=keep)
+            if i % 2 == 0
+            else self.mask_text(part, mapping, keep)
+            for i, part in enumerate(parts)
+        ]
+        return ",".join(masked_parts)
 
     def _mask_breakdowns(self, value: Any, mapping: dict[str, str], keep: frozenset[str]) -> Any:
         """``{dimension: [{"value": ..., "hits": N}, ...]}`` (#98).

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -2532,6 +2532,22 @@ class TestAuditConfirmedLeaks:
         assert self.MAC not in rendered
         assert second not in rendered
 
+    def test_a_second_hostname_pair_in_the_tail_does_not_leak(self, masker: OutputMasker) -> None:
+        """mac_devtype_agg's second-pair coverage above is incidental,
+        not designed: mask_text's MAC regex happens to catch a second
+        MAC, but has no hostname regex, so dev_src_agg's second pair had
+        no protection at all. Walking every pair by position rather than
+        only typing the first closes this without needing one."""
+        second = "wkstn-02.corp.local"
+        out = masker.mask_result(
+            {"dev_src_agg": f"{self.HOST},{self.DEVTYPE},{second},{self.DEVTYPE}"}
+        )
+        rendered = str(out)
+        assert self.HOST not in rendered
+        assert second not in rendered
+        # the devtype strings stay readable
+        assert rendered.count(self.DEVTYPE) == 2
+
     def test_a_value_with_no_comma_is_masked_whole(self, masker: OutputMasker) -> None:
         """Same fallback devvds uses for a shape it has not seen: mask the
         whole thing rather than hand back an untyped string."""

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -2380,3 +2380,205 @@ class TestCompositeContainerShapesKeepKeyContext:
         assert self.IP not in str(masker.mask_result({"grpby": [self._blob()]}))
         assert self.HOST not in str(masker.mask_result({"http_url": self.URL}))
         assert self.HOST not in str(masker.mask_result({"http_url": [self.URL]}))
+
+
+class TestAuditConfirmedLeaks:
+    """The five leaks confirmed by the live coverage sweep (#80).
+
+    Every one has the same shape: the masker covers one spelling of an
+    identifier and the appliance ships a second spelling of the same
+    value on the same surface, often in the same record. Because FPE is
+    deterministic, a record carrying both publishes the token and the
+    plaintext for one identifier and hands over the mapping.
+
+    Measured on 2.13.0 (``cfc2585``) with a known test key, in the live
+    record shape, with the device-identity flag both off and on:
+
+        {"mac_devtype_agg": "<mac>,DSM 7.3-86009"}   byte-identical
+        {"dev_src_agg": "<host>,DSM 7.3-86009"}      byte-identical
+        {"f_user": "<user>"}                         5 of 5 shapes verbatim
+        {"auto_raise_grpby": '[{"dstendpoint": "<ip>"}]'}   verbatim
+
+    while the covered twins (``mac``, ``dstmac``, ``hostname``,
+    ``srcname``, ``device``, ``unauthuser``, ``grpby``) all masked the
+    identical value.
+    """
+
+    MAC = "aa:bb:cc:dd:ee:11"
+    HOST = "wkstn-audit-01"
+    DEVTYPE = "Ubuntu 22.04.5"
+    UUID = "ffeb3f77-0000-4000-8000-000000000001"
+    IP = "198.51.100.22"
+    USER = "audituser"
+
+    # ---- f_user: a plain username slot, no composite involved ----
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            "audituser",
+            "audituser@example.com",
+            "EXAMPLE\\audituser",
+            "wkstn-audit-01",
+            "198.51.100.22",
+        ],
+    )
+    @pytest.mark.parametrize("flag", [False, True])
+    def test_f_user_does_not_leak_any_measured_payload_shape(
+        self, payload: str, flag: bool, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """All five shapes the audit measured. Whether a given one becomes
+        a token or a placeholder is the USERNAME handler's business; not
+        plaintext is the contract.
+
+        Asserts against the field, NOT against ``str(out)``: the repr
+        escapes a backslash, so ``EXAMPLE\\audituser`` is not a substring
+        of the rendered dict and that case could never have failed."""
+        monkeypatch.setenv("FAZ_MASKING_KEY", KEY)
+        masker = OutputMasker(FPEEngine(KEY), mask_device_identity=flag)
+        out = masker.mask_result({"f_user": payload})
+        assert out["f_user"] != payload
+        assert payload not in out["f_user"]
+
+    def test_f_user_masks_like_its_covered_twin(self, masker: OutputMasker) -> None:
+        """unauthuser holding the same literal masked while f_user did
+        not, in the same dict. That pairing is what hands over the map."""
+        out = masker.mask_result({"unauthuser": self.USER, "f_user": self.USER})
+        assert out["f_user"] == out["unauthuser"]
+
+    # ---- auto_raise_grpby: the twin of the covered grpby ----
+
+    def test_auto_raise_grpby_does_not_leak(self, masker: OutputMasker) -> None:
+        """COMPOSITE_JSON was ("grpby",) only. The audit's exact payload is
+        a JSON array string, not an object."""
+        blob = f'[{{"dstendpoint": "{self.IP}"}}]'
+        out = masker.mask_result({"auto_raise_grpby": blob})
+        assert self.IP not in str(out)
+
+    def test_auto_raise_grpby_masks_like_grpby(self, masker: OutputMasker) -> None:
+        blob = f'[{{"dstendpoint": "{self.IP}"}}]'
+        out = masker.mask_result({"grpby": blob, "auto_raise_grpby": blob})
+        assert out["auto_raise_grpby"] == out["grpby"]
+
+    # ---- the two <identifier>,<devtype> aggregates ----
+
+    @pytest.mark.parametrize("flag", [False, True])
+    def test_mac_devtype_agg_masks_the_mac_and_keeps_the_devtype(
+        self, flag: bool, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FAZ_MASKING_KEY", KEY)
+        masker = OutputMasker(FPEEngine(KEY), mask_device_identity=flag)
+        out = masker.mask_result({"mac_devtype_agg": f"{self.MAC},{self.DEVTYPE}"})
+        rendered = out["mac_devtype_agg"]
+        assert self.MAC not in rendered
+        assert rendered.endswith(f",{self.DEVTYPE}")
+
+    @pytest.mark.parametrize("flag", [False, True])
+    def test_dev_src_agg_masks_the_device_and_keeps_the_devtype(
+        self, flag: bool, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FAZ_MASKING_KEY", KEY)
+        masker = OutputMasker(FPEEngine(KEY), mask_device_identity=flag)
+        out = masker.mask_result({"dev_src_agg": f"{self.HOST},{self.DEVTYPE}"})
+        rendered = out["dev_src_agg"]
+        assert self.HOST not in rendered
+        assert rendered.endswith(f",{self.DEVTYPE}")
+
+    def test_the_agg_heads_mask_like_their_covered_twins(self, masker: OutputMasker) -> None:
+        """The whole point of the finding: the covered and uncovered
+        spellings land in the same record, so they must agree."""
+        out = masker.mask_result(
+            {
+                "mac": self.MAC,
+                "mac_devtype_agg": f"{self.MAC},{self.DEVTYPE}",
+                "hostname": self.HOST,
+                "dev_src_agg": f"{self.HOST},{self.DEVTYPE}",
+            }
+        )
+        assert out["mac_devtype_agg"] == f"{out['mac']},{self.DEVTYPE}"
+        assert out["dev_src_agg"] == f"{out['hostname']},{self.DEVTYPE}"
+
+    def test_the_aggs_are_not_gated_on_the_device_identity_flag(self, masker: OutputMasker) -> None:
+        """Their covered twins (mac, hostname) are FIELD_TYPES entries, so
+        they mask with the flag OFF. The neighbouring devvds handler IS
+        flag-gated, so the asymmetry needs a pin rather than an assumption
+        of symmetry."""
+        out = masker.mask_result(
+            {
+                "mac_devtype_agg": f"{self.MAC},{self.DEVTYPE}",
+                "dev_src_agg": f"{self.HOST},{self.DEVTYPE}",
+            }
+        )
+        assert self.MAC not in str(out)
+        assert self.HOST not in str(out)
+
+    def test_a_forticlient_uuid_head_is_masked_too(self, masker: OutputMasker) -> None:
+        """dev_src_agg also carries the FortiClient UUID form. The
+        srcuuid/dstuuid carve-out is scoped to those KEYS, not to the
+        value's shape, and nothing else in this masker types by shape, so
+        the head is masked by the key's type either way."""
+        out = masker.mask_result({"dev_src_agg": f"{self.UUID},macOS 10.15.7"})
+        assert self.UUID not in str(out)
+
+    def test_a_second_pair_in_the_tail_does_not_leak(self, masker: OutputMasker) -> None:
+        """These are agg fields: devvds's own docstring records that an
+        aggregating row comma-joins several. A verbatim tail would hand
+        back every identifier after the first."""
+        second = "aa:bb:cc:dd:ee:22"
+        out = masker.mask_result(
+            {"mac_devtype_agg": f"{self.MAC},{self.DEVTYPE},{second},{self.DEVTYPE}"}
+        )
+        rendered = str(out)
+        assert self.MAC not in rendered
+        assert second not in rendered
+
+    def test_a_value_with_no_comma_is_masked_whole(self, masker: OutputMasker) -> None:
+        """Same fallback devvds uses for a shape it has not seen: mask the
+        whole thing rather than hand back an untyped string."""
+        out = masker.mask_result({"mac_devtype_agg": self.MAC})
+        assert self.MAC not in str(out)
+
+    def test_an_empty_value_is_unchanged(self, masker: OutputMasker) -> None:
+        """The audit measured these empty on most live rows. An empty
+        string must not become a placeholder."""
+        out = masker.mask_result({"mac_devtype_agg": "", "dev_src_agg": "", "f_user": ""})
+        assert out == {"mac_devtype_agg": "", "dev_src_agg": "", "f_user": ""}
+
+    # ---- the new kind must be wired everywhere the existing kinds are ----
+
+    @pytest.mark.parametrize("key", ["mac_devtype_agg", "dev_src_agg", "auto_raise_grpby"])
+    def test_the_new_keys_survive_the_container_shapes(
+        self, masker: OutputMasker, key: str
+    ) -> None:
+        """A composite kind handled at one site and not another is exactly
+        how #73, #116 and #117 each found a leak. This walks the same
+        shapes #117's matrix walks."""
+        payloads = {
+            "mac_devtype_agg": f"{self.MAC},{self.DEVTYPE}",
+            "dev_src_agg": f"{self.HOST},{self.DEVTYPE}",
+            "auto_raise_grpby": f'[{{"dstendpoint": "{self.IP}"}}]',
+        }
+        secrets = {
+            "mac_devtype_agg": self.MAC,
+            "dev_src_agg": self.HOST,
+            "auto_raise_grpby": self.IP,
+        }
+        value, secret = payloads[key], secrets[key]
+        for shape in (value, [value], {"a": value}, [[value]], {value: 1}):
+            out = masker.mask_result({key: shape})
+            assert secret not in str(out), f"{key} leaked under {shape!r}"
+
+    @pytest.mark.parametrize("key", ["mac_devtype_agg", "dev_src_agg", "auto_raise_grpby"])
+    def test_the_new_keys_work_as_a_groupby_dimension(self, masker: OutputMasker, key: str) -> None:
+        """A composite key served by a handler rather than by FIELD_TYPES
+        has to be listed as a composite dimension too, or a breakdown
+        bucket under that name types from the empty table and passes
+        through in clear (the #109 review's finding)."""
+        payloads = {
+            "mac_devtype_agg": (f"{self.MAC},{self.DEVTYPE}", self.MAC),
+            "dev_src_agg": (f"{self.HOST},{self.DEVTYPE}", self.HOST),
+            "auto_raise_grpby": (f'[{{"dstendpoint": "{self.IP}"}}]', self.IP),
+        }
+        value, secret = payloads[key]
+        out = masker.mask_result({"breakdowns": {key: [{"value": value, "hits": 3}]}})
+        assert secret not in str(out)


### PR DESCRIPTION
Covers four of the five leaks confirmed in the #80 live sweep. The fifth is blocked on the #40 ruling; see the end.

**Stacked on #117**, which is stacked on #116. It will shrink to one commit as those land.

## What was wrong

Every one has the same shape, which is the finding that matters more than any single key: the masker covers one spelling of an identifier and the appliance ships a second spelling of the same value on the same surface, usually in the same record. FPE is deterministic, so a record carrying both publishes the token and the plaintext for one identifier and hands over the mapping.

| Key | Covered twin in the same record | Fix |
|---|---|---|
| `f_user` | `unauthuser`, `user`, `dstuser` | one `FIELD_TYPES` entry, `USERNAME` |
| `auto_raise_grpby` | `grpby` | added to `COMPOSITE_JSON` |
| `mac_devtype_agg` | `mac`, `dstmac`, `srcmac`, `stamac` | new `COMPOSITE_ID_DEVTYPE` handler |
| `dev_src_agg` | `hostname`, `srcname`, `device` | same handler, `HOSTNAME` head |

Measured on the sweep's own record shape after the fix, one masker, one key:

```
mac                ee:26:f1:4d:95:e0
mac_devtype_agg    ee:26:f1:4d:95:e0,Ubuntu 22.04.5
hostname           host-045f-d7.4v4tiek6m_5
dev_src_agg        host-045f-d7.4v4tiek6m_5,Ubuntu 22.04.5
unauthuser         user-045f-kPHUgn8~l
f_user             user-045f-kPHUgn8~l
grpby              [{"dstendpoint": "<masked>"}]
auto_raise_grpby   [{"dstendpoint": "<masked>"}]
```

Each uncovered spelling now produces exactly the token its covered twin produces. That equality is the thing worth pinning, not just "it is no longer plaintext": it proves the value routes through the same handler rather than a second one that happens to also mask.

## The two aggregates

`COMPOSITE_ID_DEVTYPE` maps each key to the type its own head carries, which is the type the covered flat spelling already uses.

**A flat `FIELD_TYPES` entry would have been the wrong fix** and I want to be explicit about why, since it is the obvious one-liner: it hands the whole `"<identifier>,<devtype>"` string to a scalar handler, which fails closed to an irreversible placeholder and burns the devtype with it. That is the same reason `devvds` has a handler rather than a type.

**The devtype tail stays readable.** It is an OS or product string, the same class as `srchwvendor` and `catdesc` that `fields.py` declines by name.

**The tail goes through `mask_text`, not back verbatim.** These are aggregating fields: `devvds`'s own docstring records that a row covering several devices comma-joins them. A verbatim tail would hand back every identifier after the first. Measured:

```
in : aa:bb:cc:dd:ee:11,Ubuntu 22.04.5,aa:bb:cc:dd:ee:22,Ubuntu 22.04.5
out: ee:26:f1:4d:95:e0,Ubuntu 22.04.5,17:18:34:bc:06:4a,Ubuntu 22.04.5
```

**Not gated on `FAZ_MASK_DEVICE_IDENTITY`**, unlike the `COMPOSITE_DEVICE_VDOM` handler sitting next to it. These carry endpoint identity, not estate identity, and their covered twins are `FIELD_TYPES` entries that mask with the flag off. Masking one spelling while its twin stays readable in the same record is the exact failure this issue is about. Pinned with its own test, because a reader will otherwise assume symmetry with the neighbour.

**A FortiClient UUID head is masked too.** `dev_src_agg` also carries `"<uuid>,macOS 10.15.7"`. The `srcuuid`/`dstuuid` carve-out is scoped to those keys, not to the value's shape, and nothing else in this masker types by shape, so the head is masked by the key's type either way. Flagging it since it is the one place this PR touches the carve-out's neighbourhood.

## Wiring, which is where this bug class keeps hiding

#73, #116 and #117 were each a composite kind handled at one site and not another. So the new kind is registered as a composite dimension as well as in the dispatch, and the tests walk **every container shape and both flag settings for all three new keys**, plus the breakdown-dimension path. That matrix is what would catch a missed site, and the `not-registered-as-dimension` mutant confirms it does.

## Not fixed: the fifth finding

A domain present only in free text is never masked, because pass 2 regexes IPv4, MAC and email but not domains.

**Blocked rather than deferred by preference.** A domain regex in `mask_text` must not re-mask the engine's own domain tokens, and the domain-token spelling is the open question on #40: the proposed v2 form is itself domain-shaped and would match any naive domain regex. Building this now means building against a format that may change. The false-positive cost is real too, since a bare `\w+\.[a-z]{2,}` matches ordinary filenames and version strings.

I will take it as soon as you rule on #40.

Also stated rather than left implicit: a second **hostname** inside an agg tail is not recovered, because no hostname regex exists in the free-text pass and adding one would burn ordinary prose. IPv4, MAC and email in a tail are caught.

## Verification

- 28 tests red first, 1 green (the empty-value pin). One of the red tests was **itself wrong** and was corrected before the fix: asserting a `DOMAIN\user` payload against `str(out)` can never fail, because the repr escapes the backslash, so that case was passing for the wrong reason. It asserts against the field now.
- Green control 312, then 10 mutants, all killed: each new key removed individually, `dev_src_agg` given the wrong type, the dimension registration dropped, the container arm dropped, the tail returned verbatim, the no-comma path passed through, and the head never split.
- 2123 tests pass, up from 2094 with nothing regressed. ruff and mypy clean.
