### PR TITLE
fix(masking): cover the second-tier audit keys that need only a table entry (#80)

### DIFF
--- a/src/fortianalyzer_mcp/masking/fields.py
+++ b/src/fortianalyzer_mcp/masking/fields.py
@@ -176,6 +176,12 @@ FIELD_TYPES: dict[str, str] = {
     "masterdstmac": MAC,
     "mac": MAC,
     "bssid": MAC,
+    # The name form of the same wireless network whose MAC form is
+    # bssid above. Masking one while the other sits beside it in clear
+    # is the twin disagreement #80 is about, so these follow bssid and
+    # mask regardless of the device-identity flag.
+    "ssid": HOSTNAME,
+    "vap": HOSTNAME,
     "stamac": MAC,
     "tamac": MAC,
     "source_mac": MAC,
@@ -401,12 +407,30 @@ FIELD_NAME_ARGS = ("fields", "group_by", "sample_by", "sort_by", "view_name")
 #:   groupby1/groupby2  "<fieldname>:<value>"   e.g. "dstip:192.0.2.1"
 #:   grpby              JSON, e.g. '[{"dstendpoint": "192.0.2.1"}]'
 #:   target             [{"name": "ip", "value": "192.0.2.1"}, ...]
-COMPOSITE_PREFIXED = ("groupby1", "groupby2")
+#: ``groupby3`` was uncovered while its two siblings were handled. The
+#: shipped alert-handler catalogue puts ``qname`` in slot 3 on one
+#: handler, so an allowlisted dimension rode through in clear purely
+#: because of which slot it landed in (#80).
+COMPOSITE_PREFIXED = ("groupby1", "groupby2", "groupby3")
 #: ``auto_raise_grpby`` is the incident-surface twin of ``grpby`` and
 #: carries the identical JSON payload; it was uncovered while its twin
 #: masked, measured on the live estate (#80).
 COMPOSITE_JSON = ("grpby", "auto_raise_grpby")
 COMPOSITE_TARGET = ("target",)
+
+#: The structural twin of ``target`` on the alert surface, same
+#: ``[{"name": ..., "value": ...}]`` shape, measured carrying an endpoint
+#: address in clear while five allowlisted renderings of the same asset
+#: masked in the same response (#80).
+#:
+#: Deliberately NOT folded into ``COMPOSITE_TARGET``: that kind burns every
+#: non-list shape, and ``get_endpoints`` at ``detail_level="standard"``
+#: emits a bare scalar ``source``, so a blanket burn would destroy an
+#: ordinary field on every endpoint read. ``target`` can afford to burn
+#: because the name is specific to one surface; ``source`` is a generic
+#: word and cannot. Only the list form is claimed here; every other shape
+#: keeps the ordinary allowlist treatment.
+COMPOSITE_SOURCE = ("source",)
 
 #: ``analyze_policy_traffic`` and ``query_logs(sample_by=...)``:
 #: ``{dimension: [{"value": "...", "hits": N}, ...]}``. The dimension name
@@ -497,8 +521,19 @@ COMPOSITE_ID_DEVTYPE: dict[str, str] = {
 DEVICE_IDENTITY_TYPES: dict[str, str] = {
     "devname": HOSTNAME,
     "devid": HOSTNAME,
+    # logs-event: the access point's own name, estate identity of the
+    # same class as devname, so it follows the flag rather than masking
+    # unconditionally the way the ssid beside it does (#80).
+    "ap": HOSTNAME,
     "sn": HOSTNAME,
     "serialno": HOSTNAME,
+    # get_system_status spells its keys Title Case With Spaces.
+    # "Hostname" matched despite the capital H because every key match
+    # lowercases, but "Serial Number" differs from sn by more than
+    # case and matched nothing, so the serial rode out beside a masked
+    # hostname in the same dict (#80). Key matching lowercases and does
+    # not strip whitespace, so the alias is spelled with the space.
+    "serial number": HOSTNAME,
     "csf": HOSTNAME,
     "sndetected": HOSTNAME,
     "snclosest": HOSTNAME,
@@ -544,7 +579,12 @@ COMPOSITE_URL_HOST = ("http_url",)
 #: puts the indicator in its query string ("...?query=<indicator>"), so the
 #: sensitive part is the tail, not the public portal host. Same treatment
 #: as ``url``, which keeps it reversible for anyone who wants to follow it.
-COMPOSITE_URL_FULL = ("url", "referralurl", "link")
+#: ``link`` is here precisely because the reputation source puts the
+#: indicator in the reference URL query string, but the raw IOC tool
+#: emits ``reference_url``: ``client.py`` sets the row verbatim and
+#: only the skills layer renames it, so the raw spelling was typed by
+#: nothing (#80).
+COMPOSITE_URL_FULL = ("url", "referralurl", "link", "reference_url")
 
 # Values that carry no identifier and pass through unmasked.
 SKIP_VALUES = frozenset({"", "N/A", "n/a", "unknown", "none", "-"})

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -595,9 +595,50 @@ class OutputMasker:
 
         Keys are masked as well as values: no later pass ever scans a key,
         so a map keyed by the identifier hands it over as the key itself.
+
+        COMPOSITE_JSON's dict form is the one exception to "re-enter under
+        the same key": a native dict here can be either shape _mask_json_blob
+        would otherwise have to parse out of a string -- an already-parsed
+        payload, whose own field names (not the outer key) type its
+        contents, or a wrapper whose values are themselves JSON-string
+        blobs one level down (the same shape #117's tests keep under the
+        outer key). Re-entering everything under the outer key asked
+        _mask_entry to type the whole dict as e.g. "grpby", which only the
+        str-only _mask_json_blob can read; every field inside a parsed
+        payload fell through unmasked. Measured:
+        {"grpby": [{"dstendpoint": "web-01.corp.local"}]} (a list containing
+        one such dict) leaked the hostname in clear while the JSON-STRING
+        form of the identical payload correctly masked it.
+
+        Distinguishing the two shapes per inner value rather than per whole
+        dict: a string value that parses as JSON is a nested blob and goes
+        to _mask_json_blob (preserves #117's wrapper-of-blobs shape); any
+        other value belongs to this dict's own structure and is typed by
+        its own inner key via _mask_entry, not the outer composite key --
+        that inner-key dispatch is what correctly masks a bare
+        "dstendpoint": "web-01.corp.local" pair, typed rather than caught
+        incidentally by mask_text's IP/MAC/email-only regexes. A nested
+        dict/list value recurses through _mask_structured so its own keys
+        keep typing it. A list of JSON-string elements is unaffected: each
+        string element still re-enters under the outer key one level up
+        and dispatches to _mask_json_blob exactly as before.
         """
         if isinstance(value, list | tuple):
             return [self._mask_entry(key, item, mapping, keep) for item in value]
+        if key in COMPOSITE_JSON:
+            out: dict[Any, Any] = {}
+            for inner_key, item in value.items():
+                masked_key = self._mask_entry(key, inner_key, mapping, keep)
+                if isinstance(item, str):
+                    try:
+                        json.loads(item)
+                    except (ValueError, TypeError):
+                        out[masked_key] = self._mask_entry(inner_key, item, mapping, keep)
+                    else:
+                        out[masked_key] = self._mask_json_blob(item, mapping, keep)
+                else:
+                    out[masked_key] = self._mask_structured(item, mapping, keep)
+            return out
         return {
             self._mask_entry(key, inner_key, mapping, keep): self._mask_entry(
                 key, item, mapping, keep

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -77,6 +77,7 @@ from fortianalyzer_mcp.masking.fields import (
     COMPOSITE_ID_DEVTYPE,
     COMPOSITE_JSON,
     COMPOSITE_PREFIXED,
+    COMPOSITE_SOURCE,
     COMPOSITE_TARGET,
     COMPOSITE_URL_FULL,
     COMPOSITE_URL_HOST,
@@ -1227,6 +1228,13 @@ class OutputMasker:
             # cost is the same too: any analytic structure a producer put
             # there burns rather than round-tripping.
             return self._burn_strings(value, keep)
+        if lowered in COMPOSITE_SOURCE and isinstance(value, list):
+            # The list form is target's shape and gets target's handler.
+            # No other arm on purpose: unlike "target", the name "source"
+            # is generic (get_endpoints emits a bare scalar one), so every
+            # other shape keeps the ordinary allowlist treatment rather
+            # than being burned. See COMPOSITE_SOURCE in fields.py.
+            return self._mask_target(value, mapping, keep)
         if lowered in COMPOSITE_TARGET:
             if isinstance(value, list):
                 return self._mask_target(value, mapping, keep)

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -1285,12 +1285,24 @@ class OutputMasker:
             # cost is the same too: any analytic structure a producer put
             # there burns rather than round-tripping.
             return self._burn_strings(value, keep)
-        if lowered in COMPOSITE_SOURCE and isinstance(value, list):
-            # The list form is target's shape and gets target's handler.
-            # No other arm on purpose: unlike "target", the name "source"
-            # is generic (get_endpoints emits a bare scalar one), so every
-            # other shape keeps the ordinary allowlist treatment rather
-            # than being burned. See COMPOSITE_SOURCE in fields.py.
+        if (
+            lowered in COMPOSITE_SOURCE
+            and isinstance(value, list)
+            and any(isinstance(item, dict) for item in value)
+        ):
+            # Gated on the ELEMENT type, not just on being a list, because
+            # "source" has two live shapes and only one of them is
+            # target's. The alert surface sends [{"name": ..., "value":
+            # ...}], which carries an identifier. The UEBA endpoint
+            # surface sends a list of bare detection-method labels, and
+            # _mask_target burns every entry that is not a dict, so
+            # claiming the whole list destroyed them (measured live: 152
+            # of 394 endpoint records, 16 distinct label values, burned
+            # irreversibly with the device-identity flag off).
+            #
+            # Everything else keeps the ordinary allowlist treatment, for
+            # the reason in fields.py: "source" is a generic name and this
+            # key cannot afford target's burn-by-default.
             return self._mask_target(value, mapping, keep)
         if lowered in COMPOSITE_TARGET:
             if isinstance(value, list):

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -2582,3 +2582,153 @@ class TestAuditConfirmedLeaks:
         value, secret = payloads[key]
         out = masker.mask_result({"breakdowns": {key: [{"value": value, "hits": 3}]}})
         assert secret not in str(out)
+
+
+class TestSecondTierAuditKeys:
+    """The #80 second-tier table, re-measured at `0d17c41` and fixed where
+    the fix is an allowlist or composite entry rather than a mechanism.
+
+    Two rows of that table did NOT survive re-measurement and are pinned
+    here as correct rather than fixed, because the sweep ran with
+    FAZ_MASK_DEVICE_IDENTITY off and estate identity is clear by design in
+    that configuration:
+
+      - ``name`` on ``list_devices`` masks correctly with the flag on when
+        the record carries a device-proving sibling (``sn``,
+        ``platform_str``). The bare ``{"name": ...}`` form is not a device
+        object and must stay clear, which is what the sibling machinery
+        exists to decide.
+      - ``devid`` on a vdom object masks with the flag on.
+
+    Each key below is classified by the table its covered twin already
+    uses, which is the whole principle of the audit: two spellings of one
+    value in one record must not disagree.
+    """
+
+    IP = "192.0.2.57"
+    HOST = "wkstn-audit-01"
+    SN = "FAZVM0000000000"
+    SSID = "CorpWiFi"
+    AP = "ap-lobby-01"
+    MAC = "aa:bb:cc:dd:ee:11"
+
+    def _masker(self, monkeypatch: pytest.MonkeyPatch, flag: bool) -> OutputMasker:
+        monkeypatch.setenv("FAZ_MASKING_KEY", KEY)
+        return OutputMasker(FPEEngine(KEY), mask_device_identity=flag)
+
+    # ---- source: the structural twin of target ----
+
+    def test_source_entries_mask_like_target(self, masker: OutputMasker) -> None:
+        """Same [{"name": ..., "value": ...}] shape, alongside target in the
+        same alert. Measured leaking: five allowlisted renderings of the
+        same asset masked while source kept the address in clear."""
+        entry = [{"name": "device", "value": self.IP, "risk_type": "EndPoint"}]
+        out = masker.mask_result({"target": entry, "source": list(entry)})
+        assert self.IP not in str(out)
+        assert out["source"] == out["target"]
+
+    def test_a_scalar_source_is_not_burned(self, masker: OutputMasker) -> None:
+        """Deliberate divergence from target, which burns every non-list
+        shape. ``get_endpoints`` at detail_level="standard" emits a bare
+        ``source`` (measured during the #80 sweep), so a blanket burn would
+        destroy an ordinary enum on every endpoint read. target can burn
+        because the name is specific to the alert surface; source cannot,
+        because the name is generic."""
+        out = masker.mask_result({"source": "FortiClient"})
+        assert out["source"] == "FortiClient"
+
+    # ---- groupby3: an allowlisted dimension riding through on slot ----
+
+    def test_groupby3_masks_like_its_lower_numbered_siblings(self, masker: OutputMasker) -> None:
+        """The shipped handler catalogue puts qname in slot 3 on one
+        handler, so an allowlisted dimension rode through in clear purely
+        because of which slot it landed in."""
+        out = masker.mask_result({"groupby1": f"srcip:{self.IP}", "groupby3": f"srcip:{self.IP}"})
+        assert self.IP not in str(out)
+        assert out["groupby3"] == out["groupby1"]
+
+    # ---- Serial Number: the system-status vocabulary ----
+
+    def test_serial_number_follows_the_flag_like_sn(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """get_system_status spells its keys Title Case With Spaces.
+        Hostname matched despite the capital H because matching lowercases,
+        but "Serial Number" differs from sn by more than case. It is estate
+        identity, so it follows FAZ_MASK_DEVICE_IDENTITY exactly as sn
+        does: clear with the flag off, masked with it on."""
+        off = self._masker(monkeypatch, False).mask_result({"Serial Number": self.SN})
+        assert off["Serial Number"] == self.SN
+
+        on = self._masker(monkeypatch, True).mask_result({"Serial Number": self.SN, "sn": self.SN})
+        assert self.SN not in str(on)
+        assert on["Serial Number"] == on["sn"]
+
+    # ---- wireless: each key classified by its own twin ----
+
+    def test_ssid_and_vap_mask_whenever_bssid_does(self, masker: OutputMasker) -> None:
+        """bssid is a plain FIELD_TYPES entry, so it masks with the flag
+        off. The MAC form of a wireless network being masked while the name
+        form of the SAME network sits beside it in clear is exactly the
+        twin disagreement this audit is about."""
+        out = masker.mask_result({"bssid": self.MAC, "ssid": self.SSID, "vap": self.SSID})
+        assert self.SSID not in str(out)
+        assert out["ssid"] == out["vap"]
+
+    def test_ap_follows_the_flag_like_devname(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An access point name is estate identity, the same class as
+        devname, so it follows the flag rather than masking unconditionally
+        the way ssid does. The asymmetry is intentional and follows from
+        each key's own twin."""
+        off = self._masker(monkeypatch, False).mask_result({"ap": self.AP})
+        assert off["ap"] == self.AP
+
+        on = self._masker(monkeypatch, True).mask_result({"ap": self.AP, "devname": self.AP})
+        assert self.AP not in str(on)
+        assert on["ap"] == on["devname"]
+
+    # ---- reference_url ----
+
+    def test_reference_url_masks_like_url(self, masker: OutputMasker) -> None:
+        """COMPOSITE_URL_FULL carries "link" precisely because the
+        reputation source puts the indicator in the reference URL query
+        string, but the raw tool emits reference_url, which was typed by
+        nothing."""
+        raw = f"https://ti.example.com/q?ioc={self.IP}"
+        out = masker.mask_result({"url": raw, "reference_url": raw})
+        assert self.IP not in str(out)
+        assert out["reference_url"] == out["url"]
+
+    # ---- the container-shape matrix, extended to the new composite keys ----
+
+    @pytest.mark.parametrize("key", ["groupby3", "reference_url"])
+    def test_the_new_composite_keys_survive_the_container_shapes(
+        self, masker: OutputMasker, key: str
+    ) -> None:
+        payloads = {
+            "groupby3": (f"srcip:{self.IP}", self.IP),
+            "reference_url": (f"https://ti.example.com/q?ioc={self.IP}", self.IP),
+        }
+        value, secret = payloads[key]
+        for shape in (value, [value], {"a": value}, [[value]]):
+            out = masker.mask_result({key: shape})
+            assert secret not in str(out), f"{key} leaked under {shape!r}"
+
+    # ---- the two rows that did not survive re-measurement ----
+
+    def test_a_device_object_name_masks_with_the_flag_on(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pinned as correct, not fixed. The #80 table listed this as a
+        leak; the sweep ran flag-off, where estate identity is clear by
+        design."""
+        on = self._masker(monkeypatch, True)
+        assert self.HOST not in str(on.mask_result({"name": self.HOST, "sn": self.SN}))
+        assert self.HOST not in str(
+            on.mask_result({"name": self.HOST, "platform_str": "FortiGate-VM64"})
+        )
+
+    def test_a_bare_name_is_not_treated_as_a_device(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The counterpart. A name with no device-proving sibling belongs
+        to an ADOM, a report layout or a group, and burning it would mangle
+        every one of those."""
+        on = self._masker(monkeypatch, True)
+        assert on.mask_result({"name": "my-report-layout"}) == {"name": "my-report-layout"}

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -2774,3 +2774,60 @@ class TestSecondTierAuditKeys:
         every one of those."""
         on = self._masker(monkeypatch, True)
         assert on.mask_result({"name": "my-report-layout"}) == {"name": "my-report-layout"}
+
+
+class TestSourceListOfStringsIsNotBurned:
+    """``source`` has two live shapes, and only one of them is target's.
+
+    Measured on a live FortiAnalyzer, ``get_endpoints(detail_level=
+    "standard", fields=["*"])``: 394 records, 152 carry ``source``, and
+    every one of the 152 is an **array of strings**. Zero dicts, zero
+    scalars. The 16 distinct values all contain a space, none contains a
+    dot, colon, ``@`` or an all-hex form, and none matches any other key
+    on its own record. They are the detection-method labels the UEBA
+    schema describes ("The source(s) of detecting an endpoint"), not
+    identifiers.
+
+    Routing every list to ``_mask_target`` burned all of them, because
+    that handler burns any entry that is not a dict. Irreversibly, and
+    with ``FAZ_MASK_DEVICE_IDENTITY`` off, so a deployment lost a label
+    vocabulary it was entitled to read and got no privacy for it.
+
+    The alert shape, ``[{"name": ..., "value": ...}]``, is the one that
+    carries an identifier and still gets target's handler. So the arm is
+    gated on the ELEMENT type rather than on the value being a list.
+    """
+
+    IP = "192.0.2.35"
+    LABELS = ["FortiClient EMS", "Endpoint Vulnerability Scan"]
+
+    def test_a_list_of_label_strings_survives(self, masker: OutputMasker) -> None:
+        out = masker.mask_result({"source": list(self.LABELS)})
+        assert out["source"] == self.LABELS
+
+    def test_a_list_of_label_strings_survives_with_the_flag_on(
+        self, full_masker: OutputMasker
+    ) -> None:
+        """Flag-independent: these are not estate identity under either
+        setting, so neither setting should burn them."""
+        out = full_masker.mask_result({"source": list(self.LABELS)})
+        assert out["source"] == self.LABELS
+
+    def test_the_alert_entry_shape_still_masks(self, masker: OutputMasker) -> None:
+        """The half that must not regress. A dict entry still carries an
+        identifier and still goes through target's handler."""
+        entry = [{"name": "device", "value": self.IP, "risk_type": "EndPoint"}]
+        out = masker.mask_result({"target": [dict(entry[0])], "source": entry})
+        assert self.IP not in str(out)
+        assert out["source"] == out["target"]
+
+    def test_a_mixed_list_still_masks_its_dict_entries(self, masker: OutputMasker) -> None:
+        """A list carrying both shapes is typed by what is in it, not by
+        the first element."""
+        out = masker.mask_result({"source": [{"name": "ip", "value": self.IP}, "FortiClient EMS"]})
+        assert self.IP not in str(out)
+
+    def test_a_scalar_source_is_still_not_burned(self, masker: OutputMasker) -> None:
+        """Unchanged, and still the reason this key is not folded into
+        COMPOSITE_TARGET."""
+        assert masker.mask_result({"source": "FortiClient"})["source"] == "FortiClient"

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -2362,6 +2362,32 @@ class TestCompositeContainerShapesKeepKeyContext:
         out = masker.mask_result({"grpby": [[self._blob()]]})
         assert self.IP not in str(out)
 
+    # ---- grpby: the ALREADY-PARSED dict form, not a JSON-string blob ----
+    #
+    # Distinct from the map-of-blob-string tests above: here the dict IS
+    # the parsed payload (as fetch_fortiview hands it back for some FAZ
+    # builds), not a wrapper whose values are still JSON strings. Measured
+    # live: {"grpby": [{"dstendpoint": "<hostname>"}]} leaked the hostname
+    # verbatim while the JSON-STRING form of the identical payload masked
+    # it correctly -- the dict form had no key-typed arm and fell through
+    # to the outer-key-only route, which only a bare string can be typed
+    # by. A hostname (not an IP) is used deliberately: it cannot be caught
+    # incidentally by mask_text's IP/MAC/email regexes, so it only passes
+    # if the dict's own inner key ("dstendpoint") is actually doing the
+    # typing.
+
+    NATIVE_HOST = "websrv-native-01.corp.local"
+
+    def test_a_grpby_list_of_native_dicts_does_not_leak_a_hostname(
+        self, masker: OutputMasker
+    ) -> None:
+        out = masker.mask_result({"grpby": [{"dstendpoint": self.NATIVE_HOST}]})
+        assert self.NATIVE_HOST not in str(out)
+
+    def test_a_grpby_bare_native_dict_does_not_leak_a_hostname(self, masker: OutputMasker) -> None:
+        out = masker.mask_result({"grpby": {"dstendpoint": self.NATIVE_HOST}})
+        assert self.NATIVE_HOST not in str(out)
+
     # ---- the URL composites, one level down from the arm that works ----
 
     @pytest.mark.parametrize("key", ["http_url", "url", "referralurl", "link"])


### PR DESCRIPTION
Works the #80 second-tier table: the findings that were measured during the sweep but not adversarially re-verified. Every one was re-measured at `0d17c41` first, and the rows fixed here are the ones whose fix is a table entry rather than a mechanism.

**Stacked on #118**, which is stacked on #117 and #116. It will shrink to one commit as those land.

## Two rows of the table were wrong, including one I published

Re-measuring under the right flag setting is what found them. The sweep ran with `FAZ_MASK_DEVICE_IDENTITY` **off**, where estate identity is clear by design, so two entries were read as leaks when they were the documented behaviour:

| Row | Re-measured | Verdict |
|---|---|---|
| `name` on `list_devices` | masks flag-on when the record carries a device-proving sibling (`sn`, `platform_str`) | **not a leak** |
| `devid` on a vdom object | masks flag-on | **not a leak** |

The bare `{"name": ...}` form stays clear on purpose: without a proving sibling it belongs to an ADOM, a report layout or a device group, which is what the `_DEVICE_SHAPE_SIBLINGS` machinery exists to decide. Both are now pinned as correct, along with the counterpart pin that a bare name is not burned.

This is the same trap the sweep's own method warning describes, one level up: the first warning was that a badly sorted surface looks clean, and this one is that a flag-off run makes correct behaviour look like a leak. I am correcting it on #80 as well.

## Fixed

| Key | Twin it now matches | Table |
|---|---|---|
| `source` | `target` | new `COMPOSITE_SOURCE`, list arm only |
| `groupby3` | `groupby1`, `groupby2` | `COMPOSITE_PREFIXED` |
| `reference_url` | `link` | `COMPOSITE_URL_FULL` |
| `ssid`, `vap` | `bssid` | `FIELD_TYPES`, always masks |
| `ap` | `devname` | `DEVICE_IDENTITY_TYPES`, flag-gated |
| `serial number` | `sn` | `DEVICE_IDENTITY_TYPES`, flag-gated |

Two classification calls that could each have gone the lazy way:

**`source` is not folded into `COMPOSITE_TARGET`.** That kind burns every non-list shape, and `get_endpoints` at `detail_level="standard"` emits a bare scalar `source` (measured during the sweep). A blanket burn would destroy an ordinary field on every endpoint read, which is the over-mask class #75 had to be walked back for. `target` can afford to burn because the name is specific to one surface; `source` is a generic word and cannot. Only the list form is claimed, and a scalar passing through is pinned by its own test.

**`ssid` and `ap` land in different tables on purpose.** `ssid` and `vap` are the name form of the network whose MAC form is `bssid`, and `bssid` is a plain `FIELD_TYPES` entry that masks with the flag off, so they must too. `ap` is the access point's own name, estate identity of the same class as `devname`, so it follows the flag. Both asymmetries are pinned, because a reader will otherwise assume the four wireless keys behave alike.

Small mechanical note: key matching lowercases but does not strip whitespace, so the `get_system_status` spelling is registered literally as `"serial number"`.

## Not fixed, each for a stated reason

- **`msg` (percent-encoded).** A mechanism change, not a table entry: the free-text scan has to decode before matching, then decide whether to emit the decoded form or the original. That is a format decision about tool output and deserves its own change rather than riding along here.
- **`links.self`.** `self` is far too generic to type. It wants either a `links` composite that URL-masks its string values, or a fix at the skills rename layer. The IOC/SOAR surface is unlicensed on our estate, so this remains a code read and I would rather not ship a guess against a surface I cannot exercise.
- **`subject`, and `name` on incidents.** Both are a hostname sitting in prose. Masking those needs a hostname regex in the free-text pass, which is the same design question as the domain leak deferred in #118, and it burns ordinary prose if it is wrong.

## Also re-measured: #73 items 2 to 7

Since this branch sits on the three PRs that touched that code, I checked whether the older residuals still reproduce. **Items 2, 3, 4, 5 and 7a no longer do** at `0d17c41`; item 6 does. Posting the probes and the closing PRs on #73 separately rather than burying it here.

## Verification

- 8 tests red first, 3 green from the start: the scalar-`source` pin and the two re-measurement pins, all three there to catch an over-correction.
- Green control 323, then 10 mutants, all killed: each key removed individually, `COMPOSITE_SOURCE` emptied, its arm redirected, a burn added for scalar `source`, and `ap` moved into the wrong table.
- 2134 tests pass, up from 2123, nothing regressed. ruff and mypy clean.
