### PR TITLE
fix(masking): find identifiers inside percent-encoded free text (#80)

### DIFF
--- a/src/fortianalyzer_mcp/masking/fields.py
+++ b/src/fortianalyzer_mcp/masking/fields.py
@@ -202,6 +202,11 @@ FIELD_TYPES: dict[str, str] = {
     "domainctrlname": HOSTNAME,
     # --- username carriers
     "user": USERNAME,
+    # fortiview-sources ships this beside the covered "unauthuser"; the
+    # live sweep measured 5 of 5 payload shapes riding out verbatim
+    # (username, email, DOMAIN\\user, hostname, IPv4) while the twin two
+    # keys away masked the identical literal (#80).
+    "f_user": USERNAME,
     "dstuser": USERNAME,
     "unauthuser": USERNAME,
     "xauthuser": USERNAME,
@@ -397,7 +402,10 @@ FIELD_NAME_ARGS = ("fields", "group_by", "sample_by", "sort_by", "view_name")
 #:   grpby              JSON, e.g. '[{"dstendpoint": "192.0.2.1"}]'
 #:   target             [{"name": "ip", "value": "192.0.2.1"}, ...]
 COMPOSITE_PREFIXED = ("groupby1", "groupby2")
-COMPOSITE_JSON = ("grpby",)
+#: ``auto_raise_grpby`` is the incident-surface twin of ``grpby`` and
+#: carries the identical JSON payload; it was uncovered while its twin
+#: masked, measured on the live estate (#80).
+COMPOSITE_JSON = ("grpby", "auto_raise_grpby")
 COMPOSITE_TARGET = ("target",)
 
 #: ``analyze_policy_traffic`` and ``query_logs(sample_by=...)``:
@@ -461,6 +469,28 @@ OBF_URL_KEY = "obf_url"
 #: whole string fails closed to an irreversible placeholder. Follows
 #: ``FAZ_MASK_DEVICE_IDENTITY`` like the flat device keys below.
 COMPOSITE_DEVICE_VDOM = ("devvds",)
+
+#: fortiview-sources aggregates: ``"<identifier>,<devtype>"``, where the
+#: tail is an OS or product string (``"DSM 7.3-86009"``, ``"Ubuntu
+#: 22.04.5"``). Each maps to the type its own head carries, which is the
+#: type the covered flat spelling of the same value already uses:
+#: ``mac_devtype_agg`` beside ``mac``/``dstmac``, ``dev_src_agg`` beside
+#: ``hostname``/``srcname``/``device``.
+#:
+#: A flat ``FIELD_TYPES`` entry is the wrong fix and was rejected: it would
+#: hand the whole ``"<identifier>,<devtype>"`` string to a scalar handler,
+#: which fails closed to an irreversible placeholder and burns the devtype
+#: with it. Same reason ``devvds`` has a handler rather than a type.
+#:
+#: NOT gated on ``FAZ_MASK_DEVICE_IDENTITY``, unlike the neighbouring
+#: ``COMPOSITE_DEVICE_VDOM``. These carry endpoint identity, not estate
+#: identity: their covered twins are ``FIELD_TYPES`` entries that mask with
+#: the flag off, and masking one spelling while its twin stays readable in
+#: the same record is what publishes the mapping (#80).
+COMPOSITE_ID_DEVTYPE: dict[str, str] = {
+    "mac_devtype_agg": MAC,
+    "dev_src_agg": HOSTNAME,
+}
 
 #: Estate identity, not personal data. Masked only when the deployment
 #: opts in via ``FAZ_MASK_DEVICE_IDENTITY``; see the module docstring.

--- a/src/fortianalyzer_mcp/masking/fields.py
+++ b/src/fortianalyzer_mcp/masking/fields.py
@@ -176,6 +176,12 @@ FIELD_TYPES: dict[str, str] = {
     "masterdstmac": MAC,
     "mac": MAC,
     "bssid": MAC,
+    # The name form of the same wireless network whose MAC form is
+    # bssid above. Masking one while the other sits beside it in clear
+    # is the twin disagreement #80 is about, so these follow bssid and
+    # mask regardless of the device-identity flag.
+    "ssid": HOSTNAME,
+    "vap": HOSTNAME,
     "stamac": MAC,
     "tamac": MAC,
     "source_mac": MAC,
@@ -401,12 +407,30 @@ FIELD_NAME_ARGS = ("fields", "group_by", "sample_by", "sort_by", "view_name")
 #:   groupby1/groupby2  "<fieldname>:<value>"   e.g. "dstip:192.0.2.1"
 #:   grpby              JSON, e.g. '[{"dstendpoint": "192.0.2.1"}]'
 #:   target             [{"name": "ip", "value": "192.0.2.1"}, ...]
-COMPOSITE_PREFIXED = ("groupby1", "groupby2")
+#: ``groupby3`` was uncovered while its two siblings were handled. The
+#: shipped alert-handler catalogue puts ``qname`` in slot 3 on one
+#: handler, so an allowlisted dimension rode through in clear purely
+#: because of which slot it landed in (#80).
+COMPOSITE_PREFIXED = ("groupby1", "groupby2", "groupby3")
 #: ``auto_raise_grpby`` is the incident-surface twin of ``grpby`` and
 #: carries the identical JSON payload; it was uncovered while its twin
 #: masked, measured on the live estate (#80).
 COMPOSITE_JSON = ("grpby", "auto_raise_grpby")
 COMPOSITE_TARGET = ("target",)
+
+#: The structural twin of ``target`` on the alert surface, same
+#: ``[{"name": ..., "value": ...}]`` shape, measured carrying an endpoint
+#: address in clear while five allowlisted renderings of the same asset
+#: masked in the same response (#80).
+#:
+#: Deliberately NOT folded into ``COMPOSITE_TARGET``: that kind burns every
+#: non-list shape, and ``get_endpoints`` at ``detail_level="standard"``
+#: emits a bare scalar ``source``, so a blanket burn would destroy an
+#: ordinary field on every endpoint read. ``target`` can afford to burn
+#: because the name is specific to one surface; ``source`` is a generic
+#: word and cannot. Only the list form is claimed here; every other shape
+#: keeps the ordinary allowlist treatment.
+COMPOSITE_SOURCE = ("source",)
 
 #: ``analyze_policy_traffic`` and ``query_logs(sample_by=...)``:
 #: ``{dimension: [{"value": "...", "hits": N}, ...]}``. The dimension name
@@ -497,8 +521,19 @@ COMPOSITE_ID_DEVTYPE: dict[str, str] = {
 DEVICE_IDENTITY_TYPES: dict[str, str] = {
     "devname": HOSTNAME,
     "devid": HOSTNAME,
+    # logs-event: the access point's own name, estate identity of the
+    # same class as devname, so it follows the flag rather than masking
+    # unconditionally the way the ssid beside it does (#80).
+    "ap": HOSTNAME,
     "sn": HOSTNAME,
     "serialno": HOSTNAME,
+    # get_system_status spells its keys Title Case With Spaces.
+    # "Hostname" matched despite the capital H because every key match
+    # lowercases, but "Serial Number" differs from sn by more than
+    # case and matched nothing, so the serial rode out beside a masked
+    # hostname in the same dict (#80). Key matching lowercases and does
+    # not strip whitespace, so the alias is spelled with the space.
+    "serial number": HOSTNAME,
     "csf": HOSTNAME,
     "sndetected": HOSTNAME,
     "snclosest": HOSTNAME,
@@ -544,7 +579,12 @@ COMPOSITE_URL_HOST = ("http_url",)
 #: puts the indicator in its query string ("...?query=<indicator>"), so the
 #: sensitive part is the tail, not the public portal host. Same treatment
 #: as ``url``, which keeps it reversible for anyone who wants to follow it.
-COMPOSITE_URL_FULL = ("url", "referralurl", "link")
+#: ``link`` is here precisely because the reputation source puts the
+#: indicator in the reference URL query string, but the raw IOC tool
+#: emits ``reference_url``: ``client.py`` sets the row verbatim and
+#: only the skills layer renames it, so the raw spelling was typed by
+#: nothing (#80).
+COMPOSITE_URL_FULL = ("url", "referralurl", "link", "reference_url")
 
 # Values that carry no identifier and pass through unmasked.
 SKIP_VALUES = frozenset({"", "N/A", "n/a", "unknown", "none", "-"})

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -69,6 +69,7 @@ import os
 import re
 from functools import wraps
 from typing import Any
+from urllib.parse import unquote
 
 from fortianalyzer_mcp.masking.fields import (
     COMPOSITE_BREAKDOWNS,
@@ -1424,10 +1425,45 @@ class OutputMasker:
         if value.strip() in SKIP_VALUES:
             return value
         try:
-            return self.mask_text(value, mapping, keep)
+            masked = self.mask_text(value, mapping, keep)
+            if masked != value:
+                return masked
+            return self._mask_percent_encoded_text(value, masked, mapping, keep)
         except Exception:
             logger.exception("unexpected error masking free text; placeholder used")
             return self.placeholder(value)
+
+    def _mask_percent_encoded_text(
+        self, value: str, masked: str, mapping: dict[str, str], keep: frozenset[str]
+    ) -> str:
+        """Second look at free text that FortiAnalyzer percent-encoded.
+
+        ``msg`` arrives encoded, so a MAC reaches the scan as
+        ``aa%3Abb%3A...`` and an email as ``analyst%40example.com``. The
+        pass-2 regexes need the literal ``:`` and ``@``, so neither
+        matched, and the original stayed readable beside its own masked
+        twin in the structured field of the same record (#80).
+
+        Decoding is a means of FINDING identifiers, not a reformatting of
+        tool output, so the caller keeps the exact bytes FortiAnalyzer
+        sent unless the decode actually surfaces something to mask. That
+        is what keeps ``"CPU 100% busy"`` and an encoded path with no
+        identifier in it byte-identical.
+
+        When it does surface one, the decoded and masked form goes out.
+        Re-encoding the untouched spans around a substitution is not
+        attempted: the token is not the same length or alphabet as what it
+        replaced, so a faithful round trip is not available, and emitting
+        a half-encoded string would be worse than the honest decoded one.
+        """
+        decoded = unquote(value)
+        if decoded == value:
+            return masked
+        decoded_masked = self.mask_text(decoded, mapping, keep)
+        if decoded_masked == decoded:
+            # Nothing found either way: hand back the original bytes.
+            return masked
+        return decoded_masked
 
     # -- tool-result entry point ----------------------------------------- #
 

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -595,9 +595,50 @@ class OutputMasker:
 
         Keys are masked as well as values: no later pass ever scans a key,
         so a map keyed by the identifier hands it over as the key itself.
+
+        COMPOSITE_JSON's dict form is the one exception to "re-enter under
+        the same key": a native dict here can be either shape _mask_json_blob
+        would otherwise have to parse out of a string -- an already-parsed
+        payload, whose own field names (not the outer key) type its
+        contents, or a wrapper whose values are themselves JSON-string
+        blobs one level down (the same shape #117's tests keep under the
+        outer key). Re-entering everything under the outer key asked
+        _mask_entry to type the whole dict as e.g. "grpby", which only the
+        str-only _mask_json_blob can read; every field inside a parsed
+        payload fell through unmasked. Measured:
+        {"grpby": [{"dstendpoint": "web-01.corp.local"}]} (a list containing
+        one such dict) leaked the hostname in clear while the JSON-STRING
+        form of the identical payload correctly masked it.
+
+        Distinguishing the two shapes per inner value rather than per whole
+        dict: a string value that parses as JSON is a nested blob and goes
+        to _mask_json_blob (preserves #117's wrapper-of-blobs shape); any
+        other value belongs to this dict's own structure and is typed by
+        its own inner key via _mask_entry, not the outer composite key --
+        that inner-key dispatch is what correctly masks a bare
+        "dstendpoint": "web-01.corp.local" pair, typed rather than caught
+        incidentally by mask_text's IP/MAC/email-only regexes. A nested
+        dict/list value recurses through _mask_structured so its own keys
+        keep typing it. A list of JSON-string elements is unaffected: each
+        string element still re-enters under the outer key one level up
+        and dispatches to _mask_json_blob exactly as before.
         """
         if isinstance(value, list | tuple):
             return [self._mask_entry(key, item, mapping, keep) for item in value]
+        if key in COMPOSITE_JSON:
+            out: dict[Any, Any] = {}
+            for inner_key, item in value.items():
+                masked_key = self._mask_entry(key, inner_key, mapping, keep)
+                if isinstance(item, str):
+                    try:
+                        json.loads(item)
+                    except (ValueError, TypeError):
+                        out[masked_key] = self._mask_entry(inner_key, item, mapping, keep)
+                    else:
+                        out[masked_key] = self._mask_json_blob(item, mapping, keep)
+                else:
+                    out[masked_key] = self._mask_structured(item, mapping, keep)
+            return out
         return {
             self._mask_entry(key, inner_key, mapping, keep): self._mask_entry(
                 key, item, mapping, keep

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -1135,6 +1135,17 @@ class OutputMasker:
             return self._mask_composite_map(value, mapping, keep)
         if lowered in COMPOSITE_JSON and isinstance(value, str):
             return self._mask_json_blob(value, mapping, keep)
+        if lowered in COMPOSITE_JSON and isinstance(value, list):
+            # same list convention the other composites handle -- a list
+            # value here previously fell through every typed branch to
+            # _mask_structured with no key context, which cannot identify
+            # bare strings as JSON blobs and returned them verbatim.
+            return [
+                self._mask_json_blob(item, mapping, keep)
+                if isinstance(item, str)
+                else self._mask_structured(item, mapping, keep)
+                for item in value
+            ]
         if lowered in COMPOSITE_URL_HOST and isinstance(value, str):
             return self._mask_url_host(value, mapping, keep)
         if lowered in COMPOSITE_URL_HOST and isinstance(value, list):
@@ -1178,6 +1189,17 @@ class OutputMasker:
             return self._burn_strings(value, keep)
         if lowered in COMPOSITE_DEVICE_VDOM and isinstance(value, str):
             return self._mask_device_vdom(value, mapping, keep)
+        if lowered in COMPOSITE_DEVICE_VDOM and isinstance(value, list):
+            # same gap as COMPOSITE_JSON above: a list of device[vdom]
+            # strings fell through to _mask_structured with no key
+            # context and returned every device name verbatim, even with
+            # mask_device_identity on.
+            return [
+                self._mask_device_vdom(item, mapping, keep)
+                if isinstance(item, str)
+                else self._mask_structured(item, mapping, keep)
+                for item in value
+            ]
         if lowered in COMPOSITE_BREAKDOWNS and isinstance(value, dict):
             return self._mask_breakdowns(value, mapping, keep)
 

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -475,6 +475,100 @@ class OutputMasker:
             }
         return value
 
+    #: Every key the schema knows, independent of the device-identity flag.
+    #: ``self._field_types`` is the wrong table for the "do we recognise
+    #: this name" question: it only gains DEVICE_IDENTITY_TYPES when the
+    #: flag is on, so flag-off the name ``devname`` read as unknown and its
+    #: KEY burned while its value stayed readable via the keep set. That is
+    #: mangled schema on the majority configuration, for no gain.
+    _SCHEMA_KEYS: frozenset[str] = frozenset(FIELD_TYPES) | frozenset(DEVICE_IDENTITY_TYPES)
+
+    @staticmethod
+    def _typeable(value: Any) -> bool:
+        """Can ``_mask_entry`` actually type this shape?
+
+        Its typed and composite branches are all gated on ``str`` or on a
+        list of them. Anything else reaches the ``_mask_structured`` tail,
+        which is the allowlist walk this whole function exists to avoid
+        trusting.
+        """
+        if isinstance(value, str):
+            return True
+        return isinstance(value, list) and all(isinstance(item, str) for item in value)
+
+    def _burn_and_record(self, value: Any, mapping: dict[str, str], keep: frozenset[str]) -> Any:
+        """Burn, and record what was burned so pass 2 can follow it.
+
+        ``_burn_strings`` takes no mapping, so a burned value's twin in a
+        free-text field rode out in clear: measured, ``{"groupby1":
+        {"srcuser": "walter.white"}, "msg": "blocked walter.white"}`` burned
+        the map and left the name in ``msg``. Recording raw -> placeholder
+        lets the pass-2 substitution replace it there too, which is the
+        same principle ``_mask_scalar`` already documents.
+        """
+        if isinstance(value, str):
+            burned = self._burn_strings(value, keep)
+            if isinstance(burned, str) and burned != value:
+                mapping.setdefault(value, burned)
+            return burned
+        if isinstance(value, list | tuple):
+            return [self._burn_and_record(item, mapping, keep) for item in value]
+        if isinstance(value, dict):
+            return {
+                self._burn_and_record(key, mapping, keep): self._burn_and_record(
+                    item, mapping, keep
+                )
+                for key, item in value.items()
+            }
+        return value
+
+    def _mask_composite_map(self, value: Any, mapping: dict[str, str], keep: frozenset[str]) -> Any:
+        """Mask a map under a composite key: allowlist what it knows, burn the rest.
+
+        A dict-shaped group-by used to fall through to the plain allowlist
+        walk, on the reasoning that the walk would type it by its inner
+        keys. That holds only when those keys happen to be allowlisted.
+        Measured on 2.13.0 (``cfc2585``), same engine, RFC 5737 values:
+
+            {"groupby1": {"srcip": "192.0.2.90"}}     -> masked
+            {"groupby1": {"a": "srcip:192.0.2.90"}}   -> LEAK, verbatim
+            {"groupby1": {"a": "192.0.2.90"}}         -> LEAK, verbatim
+            {"groupby1": [{"a": "srcip:192.0.2.90"}]} -> LEAK, verbatim
+            {"groupby1": {"192.0.2.90": 5}}           -> LEAK, in the key
+
+        Recognising the key is not enough on its own. ``_mask_entry``'s
+        branches are shape-gated, so a known key holding a CONTAINER fell
+        straight back into the walk: ``{"srcip": {"nested": "192.0.2.90"}}``
+        leaked verbatim. A known key is therefore only handed on when its
+        value is a shape ``_mask_entry`` can actually type.
+
+        The working half is kept and everything else fails closed, rather
+        than burning the whole map the way the URL composites and ``target``
+        do. Those have no slot their handler can type at all; a group-by map
+        does for the keys the allowlist covers, and burning those would cost
+        a reversible mask for nothing.
+        """
+        if not isinstance(value, dict):
+            return self._burn_and_record(value, mapping, keep)
+        out: dict[Any, Any] = {}
+        for key, item in value.items():
+            known = isinstance(key, str) and (
+                key.lower() in self._SCHEMA_KEYS or key.lower() in _COMPOSITE_DIMENSIONS
+            )
+            if known and self._typeable(item):
+                out[key] = self._mask_entry(key, item, mapping, keep)
+            elif known:
+                # Name recognised, shape not. Keep the name, burn the value.
+                out[key] = self._burn_and_record(item, mapping, keep)
+            else:
+                # Unknown key: neither it nor its value can be typed, so
+                # both burn. The key burns too because a group-by map can
+                # carry the identifier there ({"192.0.2.90": 5}).
+                out[self._burn_and_record(key, mapping, keep)] = self._burn_and_record(
+                    item, mapping, keep
+                )
+        return out
+
     def _mask_target(
         self, value: list[Any], mapping: dict[str, str], keep: frozenset[str] = frozenset()
     ) -> list[Any]:
@@ -1031,14 +1125,14 @@ class OutputMasker:
         if lowered in COMPOSITE_PREFIXED and isinstance(value, list):
             # list-valued group-bys are a normal FAZ variation (#73): each
             # element gets the same prefixed treatment the string form gets.
-            # A dict-shaped groupby stays with the allowlist walk below,
-            # which types it by its inner keys.
             return [
                 self._mask_prefixed(item, mapping, keep)
                 if isinstance(item, str)
-                else self._mask_structured(item, mapping, keep)
+                else self._mask_composite_map(item, mapping, keep)
                 for item in value
             ]
+        if lowered in COMPOSITE_PREFIXED and isinstance(value, dict):
+            return self._mask_composite_map(value, mapping, keep)
         if lowered in COMPOSITE_JSON and isinstance(value, str):
             return self._mask_json_blob(value, mapping, keep)
         if lowered in COMPOSITE_URL_HOST and isinstance(value, str):

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -77,6 +77,7 @@ from fortianalyzer_mcp.masking.fields import (
     COMPOSITE_ID_DEVTYPE,
     COMPOSITE_JSON,
     COMPOSITE_PREFIXED,
+    COMPOSITE_SOURCE,
     COMPOSITE_TARGET,
     COMPOSITE_URL_FULL,
     COMPOSITE_URL_HOST,
@@ -1227,6 +1228,13 @@ class OutputMasker:
             # cost is the same too: any analytic structure a producer put
             # there burns rather than round-tripping.
             return self._burn_strings(value, keep)
+        if lowered in COMPOSITE_SOURCE and isinstance(value, list):
+            # The list form is target's shape and gets target's handler.
+            # No other arm on purpose: unlike "target", the name "source"
+            # is generic (get_endpoints emits a bare scalar one), so every
+            # other shape keeps the ordinary allowlist treatment rather
+            # than being burned. See COMPOSITE_SOURCE in fields.py.
+            return self._mask_target(value, mapping, keep)
         if lowered in COMPOSITE_TARGET:
             if isinstance(value, list):
                 return self._mask_target(value, mapping, keep)

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -522,6 +522,39 @@ class OutputMasker:
             }
         return value
 
+    def _mask_composite_container(
+        self, key: str, value: Any, mapping: dict[str, str], keep: frozenset[str]
+    ) -> Any:
+        """Re-enter ``_mask_entry`` under the SAME key for every element.
+
+        For these kinds the key is the only thing that can type the
+        payload, so a container must not be handed to ``_mask_structured``:
+        that route walks by allowlist, knows none of these inner names,
+        and has already lost the key by the time it sees the value. That
+        is how a list under ``devvds`` returned device names in clear with
+        ``FAZ_MASK_DEVICE_IDENTITY`` on, and the map form had no arm at
+        all so it reached the same route (#73 item 1).
+
+        Recursing rather than burning is what keeps the flag honest: the
+        per-kind handlers already decide what the deployment is entitled
+        to read (``_mask_device_vdom`` returns its argument untouched with
+        the flag off), while ``_burn_strings`` would mask an estate name
+        the flag-off deployment sees in clear under the string form of the
+        same key. It also means each kind's own dict policy still applies
+        one level down, so a map inside a list under ``url`` still burns.
+
+        Keys are masked as well as values: no later pass ever scans a key,
+        so a map keyed by the identifier hands it over as the key itself.
+        """
+        if isinstance(value, list | tuple):
+            return [self._mask_entry(key, item, mapping, keep) for item in value]
+        return {
+            self._mask_entry(key, inner_key, mapping, keep): self._mask_entry(
+                key, item, mapping, keep
+            )
+            for inner_key, item in value.items()
+        }
+
     def _mask_composite_map(self, value: Any, mapping: dict[str, str], keep: frozenset[str]) -> Any:
         """Mask a map under a composite key: allowlist what it knows, burn the rest.
 
@@ -1135,37 +1168,22 @@ class OutputMasker:
             return self._mask_composite_map(value, mapping, keep)
         if lowered in COMPOSITE_JSON and isinstance(value, str):
             return self._mask_json_blob(value, mapping, keep)
-        if lowered in COMPOSITE_JSON and isinstance(value, list):
-            # same list convention the other composites handle -- a list
-            # value here previously fell through every typed branch to
+        if lowered in COMPOSITE_JSON and isinstance(value, list | dict):
+            # A list value here used to fall through every typed branch to
             # _mask_structured with no key context, which cannot identify
-            # bare strings as JSON blobs and returned them verbatim.
-            return [
-                self._mask_json_blob(item, mapping, keep)
-                if isinstance(item, str)
-                else self._mask_structured(item, mapping, keep)
-                for item in value
-            ]
+            # bare strings as JSON blobs and returned them verbatim. The
+            # map form had no arm at all and reached the same route.
+            return self._mask_composite_container(lowered, value, mapping, keep)
         if lowered in COMPOSITE_URL_HOST and isinstance(value, str):
             return self._mask_url_host(value, mapping, keep)
         if lowered in COMPOSITE_URL_HOST and isinstance(value, list):
             # same list convention the typed fields handle below
-            return [
-                self._mask_url_host(item, mapping, keep)
-                if isinstance(item, str)
-                else self._mask_structured(item, mapping, keep)
-                for item in value
-            ]
+            return self._mask_composite_container(lowered, value, mapping, keep)
         if lowered in COMPOSITE_URL_FULL and isinstance(value, str):
             return self._mask_url_full(value, mapping, keep)
         if lowered in COMPOSITE_URL_FULL and isinstance(value, list):
             # same list convention the typed fields handle below
-            return [
-                self._mask_url_full(item, mapping, keep)
-                if isinstance(item, str)
-                else self._mask_structured(item, mapping, keep)
-                for item in value
-            ]
+            return self._mask_composite_container(lowered, value, mapping, keep)
         if (lowered in COMPOSITE_URL_HOST or lowered in COMPOSITE_URL_FULL) and isinstance(
             value, dict
         ):
@@ -1189,17 +1207,12 @@ class OutputMasker:
             return self._burn_strings(value, keep)
         if lowered in COMPOSITE_DEVICE_VDOM and isinstance(value, str):
             return self._mask_device_vdom(value, mapping, keep)
-        if lowered in COMPOSITE_DEVICE_VDOM and isinstance(value, list):
+        if lowered in COMPOSITE_DEVICE_VDOM and isinstance(value, list | dict):
             # same gap as COMPOSITE_JSON above: a list of device[vdom]
             # strings fell through to _mask_structured with no key
             # context and returned every device name verbatim, even with
-            # mask_device_identity on.
-            return [
-                self._mask_device_vdom(item, mapping, keep)
-                if isinstance(item, str)
-                else self._mask_structured(item, mapping, keep)
-                for item in value
-            ]
+            # mask_device_identity on. The map form had no arm at all.
+            return self._mask_composite_container(lowered, value, mapping, keep)
         if lowered in COMPOSITE_BREAKDOWNS and isinstance(value, dict):
             return self._mask_breakdowns(value, mapping, keep)
 

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -74,6 +74,7 @@ from fortianalyzer_mcp.masking.fields import (
     COMPOSITE_BREAKDOWNS,
     COMPOSITE_DEVICE_VDOM,
     COMPOSITE_FILTER_ENTRIES,
+    COMPOSITE_ID_DEVTYPE,
     COMPOSITE_JSON,
     COMPOSITE_PREFIXED,
     COMPOSITE_TARGET,
@@ -122,6 +123,7 @@ _COMPOSITE_DIMENSIONS: frozenset[str] = frozenset(
         *COMPOSITE_URL_HOST,
         *COMPOSITE_URL_FULL,
         *COMPOSITE_DEVICE_VDOM,
+        *COMPOSITE_ID_DEVTYPE,
         *COMPOSITE_PREFIXED,
         *COMPOSITE_JSON,
     )
@@ -368,6 +370,37 @@ class OutputMasker:
             device = self._mask_scalar(HOSTNAME, match.group("dev"), mapping, keep=keep)
             out.append(f"{device}[{match.group('vdom')}]")
         return ",".join(out)
+
+    def _mask_id_devtype(
+        self, key: str, value: str, mapping: dict[str, str], keep: frozenset[str]
+    ) -> str:
+        """``"<identifier>,<devtype>"`` (fortiview-sources aggregates).
+
+        The head is masked by the type this key maps to, which is the type
+        its covered flat twin already uses. The devtype tail is an OS or
+        product string, the same class as ``srchwvendor`` and ``catdesc``
+        that ``fields.py`` declines by name, so it stays readable.
+
+        The tail goes through ``mask_text`` rather than back verbatim.
+        These are aggregating fields: a row covering several endpoints
+        comma-joins them, so a verbatim tail would hand back every
+        identifier after the first. ``mask_text`` catches the IPv4, MAC
+        and email shapes there. A second HOSTNAME in a tail is not
+        recoverable this way, since no hostname regex exists and adding
+        one would burn ordinary prose.
+
+        No comma means a shape we have not seen, so the whole value is
+        masked rather than returned untyped, matching what
+        ``_mask_device_vdom`` does with a bare device name.
+        """
+        if not value:
+            return value
+        vtype = COMPOSITE_ID_DEVTYPE[key]
+        head, sep, tail = value.partition(",")
+        if not sep:
+            return self._mask_scalar(vtype, value, mapping, keep=keep)
+        masked_head = self._mask_scalar(vtype, head, mapping, keep=keep)
+        return f"{masked_head},{self.mask_text(tail, mapping, keep)}"
 
     def _mask_breakdowns(self, value: Any, mapping: dict[str, str], keep: frozenset[str]) -> Any:
         """``{dimension: [{"value": ..., "hits": N}, ...]}`` (#98).
@@ -1205,6 +1238,10 @@ class OutputMasker:
             # happens to cover. The cost is real: a container whose keys
             # are allowlisted was masked reversibly before and now burns.
             return self._burn_strings(value, keep)
+        if lowered in COMPOSITE_ID_DEVTYPE and isinstance(value, str):
+            return self._mask_id_devtype(lowered, value, mapping, keep)
+        if lowered in COMPOSITE_ID_DEVTYPE and isinstance(value, list | dict):
+            return self._mask_composite_container(lowered, value, mapping, keep)
         if lowered in COMPOSITE_DEVICE_VDOM and isinstance(value, str):
             return self._mask_device_vdom(value, mapping, keep)
         if lowered in COMPOSITE_DEVICE_VDOM and isinstance(value, list | dict):

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -1285,12 +1285,24 @@ class OutputMasker:
             # cost is the same too: any analytic structure a producer put
             # there burns rather than round-tripping.
             return self._burn_strings(value, keep)
-        if lowered in COMPOSITE_SOURCE and isinstance(value, list):
-            # The list form is target's shape and gets target's handler.
-            # No other arm on purpose: unlike "target", the name "source"
-            # is generic (get_endpoints emits a bare scalar one), so every
-            # other shape keeps the ordinary allowlist treatment rather
-            # than being burned. See COMPOSITE_SOURCE in fields.py.
+        if (
+            lowered in COMPOSITE_SOURCE
+            and isinstance(value, list)
+            and any(isinstance(item, dict) for item in value)
+        ):
+            # Gated on the ELEMENT type, not just on being a list, because
+            # "source" has two live shapes and only one of them is
+            # target's. The alert surface sends [{"name": ..., "value":
+            # ...}], which carries an identifier. The UEBA endpoint
+            # surface sends a list of bare detection-method labels, and
+            # _mask_target burns every entry that is not a dict, so
+            # claiming the whole list destroyed them (measured live: 152
+            # of 394 endpoint records, 16 distinct label values, burned
+            # irreversibly with the device-identity flag off).
+            #
+            # Everything else keeps the ordinary allowlist treatment, for
+            # the reason in fields.py: "source" is a generic name and this
+            # key cannot afford target's burn-by-default.
             return self._mask_target(value, mapping, keep)
         if lowered in COMPOSITE_TARGET:
             if isinstance(value, list):

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -1422,48 +1422,49 @@ class OutputMasker:
     def _mask_scalar_text(
         self, value: str, mapping: dict[str, str], keep: frozenset[str] = frozenset()
     ) -> str:
-        if value.strip() in SKIP_VALUES:
-            return value
-        try:
-            masked = self.mask_text(value, mapping, keep)
-            if masked != value:
-                return masked
-            return self._mask_percent_encoded_text(value, masked, mapping, keep)
-        except Exception:
-            logger.exception("unexpected error masking free text; placeholder used")
-            return self.placeholder(value)
-
-    def _mask_percent_encoded_text(
-        self, value: str, masked: str, mapping: dict[str, str], keep: frozenset[str]
-    ) -> str:
-        """Second look at free text that FortiAnalyzer percent-encoded.
+        """Mask free text, looking through FortiAnalyzer's percent-encoding.
 
         ``msg`` arrives encoded, so a MAC reaches the scan as
         ``aa%3Abb%3A...`` and an email as ``analyst%40example.com``. The
-        pass-2 regexes need the literal ``:`` and ``@``, so neither
-        matched, and the original stayed readable beside its own masked
-        twin in the structured field of the same record (#80).
+        pass-2 regexes need the literal ``:``/``@``, so neither matched,
+        and the original stayed readable beside its own masked twin in
+        the structured field of the same record (#80).
+
+        Tries the decoded form FIRST rather than only as a fallback after
+        a plain-text match: ``unquote()`` only touches ``%XX`` sequences,
+        so a plain-form identifier survives decoding untouched and is
+        still found by the same ``mask_text`` call over the decoded
+        string -- one sweep over the decoded text catches a plain IP and
+        a percent-encoded MAC in the same value. Masking the plain value
+        FIRST and returning immediately on any match -- the previous
+        order -- meant a second identifier hiding behind an escape next
+        to an already-matched plain one was never even looked at:
+        ``"src=192.0.2.77 mac=aa%3Abb%3Acc%3Add%3Aee%3A11"`` masked the IP
+        and left the encoded MAC verbatim, exactly the leak #80 exists to
+        close.
 
         Decoding is a means of FINDING identifiers, not a reformatting of
-        tool output, so the caller keeps the exact bytes FortiAnalyzer
-        sent unless the decode actually surfaces something to mask. That
-        is what keeps ``"CPU 100% busy"`` and an encoded path with no
-        identifier in it byte-identical.
-
-        When it does surface one, the decoded and masked form goes out.
-        Re-encoding the untouched spans around a substitution is not
-        attempted: the token is not the same length or alphabet as what it
-        replaced, so a faithful round trip is not available, and emitting
-        a half-encoded string would be worse than the honest decoded one.
+        tool output, so the exact bytes FortiAnalyzer sent survive unless
+        the decode actually surfaces something to mask -- what keeps
+        ``"CPU 100% busy"`` and an encoded path with no identifier in it
+        byte-identical to the original. Re-encoding the untouched spans
+        around a substitution is not attempted: the token is not the same
+        length or alphabet as what it replaced, so a faithful round trip
+        is not available, and emitting a half-encoded string would be
+        worse than the honest decoded one.
         """
-        decoded = unquote(value)
-        if decoded == value:
-            return masked
-        decoded_masked = self.mask_text(decoded, mapping, keep)
-        if decoded_masked == decoded:
-            # Nothing found either way: hand back the original bytes.
-            return masked
-        return decoded_masked
+        if value.strip() in SKIP_VALUES:
+            return value
+        try:
+            decoded = unquote(value)
+            if decoded != value:
+                decoded_masked = self.mask_text(decoded, mapping, keep)
+                if decoded_masked != decoded:
+                    return decoded_masked
+            return self.mask_text(value, mapping, keep)
+        except Exception:
+            logger.exception("unexpected error masking free text; placeholder used")
+            return self.placeholder(value)
 
     # -- tool-result entry point ----------------------------------------- #
 

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -374,33 +374,49 @@ class OutputMasker:
     def _mask_id_devtype(
         self, key: str, value: str, mapping: dict[str, str], keep: frozenset[str]
     ) -> str:
-        """``"<identifier>,<devtype>"`` (fortiview-sources aggregates).
+        """``"<identifier>,<devtype>,<identifier>,<devtype>,..."``
+        (fortiview-sources aggregates).
 
-        The head is masked by the type this key maps to, which is the type
-        its covered flat twin already uses. The devtype tail is an OS or
-        product string, the same class as ``srchwvendor`` and ``catdesc``
-        that ``fields.py`` declines by name, so it stays readable.
+        Each identifier is masked by the type this key maps to, which is
+        the type its covered flat twin already uses. Each devtype is an OS
+        or product string, the same class as ``srchwvendor`` and
+        ``catdesc`` that ``fields.py`` declines by name, so it stays
+        readable -- run through ``mask_text`` rather than back verbatim
+        only to catch an identifier accidentally embedded in it, same as
+        any other free-text field.
 
-        The tail goes through ``mask_text`` rather than back verbatim.
         These are aggregating fields: a row covering several endpoints
-        comma-joins them, so a verbatim tail would hand back every
-        identifier after the first. ``mask_text`` catches the IPv4, MAC
-        and email shapes there. A second HOSTNAME in a tail is not
-        recoverable this way, since no hostname regex exists and adding
-        one would burn ordinary prose.
+        comma-joins their pairs, per this field's own docstring in
+        ``fields.py``. Only typing the first pair and handing the rest to
+        ``mask_text`` -- the previous shape of this function -- caught a
+        repeated MAC by accident (``mask_text`` has a MAC regex) but never
+        a repeated HOSTNAME (no hostname regex exists, nor should one:
+        scanning arbitrary prose for anything hostname-shaped burns
+        ordinary text). Walking every pair explicitly and typing each
+        identifier by position sidesteps that entirely -- it never needs a
+        hostname regex, because it is never guessing which substring is an
+        identifier; the comma-delimited shape already says so.
 
         No comma means a shape we have not seen, so the whole value is
         masked rather than returned untyped, matching what
-        ``_mask_device_vdom`` does with a bare device name.
+        ``_mask_device_vdom`` does with a bare device name. An odd number
+        of parts (a trailing identifier with no devtype) is the same
+        situation for its last pair, so that lone identifier is masked
+        as one too rather than left readable or dropped.
         """
         if not value:
             return value
         vtype = COMPOSITE_ID_DEVTYPE[key]
-        head, sep, tail = value.partition(",")
-        if not sep:
+        parts = value.split(",")
+        if len(parts) < 2:
             return self._mask_scalar(vtype, value, mapping, keep=keep)
-        masked_head = self._mask_scalar(vtype, head, mapping, keep=keep)
-        return f"{masked_head},{self.mask_text(tail, mapping, keep)}"
+        masked_parts = [
+            self._mask_scalar(vtype, part, mapping, keep=keep)
+            if i % 2 == 0
+            else self.mask_text(part, mapping, keep)
+            for i, part in enumerate(parts)
+        ]
+        return ",".join(masked_parts)
 
     def _mask_breakdowns(self, value: Any, mapping: dict[str, str], keep: frozenset[str]) -> Any:
         """``{dimension: [{"value": ..., "hits": N}, ...]}`` (#98).

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -2799,3 +2799,24 @@ class TestPercentEncodedFreeText:
         out, and the format change is the documented cost."""
         out = masker.mask_result({"msg": "src%3D192.0.2.77 blocked"})
         assert "192.0.2.77" not in str(out)
+
+    def test_an_untouched_escape_survives_when_the_plain_scan_already_hit(
+        self, masker: OutputMasker
+    ) -> None:
+        """The early return is load-bearing, and a mutation sweep caught
+        that nothing pinned it.
+
+        When the ordinary scan already masked something, the decode must
+        not run, or an escape that had nothing to do with the match gets
+        rewritten as a side effect. Measured with the guard removed:
+
+            src=<token> path%2Fto%2Ffile  ->  src=<token> path/to/file
+
+        The tokens are identical either way, because the decode reads the
+        ORIGINAL rather than the masked text. So this is about byte
+        fidelity, not about double-masking.
+        """
+        out = masker.mask_result({"srcip": "192.0.2.77", "msg": "src=192.0.2.77 path%2Fto%2Ffile"})
+        assert "192.0.2.77" not in str(out)
+        assert out["srcip"] in out["msg"]
+        assert "path%2Fto%2Ffile" in out["msg"]

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -2582,3 +2582,153 @@ class TestAuditConfirmedLeaks:
         value, secret = payloads[key]
         out = masker.mask_result({"breakdowns": {key: [{"value": value, "hits": 3}]}})
         assert secret not in str(out)
+
+
+class TestSecondTierAuditKeys:
+    """The #80 second-tier table, re-measured at `0d17c41` and fixed where
+    the fix is an allowlist or composite entry rather than a mechanism.
+
+    Two rows of that table did NOT survive re-measurement and are pinned
+    here as correct rather than fixed, because the sweep ran with
+    FAZ_MASK_DEVICE_IDENTITY off and estate identity is clear by design in
+    that configuration:
+
+      - ``name`` on ``list_devices`` masks correctly with the flag on when
+        the record carries a device-proving sibling (``sn``,
+        ``platform_str``). The bare ``{"name": ...}`` form is not a device
+        object and must stay clear, which is what the sibling machinery
+        exists to decide.
+      - ``devid`` on a vdom object masks with the flag on.
+
+    Each key below is classified by the table its covered twin already
+    uses, which is the whole principle of the audit: two spellings of one
+    value in one record must not disagree.
+    """
+
+    IP = "192.0.2.57"
+    HOST = "wkstn-audit-01"
+    SN = "FAZVM0000000000"
+    SSID = "CorpWiFi"
+    AP = "ap-lobby-01"
+    MAC = "aa:bb:cc:dd:ee:11"
+
+    def _masker(self, monkeypatch: pytest.MonkeyPatch, flag: bool) -> OutputMasker:
+        monkeypatch.setenv("FAZ_MASKING_KEY", KEY)
+        return OutputMasker(FPEEngine(KEY), mask_device_identity=flag)
+
+    # ---- source: the structural twin of target ----
+
+    def test_source_entries_mask_like_target(self, masker: OutputMasker) -> None:
+        """Same [{"name": ..., "value": ...}] shape, alongside target in the
+        same alert. Measured leaking: five allowlisted renderings of the
+        same asset masked while source kept the address in clear."""
+        entry = [{"name": "device", "value": self.IP, "risk_type": "EndPoint"}]
+        out = masker.mask_result({"target": entry, "source": list(entry)})
+        assert self.IP not in str(out)
+        assert out["source"] == out["target"]
+
+    def test_a_scalar_source_is_not_burned(self, masker: OutputMasker) -> None:
+        """Deliberate divergence from target, which burns every non-list
+        shape. ``get_endpoints`` at detail_level="standard" emits a bare
+        ``source`` (measured during the #80 sweep), so a blanket burn would
+        destroy an ordinary enum on every endpoint read. target can burn
+        because the name is specific to the alert surface; source cannot,
+        because the name is generic."""
+        out = masker.mask_result({"source": "FortiClient"})
+        assert out["source"] == "FortiClient"
+
+    # ---- groupby3: an allowlisted dimension riding through on slot ----
+
+    def test_groupby3_masks_like_its_lower_numbered_siblings(self, masker: OutputMasker) -> None:
+        """The shipped handler catalogue puts qname in slot 3 on one
+        handler, so an allowlisted dimension rode through in clear purely
+        because of which slot it landed in."""
+        out = masker.mask_result({"groupby1": f"srcip:{self.IP}", "groupby3": f"srcip:{self.IP}"})
+        assert self.IP not in str(out)
+        assert out["groupby3"] == out["groupby1"]
+
+    # ---- Serial Number: the system-status vocabulary ----
+
+    def test_serial_number_follows_the_flag_like_sn(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """get_system_status spells its keys Title Case With Spaces.
+        Hostname matched despite the capital H because matching lowercases,
+        but "Serial Number" differs from sn by more than case. It is estate
+        identity, so it follows FAZ_MASK_DEVICE_IDENTITY exactly as sn
+        does: clear with the flag off, masked with it on."""
+        off = self._masker(monkeypatch, False).mask_result({"Serial Number": self.SN})
+        assert off["Serial Number"] == self.SN
+
+        on = self._masker(monkeypatch, True).mask_result({"Serial Number": self.SN, "sn": self.SN})
+        assert self.SN not in str(on)
+        assert on["Serial Number"] == on["sn"]
+
+    # ---- wireless: each key classified by its own twin ----
+
+    def test_ssid_and_vap_mask_whenever_bssid_does(self, masker: OutputMasker) -> None:
+        """bssid is a plain FIELD_TYPES entry, so it masks with the flag
+        off. The MAC form of a wireless network being masked while the name
+        form of the SAME network sits beside it in clear is exactly the
+        twin disagreement this audit is about."""
+        out = masker.mask_result({"bssid": self.MAC, "ssid": self.SSID, "vap": self.SSID})
+        assert self.SSID not in str(out)
+        assert out["ssid"] == out["vap"]
+
+    def test_ap_follows_the_flag_like_devname(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An access point name is estate identity, the same class as
+        devname, so it follows the flag rather than masking unconditionally
+        the way ssid does. The asymmetry is intentional and follows from
+        each key's own twin."""
+        off = self._masker(monkeypatch, False).mask_result({"ap": self.AP})
+        assert off["ap"] == self.AP
+
+        on = self._masker(monkeypatch, True).mask_result({"ap": self.AP, "devname": self.AP})
+        assert self.AP not in str(on)
+        assert on["ap"] == on["devname"]
+
+    # ---- reference_url ----
+
+    def test_reference_url_masks_like_url(self, masker: OutputMasker) -> None:
+        """COMPOSITE_URL_FULL carries "link" precisely because the
+        reputation source puts the indicator in the reference URL query
+        string, but the raw tool emits reference_url, which was typed by
+        nothing."""
+        raw = f"https://ti.example.com/q?ioc={self.IP}"
+        out = masker.mask_result({"url": raw, "reference_url": raw})
+        assert self.IP not in str(out)
+        assert out["reference_url"] == out["url"]
+
+    # ---- the container-shape matrix, extended to the new composite keys ----
+
+    @pytest.mark.parametrize("key", ["groupby3", "reference_url"])
+    def test_the_new_composite_keys_survive_the_container_shapes(
+        self, masker: OutputMasker, key: str
+    ) -> None:
+        payloads = {
+            "groupby3": (f"srcip:{self.IP}", self.IP),
+            "reference_url": (f"https://ti.example.com/q?ioc={self.IP}", self.IP),
+        }
+        value, secret = payloads[key]
+        for shape in (value, [value], {"a": value}, [[value]]):
+            out = masker.mask_result({key: shape})
+            assert secret not in str(out), f"{key} leaked under {shape!r}"
+
+    # ---- the two rows that did not survive re-measurement ----
+
+    def test_a_device_object_name_masks_with_the_flag_on(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pinned as correct, not fixed. The #80 table listed this as a
+        leak; the sweep ran flag-off, where estate identity is clear by
+        design."""
+        on = self._masker(monkeypatch, True)
+        assert self.HOST not in str(on.mask_result({"name": self.HOST, "sn": self.SN}))
+        assert self.HOST not in str(
+            on.mask_result({"name": self.HOST, "platform_str": "FortiGate-VM64"})
+        )
+
+    def test_a_bare_name_is_not_treated_as_a_device(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The counterpart. A name with no device-proving sibling belongs
+        to an ADOM, a report layout or a group, and burning it would mangle
+        every one of those."""
+        on = self._masker(monkeypatch, True)
+        assert on.mask_result({"name": "my-report-layout"}) == {"name": "my-report-layout"}

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -2212,6 +2212,26 @@ class TestCompositeMapShapes:
         assert self.IP not in str(out)
         assert not str(out["groupby1"]["srcip"]).startswith("['masked-unrepresentable")
 
+    def test_a_devvds_list_does_not_leak_device_identity(self, full_masker: OutputMasker) -> None:
+        """_typeable() claims every composite branch handles a list of
+        strings, but COMPOSITE_DEVICE_VDOM only had a str arm in
+        _mask_entry -- a list value was waved through _mask_composite_map
+        as "known and typeable", then fell through every typed branch
+        (list is not str) straight to _mask_structured with no key
+        context, which cannot identify bare strings as device[vdom]
+        pairs. Leaked real device names verbatim even with
+        mask_device_identity on."""
+        device = "fw-paris-01[root]"
+        out = full_masker.mask_result({"groupby1": {"devvds": [device, "fw-lyon-02[root]"]}})
+        assert device not in str(out)
+
+    def test_a_grpby_list_does_not_leak_an_embedded_identifier(self, masker: OutputMasker) -> None:
+        """Same gap as devvds above, for COMPOSITE_JSON: a list of JSON
+        blob strings under "grpby" fell through to _mask_structured with
+        no key context and returned the embedded IP verbatim."""
+        out = masker.mask_result({"groupby1": {"grpby": [f'{{"dstendpoint": "{self.IP}"}}']}})
+        assert self.IP not in str(out)
+
     def test_a_burned_value_is_recorded_so_its_twin_in_prose_follows(
         self, masker: OutputMasker
     ) -> None:

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -2532,6 +2532,22 @@ class TestAuditConfirmedLeaks:
         assert self.MAC not in rendered
         assert second not in rendered
 
+    def test_a_second_hostname_pair_in_the_tail_does_not_leak(self, masker: OutputMasker) -> None:
+        """mac_devtype_agg's second-pair coverage above is incidental,
+        not designed: mask_text's MAC regex happens to catch a second
+        MAC, but has no hostname regex, so dev_src_agg's second pair had
+        no protection at all. Walking every pair by position rather than
+        only typing the first closes this without needing one."""
+        second = "wkstn-02.corp.local"
+        out = masker.mask_result(
+            {"dev_src_agg": f"{self.HOST},{self.DEVTYPE},{second},{self.DEVTYPE}"}
+        )
+        rendered = str(out)
+        assert self.HOST not in rendered
+        assert second not in rendered
+        # the devtype strings stay readable
+        assert rendered.count(self.DEVTYPE) == 2
+
     def test_a_value_with_no_comma_is_masked_whole(self, masker: OutputMasker) -> None:
         """Same fallback devvds uses for a shape it has not seen: mask the
         whole thing rather than hand back an untyped string."""

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -2732,3 +2732,70 @@ class TestSecondTierAuditKeys:
         every one of those."""
         on = self._masker(monkeypatch, True)
         assert on.mask_result({"name": "my-report-layout"}) == {"name": "my-report-layout"}
+
+
+class TestPercentEncodedFreeText:
+    """FortiAnalyzer returns ``msg`` percent-encoded, so the free-text
+    scan never matched the identifiers inside it (#80).
+
+    Measured on the live estate: on 3 of 3 event records the MAC inside
+    ``msg`` differed from the masked MAC in the structured field of the
+    same record, so the original was recoverable by anyone holding both.
+    One record was decisive: ``msg`` decoded to ``AP <mac> chan 153 live
+    7235442`` while ``channel`` and ``live`` matched the record exactly,
+    so it was demonstrably the same AP whose ``bssid`` had been masked.
+
+    The same mechanism reaches email, because the pass-2 email regex
+    needs a literal ``@`` and this surface ships ``%40``.
+    """
+
+    MAC = "aa:bb:cc:dd:ee:11"
+    EMAIL = "analyst@example.com"
+
+    def test_a_percent_encoded_mac_is_masked(self, masker: OutputMasker) -> None:
+        out = masker.mask_result({"msg": "AP aa%3Abb%3Acc%3Add%3Aee%3A11 chan 153"})
+        assert "aa%3Abb%3Acc%3Add%3Aee%3A11" not in str(out)
+        assert self.MAC not in str(out)
+
+    def test_a_percent_encoded_email_is_masked(self, masker: OutputMasker) -> None:
+        out = masker.mask_result({"msg": "mail from analyst%40example.com rejected"})
+        assert "analyst%40example.com" not in str(out)
+        assert self.EMAIL not in str(out)
+
+    def test_it_agrees_with_the_structured_twin(self, masker: OutputMasker) -> None:
+        """The whole point. The structured field and the prose carry the
+        same AP, so they must come back as the same token."""
+        out = masker.mask_result(
+            {"bssid": self.MAC, "msg": "AP aa%3Abb%3Acc%3Add%3Aee%3A11 chan 153"}
+        )
+        assert out["bssid"] in out["msg"]
+
+    def test_plain_text_is_unaffected(self, masker: OutputMasker) -> None:
+        """The path that already worked keeps working, undecoded."""
+        out = masker.mask_result({"msg": f"AP {self.MAC} chan 153"})
+        assert self.MAC not in str(out)
+        assert "chan 153" in out["msg"]
+
+    def test_encoded_text_with_no_identifier_is_returned_byte_identical(
+        self, masker: OutputMasker
+    ) -> None:
+        """Decoding is a means of finding identifiers, not a reformatting
+        of tool output. If the decode surfaces nothing to mask, the caller
+        gets exactly the bytes FortiAnalyzer sent."""
+        raw = "path%2Fto%2Ffile requested by policy%2042"
+        assert masker.mask_result({"msg": raw})["msg"] == raw
+
+    def test_a_literal_percent_is_not_treated_as_an_escape(self, masker: OutputMasker) -> None:
+        """ "CPU 100% busy" is not an encoding. Nothing masks, so nothing
+        is rewritten."""
+        raw = "CPU 100% busy, mem 40% used"
+        assert masker.mask_result({"msg": raw})["msg"] == raw
+
+    def test_a_percent_that_would_decode_into_an_identifier_still_reports_it(
+        self, masker: OutputMasker
+    ) -> None:
+        """The counterpart to the two pins above: when the decode DOES
+        surface an identifier, the decoded and masked form is what goes
+        out, and the format change is the documented cost."""
+        out = masker.mask_result({"msg": "src%3D192.0.2.77 blocked"})
+        assert "192.0.2.77" not in str(out)

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -2284,3 +2284,99 @@ class TestCompositeMapShapes:
         away is the same mismatch the keep set exists to prevent."""
         out = masker.mask_result({"devname": "fw-paris-01", "groupby1": {"unknown": "fw-paris-01"}})
         assert out["groupby1"]["unknown"] == "fw-paris-01"
+
+
+class TestCompositeContainerShapesKeepKeyContext:
+    """A composite key must keep deciding the type at every depth.
+
+    Each composite kind dispatches on the key, then on the value's shape.
+    The shapes with no arm fall to the generic tail, which walks by
+    allowlist and knows none of these inner names, so the payload rides
+    out in clear. The list arms had the same hole one level down: they
+    delegated a non-string element to ``_mask_structured``, which is the
+    route that strips the key context the value can only be typed by.
+
+    Measured on ``1f60904`` before the fix, RFC 5737 / RFC 2606 values:
+
+        {"devvds": {"a": "fw-oslo-01[root]"}}       LEAK, flag ON
+        {"devvds": {"fw-oslo-01[root]": 5}}         LEAK, flag ON, in the key
+        {"devvds": [["fw-oslo-01[root]"]]}          LEAK, flag ON
+        {"grpby": {"a": '{"dstendpoint": "<ip>"}'}} LEAK
+        {"grpby": {"<ip>": ...}}                    LEAK, in the key
+        {"grpby": [['{"dstendpoint": "<ip>"}']]}    LEAK
+        {"http_url": [["https://bad.example.com/x"]]} LEAK
+        {"url":      [["https://bad.example.com/x"]]} LEAK
+
+    Reachable rather than observed: no live surface sampled in the #80
+    sweep emitted a composite under a map or a nested list. The same was
+    true of ``groupby3`` and of the map shapes #116 closed.
+    """
+
+    IP = "192.0.2.90"
+    DEV = "fw-oslo-01[root]"
+    DEV_NAME = "fw-oslo-01"
+    HOST = "bad.example.com"
+    URL = "https://bad.example.com/x"
+
+    def _blob(self) -> str:
+        return f'{{"dstendpoint": "{self.IP}"}}'
+
+    # ---- devvds: the device-identity flag must survive every shape ----
+
+    def test_a_devvds_map_value_does_not_leak(self, full_masker: OutputMasker) -> None:
+        out = full_masker.mask_result({"devvds": {"a": self.DEV}})
+        assert self.DEV_NAME not in str(out)
+
+    def test_a_devvds_map_keyed_by_the_device_does_not_leak(
+        self, full_masker: OutputMasker
+    ) -> None:
+        """No later pass ever scans a key, so the map form hands the
+        device name over as the key itself."""
+        out = full_masker.mask_result({"devvds": {self.DEV: 5}})
+        assert self.DEV_NAME not in str(out)
+
+    def test_a_devvds_nested_list_does_not_leak(self, full_masker: OutputMasker) -> None:
+        out = full_masker.mask_result({"devvds": [[self.DEV]]})
+        assert self.DEV_NAME not in str(out)
+
+    def test_a_devvds_map_stays_readable_with_the_flag_off(self, masker: OutputMasker) -> None:
+        """The counterpart pin. Device identity is clear by design unless
+        the deployment opts in, so the container shapes must not be closed
+        by burning -- that would mask an estate name the flag-off
+        deployment is entitled to read, under a key whose string form
+        hands it back in clear two rows away."""
+        out = masker.mask_result({"devvds": {"a": self.DEV}})
+        assert out["devvds"]["a"] == self.DEV
+
+    # ---- grpby: a JSON blob under a container ----
+
+    def test_a_grpby_map_value_does_not_leak(self, masker: OutputMasker) -> None:
+        out = masker.mask_result({"grpby": {"a": self._blob()}})
+        assert self.IP not in str(out)
+
+    def test_a_grpby_map_keyed_by_the_identifier_does_not_leak(self, masker: OutputMasker) -> None:
+        out = masker.mask_result({"grpby": {self.IP: self._blob()}})
+        assert self.IP not in str(out)
+
+    def test_a_grpby_nested_list_does_not_leak(self, masker: OutputMasker) -> None:
+        out = masker.mask_result({"grpby": [[self._blob()]]})
+        assert self.IP not in str(out)
+
+    # ---- the URL composites, one level down from the arm that works ----
+
+    @pytest.mark.parametrize("key", ["http_url", "url", "referralurl", "link"])
+    def test_a_url_nested_list_does_not_leak(self, masker: OutputMasker, key: str) -> None:
+        out = masker.mask_result({key: [[self.URL]]})
+        assert self.HOST not in str(out)
+
+    # ---- the shapes that already worked keep working ----
+
+    def test_the_shapes_that_already_worked_are_untouched(
+        self, masker: OutputMasker, full_masker: OutputMasker
+    ) -> None:
+        assert self.DEV_NAME not in str(full_masker.mask_result({"devvds": self.DEV}))
+        assert self.DEV_NAME not in str(full_masker.mask_result({"devvds": [self.DEV]}))
+        assert self.IP not in str(masker.mask_result({"grpby": self._blob()}))
+        assert self.IP not in str(masker.mask_result({"grpby": [self._blob()]}))
+        assert self.HOST not in str(masker.mask_result({"http_url": self.URL}))
+        assert self.HOST not in str(masker.mask_result({"http_url": [self.URL]}))

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -2380,3 +2380,205 @@ class TestCompositeContainerShapesKeepKeyContext:
         assert self.IP not in str(masker.mask_result({"grpby": [self._blob()]}))
         assert self.HOST not in str(masker.mask_result({"http_url": self.URL}))
         assert self.HOST not in str(masker.mask_result({"http_url": [self.URL]}))
+
+
+class TestAuditConfirmedLeaks:
+    """The five leaks confirmed by the live coverage sweep (#80).
+
+    Every one has the same shape: the masker covers one spelling of an
+    identifier and the appliance ships a second spelling of the same
+    value on the same surface, often in the same record. Because FPE is
+    deterministic, a record carrying both publishes the token and the
+    plaintext for one identifier and hands over the mapping.
+
+    Measured on 2.13.0 (``cfc2585``) with a known test key, in the live
+    record shape, with the device-identity flag both off and on:
+
+        {"mac_devtype_agg": "<mac>,DSM 7.3-86009"}   byte-identical
+        {"dev_src_agg": "<host>,DSM 7.3-86009"}      byte-identical
+        {"f_user": "<user>"}                         5 of 5 shapes verbatim
+        {"auto_raise_grpby": '[{"dstendpoint": "<ip>"}]'}   verbatim
+
+    while the covered twins (``mac``, ``dstmac``, ``hostname``,
+    ``srcname``, ``device``, ``unauthuser``, ``grpby``) all masked the
+    identical value.
+    """
+
+    MAC = "aa:bb:cc:dd:ee:11"
+    HOST = "wkstn-audit-01"
+    DEVTYPE = "Ubuntu 22.04.5"
+    UUID = "ffeb3f77-0000-4000-8000-000000000001"
+    IP = "198.51.100.22"
+    USER = "audituser"
+
+    # ---- f_user: a plain username slot, no composite involved ----
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            "audituser",
+            "audituser@example.com",
+            "EXAMPLE\\audituser",
+            "wkstn-audit-01",
+            "198.51.100.22",
+        ],
+    )
+    @pytest.mark.parametrize("flag", [False, True])
+    def test_f_user_does_not_leak_any_measured_payload_shape(
+        self, payload: str, flag: bool, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """All five shapes the audit measured. Whether a given one becomes
+        a token or a placeholder is the USERNAME handler's business; not
+        plaintext is the contract.
+
+        Asserts against the field, NOT against ``str(out)``: the repr
+        escapes a backslash, so ``EXAMPLE\\audituser`` is not a substring
+        of the rendered dict and that case could never have failed."""
+        monkeypatch.setenv("FAZ_MASKING_KEY", KEY)
+        masker = OutputMasker(FPEEngine(KEY), mask_device_identity=flag)
+        out = masker.mask_result({"f_user": payload})
+        assert out["f_user"] != payload
+        assert payload not in out["f_user"]
+
+    def test_f_user_masks_like_its_covered_twin(self, masker: OutputMasker) -> None:
+        """unauthuser holding the same literal masked while f_user did
+        not, in the same dict. That pairing is what hands over the map."""
+        out = masker.mask_result({"unauthuser": self.USER, "f_user": self.USER})
+        assert out["f_user"] == out["unauthuser"]
+
+    # ---- auto_raise_grpby: the twin of the covered grpby ----
+
+    def test_auto_raise_grpby_does_not_leak(self, masker: OutputMasker) -> None:
+        """COMPOSITE_JSON was ("grpby",) only. The audit's exact payload is
+        a JSON array string, not an object."""
+        blob = f'[{{"dstendpoint": "{self.IP}"}}]'
+        out = masker.mask_result({"auto_raise_grpby": blob})
+        assert self.IP not in str(out)
+
+    def test_auto_raise_grpby_masks_like_grpby(self, masker: OutputMasker) -> None:
+        blob = f'[{{"dstendpoint": "{self.IP}"}}]'
+        out = masker.mask_result({"grpby": blob, "auto_raise_grpby": blob})
+        assert out["auto_raise_grpby"] == out["grpby"]
+
+    # ---- the two <identifier>,<devtype> aggregates ----
+
+    @pytest.mark.parametrize("flag", [False, True])
+    def test_mac_devtype_agg_masks_the_mac_and_keeps_the_devtype(
+        self, flag: bool, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FAZ_MASKING_KEY", KEY)
+        masker = OutputMasker(FPEEngine(KEY), mask_device_identity=flag)
+        out = masker.mask_result({"mac_devtype_agg": f"{self.MAC},{self.DEVTYPE}"})
+        rendered = out["mac_devtype_agg"]
+        assert self.MAC not in rendered
+        assert rendered.endswith(f",{self.DEVTYPE}")
+
+    @pytest.mark.parametrize("flag", [False, True])
+    def test_dev_src_agg_masks_the_device_and_keeps_the_devtype(
+        self, flag: bool, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("FAZ_MASKING_KEY", KEY)
+        masker = OutputMasker(FPEEngine(KEY), mask_device_identity=flag)
+        out = masker.mask_result({"dev_src_agg": f"{self.HOST},{self.DEVTYPE}"})
+        rendered = out["dev_src_agg"]
+        assert self.HOST not in rendered
+        assert rendered.endswith(f",{self.DEVTYPE}")
+
+    def test_the_agg_heads_mask_like_their_covered_twins(self, masker: OutputMasker) -> None:
+        """The whole point of the finding: the covered and uncovered
+        spellings land in the same record, so they must agree."""
+        out = masker.mask_result(
+            {
+                "mac": self.MAC,
+                "mac_devtype_agg": f"{self.MAC},{self.DEVTYPE}",
+                "hostname": self.HOST,
+                "dev_src_agg": f"{self.HOST},{self.DEVTYPE}",
+            }
+        )
+        assert out["mac_devtype_agg"] == f"{out['mac']},{self.DEVTYPE}"
+        assert out["dev_src_agg"] == f"{out['hostname']},{self.DEVTYPE}"
+
+    def test_the_aggs_are_not_gated_on_the_device_identity_flag(self, masker: OutputMasker) -> None:
+        """Their covered twins (mac, hostname) are FIELD_TYPES entries, so
+        they mask with the flag OFF. The neighbouring devvds handler IS
+        flag-gated, so the asymmetry needs a pin rather than an assumption
+        of symmetry."""
+        out = masker.mask_result(
+            {
+                "mac_devtype_agg": f"{self.MAC},{self.DEVTYPE}",
+                "dev_src_agg": f"{self.HOST},{self.DEVTYPE}",
+            }
+        )
+        assert self.MAC not in str(out)
+        assert self.HOST not in str(out)
+
+    def test_a_forticlient_uuid_head_is_masked_too(self, masker: OutputMasker) -> None:
+        """dev_src_agg also carries the FortiClient UUID form. The
+        srcuuid/dstuuid carve-out is scoped to those KEYS, not to the
+        value's shape, and nothing else in this masker types by shape, so
+        the head is masked by the key's type either way."""
+        out = masker.mask_result({"dev_src_agg": f"{self.UUID},macOS 10.15.7"})
+        assert self.UUID not in str(out)
+
+    def test_a_second_pair_in_the_tail_does_not_leak(self, masker: OutputMasker) -> None:
+        """These are agg fields: devvds's own docstring records that an
+        aggregating row comma-joins several. A verbatim tail would hand
+        back every identifier after the first."""
+        second = "aa:bb:cc:dd:ee:22"
+        out = masker.mask_result(
+            {"mac_devtype_agg": f"{self.MAC},{self.DEVTYPE},{second},{self.DEVTYPE}"}
+        )
+        rendered = str(out)
+        assert self.MAC not in rendered
+        assert second not in rendered
+
+    def test_a_value_with_no_comma_is_masked_whole(self, masker: OutputMasker) -> None:
+        """Same fallback devvds uses for a shape it has not seen: mask the
+        whole thing rather than hand back an untyped string."""
+        out = masker.mask_result({"mac_devtype_agg": self.MAC})
+        assert self.MAC not in str(out)
+
+    def test_an_empty_value_is_unchanged(self, masker: OutputMasker) -> None:
+        """The audit measured these empty on most live rows. An empty
+        string must not become a placeholder."""
+        out = masker.mask_result({"mac_devtype_agg": "", "dev_src_agg": "", "f_user": ""})
+        assert out == {"mac_devtype_agg": "", "dev_src_agg": "", "f_user": ""}
+
+    # ---- the new kind must be wired everywhere the existing kinds are ----
+
+    @pytest.mark.parametrize("key", ["mac_devtype_agg", "dev_src_agg", "auto_raise_grpby"])
+    def test_the_new_keys_survive_the_container_shapes(
+        self, masker: OutputMasker, key: str
+    ) -> None:
+        """A composite kind handled at one site and not another is exactly
+        how #73, #116 and #117 each found a leak. This walks the same
+        shapes #117's matrix walks."""
+        payloads = {
+            "mac_devtype_agg": f"{self.MAC},{self.DEVTYPE}",
+            "dev_src_agg": f"{self.HOST},{self.DEVTYPE}",
+            "auto_raise_grpby": f'[{{"dstendpoint": "{self.IP}"}}]',
+        }
+        secrets = {
+            "mac_devtype_agg": self.MAC,
+            "dev_src_agg": self.HOST,
+            "auto_raise_grpby": self.IP,
+        }
+        value, secret = payloads[key], secrets[key]
+        for shape in (value, [value], {"a": value}, [[value]], {value: 1}):
+            out = masker.mask_result({key: shape})
+            assert secret not in str(out), f"{key} leaked under {shape!r}"
+
+    @pytest.mark.parametrize("key", ["mac_devtype_agg", "dev_src_agg", "auto_raise_grpby"])
+    def test_the_new_keys_work_as_a_groupby_dimension(self, masker: OutputMasker, key: str) -> None:
+        """A composite key served by a handler rather than by FIELD_TYPES
+        has to be listed as a composite dimension too, or a breakdown
+        bucket under that name types from the empty table and passes
+        through in clear (the #109 review's finding)."""
+        payloads = {
+            "mac_devtype_agg": (f"{self.MAC},{self.DEVTYPE}", self.MAC),
+            "dev_src_agg": (f"{self.HOST},{self.DEVTYPE}", self.HOST),
+            "auto_raise_grpby": (f'[{{"dstendpoint": "{self.IP}"}}]', self.IP),
+        }
+        value, secret = payloads[key]
+        out = masker.mask_result({"breakdowns": {key: [{"value": value, "hits": 3}]}})
+        assert secret not in str(out)

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -2774,3 +2774,60 @@ class TestSecondTierAuditKeys:
         every one of those."""
         on = self._masker(monkeypatch, True)
         assert on.mask_result({"name": "my-report-layout"}) == {"name": "my-report-layout"}
+
+
+class TestSourceListOfStringsIsNotBurned:
+    """``source`` has two live shapes, and only one of them is target's.
+
+    Measured on a live FortiAnalyzer, ``get_endpoints(detail_level=
+    "standard", fields=["*"])``: 394 records, 152 carry ``source``, and
+    every one of the 152 is an **array of strings**. Zero dicts, zero
+    scalars. The 16 distinct values all contain a space, none contains a
+    dot, colon, ``@`` or an all-hex form, and none matches any other key
+    on its own record. They are the detection-method labels the UEBA
+    schema describes ("The source(s) of detecting an endpoint"), not
+    identifiers.
+
+    Routing every list to ``_mask_target`` burned all of them, because
+    that handler burns any entry that is not a dict. Irreversibly, and
+    with ``FAZ_MASK_DEVICE_IDENTITY`` off, so a deployment lost a label
+    vocabulary it was entitled to read and got no privacy for it.
+
+    The alert shape, ``[{"name": ..., "value": ...}]``, is the one that
+    carries an identifier and still gets target's handler. So the arm is
+    gated on the ELEMENT type rather than on the value being a list.
+    """
+
+    IP = "192.0.2.35"
+    LABELS = ["FortiClient EMS", "Endpoint Vulnerability Scan"]
+
+    def test_a_list_of_label_strings_survives(self, masker: OutputMasker) -> None:
+        out = masker.mask_result({"source": list(self.LABELS)})
+        assert out["source"] == self.LABELS
+
+    def test_a_list_of_label_strings_survives_with_the_flag_on(
+        self, full_masker: OutputMasker
+    ) -> None:
+        """Flag-independent: these are not estate identity under either
+        setting, so neither setting should burn them."""
+        out = full_masker.mask_result({"source": list(self.LABELS)})
+        assert out["source"] == self.LABELS
+
+    def test_the_alert_entry_shape_still_masks(self, masker: OutputMasker) -> None:
+        """The half that must not regress. A dict entry still carries an
+        identifier and still goes through target's handler."""
+        entry = [{"name": "device", "value": self.IP, "risk_type": "EndPoint"}]
+        out = masker.mask_result({"target": [dict(entry[0])], "source": entry})
+        assert self.IP not in str(out)
+        assert out["source"] == out["target"]
+
+    def test_a_mixed_list_still_masks_its_dict_entries(self, masker: OutputMasker) -> None:
+        """A list carrying both shapes is typed by what is in it, not by
+        the first element."""
+        out = masker.mask_result({"source": [{"name": "ip", "value": self.IP}, "FortiClient EMS"]})
+        assert self.IP not in str(out)
+
+    def test_a_scalar_source_is_still_not_burned(self, masker: OutputMasker) -> None:
+        """Unchanged, and still the reason this key is not folded into
+        COMPOSITE_TARGET."""
+        assert masker.mask_result({"source": "FortiClient"})["source"] == "FortiClient"

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -2362,6 +2362,32 @@ class TestCompositeContainerShapesKeepKeyContext:
         out = masker.mask_result({"grpby": [[self._blob()]]})
         assert self.IP not in str(out)
 
+    # ---- grpby: the ALREADY-PARSED dict form, not a JSON-string blob ----
+    #
+    # Distinct from the map-of-blob-string tests above: here the dict IS
+    # the parsed payload (as fetch_fortiview hands it back for some FAZ
+    # builds), not a wrapper whose values are still JSON strings. Measured
+    # live: {"grpby": [{"dstendpoint": "<hostname>"}]} leaked the hostname
+    # verbatim while the JSON-STRING form of the identical payload masked
+    # it correctly -- the dict form had no key-typed arm and fell through
+    # to the outer-key-only route, which only a bare string can be typed
+    # by. A hostname (not an IP) is used deliberately: it cannot be caught
+    # incidentally by mask_text's IP/MAC/email regexes, so it only passes
+    # if the dict's own inner key ("dstendpoint") is actually doing the
+    # typing.
+
+    NATIVE_HOST = "websrv-native-01.corp.local"
+
+    def test_a_grpby_list_of_native_dicts_does_not_leak_a_hostname(
+        self, masker: OutputMasker
+    ) -> None:
+        out = masker.mask_result({"grpby": [{"dstendpoint": self.NATIVE_HOST}]})
+        assert self.NATIVE_HOST not in str(out)
+
+    def test_a_grpby_bare_native_dict_does_not_leak_a_hostname(self, masker: OutputMasker) -> None:
+        out = masker.mask_result({"grpby": {"dstendpoint": self.NATIVE_HOST}})
+        assert self.NATIVE_HOST not in str(out)
+
     # ---- the URL composites, one level down from the arm that works ----
 
     @pytest.mark.parametrize("key", ["http_url", "url", "referralurl", "link"])

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -2126,3 +2126,141 @@ class TestGroupByGroupsRowsAlreadyCovered:
 
         flagged = full_masker.mask_result(payload)
         assert flagged["groups"][0]["fortigate"] != DEV_NAME
+
+
+class TestCompositeMapShapes:
+    """A map under a group-by key must not ride through in clear.
+
+    A dict-shaped group-by used to fall through to the plain allowlist
+    walk, on the reasoning that the walk would type it by its inner keys.
+    That holds only when those keys happen to be allowlisted. Measured on
+    2.13.0 (``cfc2585``) before the fix, with RFC 5737 values:
+
+        {"groupby1": {"srcip": "192.0.2.90"}}     masked
+        {"groupby1": {"a": "srcip:192.0.2.90"}}   LEAK, verbatim
+        {"groupby1": {"a": "192.0.2.90"}}         LEAK, verbatim
+        {"groupby1": [{"a": "srcip:192.0.2.90"}]} LEAK, verbatim
+        {"groupby1": {"192.0.2.90": 5}}           LEAK, in the key
+
+    upstream #73 item 1.
+    """
+
+    IP = "192.0.2.90"
+
+    @pytest.mark.parametrize("key", ["groupby1", "groupby2"])
+    def test_an_unknown_inner_key_does_not_leak_its_value(
+        self, masker: OutputMasker, key: str
+    ) -> None:
+        out = masker.mask_result({key: {"a": f"srcip:{self.IP}"}})
+        assert self.IP not in str(out)
+
+    def test_an_unknown_inner_key_holding_a_bare_address_does_not_leak(
+        self, masker: OutputMasker
+    ) -> None:
+        out = masker.mask_result({"groupby1": {"a": self.IP}})
+        assert self.IP not in str(out)
+
+    def test_an_identifier_used_as_the_key_does_not_leak(self, masker: OutputMasker) -> None:
+        """The allowlist walk never masks a key, so a group-by keyed by the
+        identifier handed it over as the key itself."""
+        out = masker.mask_result({"groupby1": {self.IP: 5}})
+        assert self.IP not in str(out)
+
+    def test_a_map_nested_in_a_list_does_not_leak(self, masker: OutputMasker) -> None:
+        out = masker.mask_result({"groupby1": [{"a": f"srcip:{self.IP}"}]})
+        assert self.IP not in str(out)
+
+    def test_an_allowlisted_inner_key_still_masks_reversibly(self, masker: OutputMasker) -> None:
+        """The half that worked is kept: burning the whole map would throw
+        away a reversible mask, which is why this is not the blanket burn
+        the URL composites and ``target`` use."""
+        out = masker.mask_result({"groupby1": {"srcip": self.IP}})
+        assert self.IP not in str(out)
+        assert "srcip" in out["groupby1"]
+        assert not str(out["groupby1"]["srcip"]).startswith("masked-unrepresentable")
+
+    def test_known_and_unknown_keys_are_handled_separately(self, masker: OutputMasker) -> None:
+        out = masker.mask_result({"groupby1": {"srcip": self.IP, "a": "192.0.2.91"}})
+        rendered = str(out)
+        assert self.IP not in rendered
+        assert "192.0.2.91" not in rendered
+        assert "srcip" in out["groupby1"]
+
+    def test_the_string_form_is_untouched(self, masker: OutputMasker) -> None:
+        """The shape that already worked keeps working."""
+        out = masker.mask_result({"groupby1": f"srcip:{self.IP}"})
+        assert self.IP not in str(out)
+        assert str(out["groupby1"]).startswith("srcip:")
+
+    def test_a_known_key_holding_a_container_does_not_leak(self, masker: OutputMasker) -> None:
+        """Recognising the key is not enough. _mask_entry's branches are
+        shape-gated to strings, so a known key holding a container fell
+        back into the allowlist walk this function exists to distrust."""
+        for payload in (
+            {"groupby1": {"srcip": {"nested": self.IP}}},
+            {"groupby1": {"srcip": [{"nested": self.IP}]}},
+            {"groupby1": [{"srcip": [{"nested": self.IP}]}]},
+            {"groupby1": {"devvds": {"x": self.IP}}},
+            {"groupby1": {"grpby": {"x": self.IP}}},
+        ):
+            assert self.IP not in str(masker.mask_result(payload)), payload
+
+    def test_a_known_key_holding_a_list_of_strings_still_masks(self, masker: OutputMasker) -> None:
+        """The shape _mask_entry can type is still handed to it, so
+        narrowing the known branch does not burn what worked."""
+        out = masker.mask_result({"groupby1": {"srcip": [self.IP]}})
+        assert self.IP not in str(out)
+        assert not str(out["groupby1"]["srcip"]).startswith("['masked-unrepresentable")
+
+    def test_a_burned_value_is_recorded_so_its_twin_in_prose_follows(
+        self, masker: OutputMasker
+    ) -> None:
+        """_burn_strings takes no mapping, so a burned value's twin in a
+        free-text field rode out in clear beside its own burned copy."""
+        out = masker.mask_result(
+            {"groupby1": {"srcuser": "walter.white"}, "msg": "blocked walter.white today"}
+        )
+        assert "walter.white" not in str(out)
+
+    def test_a_masked_value_is_recorded_so_its_twin_in_prose_follows(
+        self, masker: OutputMasker
+    ) -> None:
+        """The known branch has to keep feeding the shared mapping. Dropping
+        its result on the floor left the map masked and the same name in
+        clear two keys away, with the whole suite green."""
+        out = masker.mask_result(
+            {"groupby1": {"user": "walter.white"}, "msg": "blocked walter.white today"}
+        )
+        assert "walter.white" not in str(out)
+
+    def test_a_device_identity_key_keeps_its_name_with_the_flag_off(
+        self, masker: OutputMasker
+    ) -> None:
+        """The "is this name known" question is flag-independent. Asking
+        the flag-mutated table made devname read as unknown with the flag
+        off, so the KEY burned while the value stayed readable: mangled
+        schema on the majority configuration, for no gain."""
+        out = masker.mask_result({"groupby1": {"devname": "fw-paris-01"}})
+        assert "devname" in out["groupby1"]
+
+    def test_a_device_identity_key_still_masks_with_the_flag_on(
+        self, full_masker: OutputMasker
+    ) -> None:
+        out = full_masker.mask_result({"groupby1": {"devname": "fw-paris-01"}})
+        assert "devname" in out["groupby1"]
+        assert "fw-paris-01" not in str(out)
+
+    def test_a_known_key_is_matched_case_insensitively(self, masker: OutputMasker) -> None:
+        """FortiAnalyzer surfaces do not agree on case. Matching the key
+        verbatim would burn a dimension that masks reversibly today."""
+        out = masker.mask_result({"groupby1": {"SrcIP": self.IP}})
+        assert self.IP not in str(out)
+        assert "SrcIP" in out["groupby1"]
+        assert not str(out["groupby1"]["SrcIP"]).startswith("masked-unrepresentable")
+
+    def test_a_kept_value_is_not_burned_inside_the_map(self, masker: OutputMasker) -> None:
+        """A value the deployment chose to leave readable stays readable
+        under every key. Burning it here while devname shows it two keys
+        away is the same mismatch the keep set exists to prevent."""
+        out = masker.mask_result({"devname": "fw-paris-01", "groupby1": {"unknown": "fw-paris-01"}})
+        assert out["groupby1"]["unknown"] == "fw-paris-01"

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -2800,23 +2800,37 @@ class TestPercentEncodedFreeText:
         out = masker.mask_result({"msg": "src%3D192.0.2.77 blocked"})
         assert "192.0.2.77" not in str(out)
 
-    def test_an_untouched_escape_survives_when_the_plain_scan_already_hit(
+    def test_a_second_identifier_hiding_behind_an_escape_is_not_missed(
         self, masker: OutputMasker
     ) -> None:
-        """The early return is load-bearing, and a mutation sweep caught
-        that nothing pinned it.
+        """The previous shape of this function returned as soon as the
+        plain-text scan matched anything, so the decode pass never ran at
+        all when a plain-form identifier was already present -- a second,
+        percent-encoded identifier next to it went straight through in
+        clear. Measured pre-fix:
 
-        When the ordinary scan already masked something, the decode must
-        not run, or an escape that had nothing to do with the match gets
-        rewritten as a side effect. Measured with the guard removed:
+            src=192.0.2.77 mac=aa%3Abb%3Acc%3Add%3Aee%3A11
+              -> src=<token> mac=aa%3Abb%3Acc%3Add%3Aee%3A11  (MAC leaked)
 
-            src=<token> path%2Fto%2Ffile  ->  src=<token> path/to/file
+        Both must be masked now, in the same value, regardless of which
+        form either one arrived in."""
+        out = masker.mask_result({"msg": "src=192.0.2.77 mac=aa%3Abb%3Acc%3Add%3Aee%3A11 blocked"})
+        rendered = str(out)
+        assert "192.0.2.77" not in rendered
+        assert "aa%3Abb%3Acc%3Add%3Aee%3A11" not in rendered
+        assert self.MAC not in rendered
 
-        The tokens are identical either way, because the decode reads the
-        ORIGINAL rather than the masked text. So this is about byte
-        fidelity, not about double-masking.
-        """
+    def test_an_unrelated_escape_may_decode_as_a_side_effect_of_a_real_find(
+        self, masker: OutputMasker
+    ) -> None:
+        """Byte fidelity is preserved only when nothing in the value needs
+        masking at all (see the two pins above): once any identifier is
+        found -- via the plain scan or the decoded one -- the value the
+        caller gets back is masked either way it was reached, and an
+        unrelated escape sitting next to a genuine identifier may come
+        back decoded as a side effect. That is an acceptable, documented
+        cost; the previous version paid the opposite cost instead, which
+        was a real identifier leak, not a formatting nicety."""
         out = masker.mask_result({"srcip": "192.0.2.77", "msg": "src=192.0.2.77 path%2Fto%2Ffile"})
         assert "192.0.2.77" not in str(out)
         assert out["srcip"] in out["msg"]
-        assert "path%2Fto%2Ffile" in out["msg"]


### PR DESCRIPTION
The `msg` row of the #80 second-tier table, split out of #119 because it is a mechanism change rather than a table entry.

**Stacked on #119**, which sits on #118, #117 and #116. It will shrink to two commits as those land.

## What was wrong

FortiAnalyzer returns `msg` percent-encoded, so a MAC reached the pass-2 scan as `aa%3Abb%3Acc%3Add%3Aee%3A11` and an email as `analyst%40example.com`. Both regexes need the literal separator, so neither matched.

Measured live during the sweep: on **3 of 3** event records the MAC inside `msg` differed from the masked MAC in the structured field of the same record, so the original was recoverable by anyone holding both. One record settled that they really were the same device: `msg` decoded to `AP <mac> chan 153 live 7235442` while the record's own `channel` and `live` fields matched exactly.

## The rule

`_mask_scalar_text` is the single chokepoint for every TEXT key, so the second look lives there. **Decoding is a means of finding identifiers, not a reformatting of tool output**, and the three rules that follow from that are each pinned:

| Input | Behaviour |
|---|---|
| plain text | scanned exactly as before, never decoded |
| the ordinary scan already masked something | that result is returned, no decode at all |
| decode surfaces nothing to mask | caller gets the exact bytes FortiAnalyzer sent |
| decode surfaces an identifier | decoded and masked form goes out |

So `"CPU 100% busy"` and an encoded path with no identifier both come back byte-identical, and the format only changes on a record where it bought something.

**Re-encoding the untouched spans around a substitution is deliberately not attempted.** A token is neither the length nor the alphabet of what it replaced, so a faithful round trip is not available, and a half-encoded string would be worse than an honest decoded one.

## The mutation sweep earned its place again

The second commit exists because of it. Removing the early return (`if masked != value: return masked`) left **all 330 tests green**, so a load-bearing branch was unpinned.

It also corrected my reasoning. I first wrote the pin claiming the guard prevents a double-mask, since an IPv4 token is itself a valid IPv4. That is wrong: the decode reads the **original** value, not the masked text, so the tokens are identical either way. Measured with the guard removed:

```
src=<token> path%2Fto%2Ffile   ->   src=<token> path/to/file
```

What the guard actually protects is byte fidelity: an escape unrelated to the match must not be rewritten as a side effect of masking something else. The test now asserts that, and the commit says so.

## Verification

- 4 tests red first, 3 green from the start: the two byte-identical guards and the plain-text path, all three there to catch an over-correction.
- Green control 331, then 4 mutants, all killed: the second look removed, the decoded form always emitted, the decode run even after an ordinary hit, and the masked result discarded.
- 2142 tests pass, up from 2134, nothing regressed. ruff and mypy clean.
