### PR TITLE
test(skills): assert the flag default, not the developer's .env

### DIFF
--- a/tests/test_skills.py
+++ b/tests/test_skills.py
@@ -792,7 +792,12 @@ class TestSkillsFlag:
         from fortianalyzer_mcp.utils.config import Settings
 
         monkeypatch.delenv("FAZ_SKILLS_ENABLED", raising=False)
-        assert Settings(FORTIANALYZER_HOST="192.0.2.1").FAZ_SKILLS_ENABLED is False
+        # _env_file=None so the assertion is about the DEFAULT, not about
+        # whatever the developer's .env happens to say. delenv clears the
+        # process env; it cannot clear the dotenv source Settings also
+        # reads, so without this the test fails for anyone whose .env
+        # sets the flag.
+        assert Settings(FORTIANALYZER_HOST="192.0.2.1", _env_file=None).FAZ_SKILLS_ENABLED is False
 
 
 class TestNestedWarningRedaction:


### PR DESCRIPTION
The `test_skills.py::test_flag_defaults_off` failure you have been carrying as a "pre-existing local-env issue" for weeks is reproducible, and it is the test's fault rather than your machine's.

## Mechanism

`Settings` reads a dotenv as well as the process environment: `config.py` sets `env_file` to the project `.env` when one exists. `monkeypatch.delenv` clears the process env; it cannot clear the dotenv source. So on any machine whose `.env` sets `FAZ_SKILLS_ENABLED`, the test reads that value, fails permanently, and says nothing about the default it exists to pin.

## Reproduced

Wrote a `.env` containing `FAZ_SKILLS_ENABLED=true` on a clean checkout of `main`:

```
FAILED tests/test_skills.py::TestSkillsFlag::test_flag_defaults_off
```

With `_env_file=None`, and that same `.env` still in place:

```
1 passed
```

## It is not weakened

The property worth having is that the test still catches a real regression. Flipping the actual default in `config.py` to `True` fails it both before and after this change, so it is environment-proof rather than defanged.

## Note on scope

The suite was already green on my machine (2302 passing), so this is not a fix for anything failing in CI. It is worth its own PR only because that caveat has had to be written on six PR descriptions now, and a test that fails for reasons unrelated to the code is one people learn to scroll past.
