### PR TITLE
fix(masking): type the identifier-bearing groupby dimension names (#80)

### DIFF
--- a/src/fortianalyzer_mcp/masking/fields.py
+++ b/src/fortianalyzer_mcp/masking/fields.py
@@ -160,6 +160,17 @@ FIELD_TYPES: dict[str, str] = {
     # --- IP carriers (log fields + alert/event_details variants)
     "srcip": IP,
     "dstip": IP,
+    # --- alert-handler groupby dimension names (#80) -------------------- #
+    # Read out of the live handler catalogue rather than guessed: 55 distinct
+    # names ship across the rules, and these carry an identifier the flat
+    # allowlist did not type. COMPOSITE_PREFIXED resolves "<field>:<value>"
+    # through this same table, so covering groupby3 bought nothing while the
+    # name inside it was unknown. Each takes the type of the covered twin it
+    # sits beside in a record, so the two spellings of one value mint the
+    # same token instead of publishing the pairing.
+    "attackerip": IP,  # twin of srcip
+    "victimip": IP,  # twin of dstip
+    "host_ip": IP,  # twin of srcip
     "trueclntip": IP,
     "transip": IP,
     "tranip": IP,
@@ -204,6 +215,7 @@ FIELD_TYPES: dict[str, str] = {
     "srcname": HOSTNAME,
     "dstname": HOSTNAME,
     "hostname": HOSTNAME,
+    "remotename": HOSTNAME,  # groupby (#80): IPsec/dialup peer name
     "epname": IP_OR_HOST,
     "dstepname": IP_OR_HOST,
     # fortiview top-sources/top-destinations: the resolved name for the
@@ -230,6 +242,9 @@ FIELD_TYPES: dict[str, str] = {
     "f_user": USERNAME,
     "dstuser": USERNAME,
     "unauthuser": USERNAME,
+    "user_name": USERNAME,  # groupby (#80): twin of user
+    "user_id": USERNAME,  # groupby (#80): twin of user
+    "enduser": USERNAME,  # groupby (#80): twin of user/euname
     "xauthuser": USERNAME,
     "eapuser": USERNAME,
     "useralt": USERNAME,
@@ -243,6 +258,8 @@ FIELD_TYPES: dict[str, str] = {
     "domainctrlusername": USERNAME,
     # --- domain carriers
     "qname": DOMAIN,
+    "dst_domain": DOMAIN,  # groupby (#80): twin of qname
+    "http_host": DOMAIN,  # groupby (#80): the HTTP Host header, twin of qname
     "srcdomain": DOMAIN,
     "botnetdomain": DOMAIN,
     "domainctrldomain": DOMAIN,
@@ -252,6 +269,7 @@ FIELD_TYPES: dict[str, str] = {
     "sender": EMAIL,
     "recipient": EMAIL,
     "from": EMAIL,
+    "mail_from": EMAIL,  # groupby (#80): twin of from
     "to": EMAIL,
     "cc": EMAIL,
     "collectedemail": EMAIL,
@@ -308,6 +326,7 @@ FIELD_TYPES: dict[str, str] = {
     "remedy_executor": EMAIL,
     "remedy_approver": EMAIL,
     "dstendpoint": IP_OR_HOST,  # inside the incident grpby JSON blob
+    "net_remote_server": IP_OR_HOST,  # groupby (#80): twin of dstendpoint
     "srcendpoint": IP_OR_HOST,
     # --- response echo keys: tool responses reflect caller inputs at the
     # top level; a filter like srcip=="192.0.2.1" re-leaks the raw value
@@ -535,6 +554,11 @@ COMPOSITE_ID_DEVTYPE: dict[str, str] = {
 #: opts in via ``FAZ_MASK_DEVICE_IDENTITY``; see the module docstring.
 DEVICE_IDENTITY_TYPES: dict[str, str] = {
     "devname": HOSTNAME,
+    # groupby (#80): the logging device's own name, estate identity of the
+    # same class as devname, so it follows the flag rather than masking
+    # unconditionally. Measured leaking in BOTH flag states before this,
+    # which is what separates it from devname reading as a leak flag-off.
+    "logdev_name": HOSTNAME,
     # This repo's own tools layer documents devid as the SERIAL-carrying
     # spelling, in three places: fortiview_tools.py builds
     # [{"devid": <serial>}] for a serial-shaped value and notes that "a

--- a/src/fortianalyzer_mcp/masking/fields.py
+++ b/src/fortianalyzer_mcp/masking/fields.py
@@ -655,4 +655,8 @@ COMPOSITE_URL_HOST = ("http_url",)
 COMPOSITE_URL_FULL = ("url", "referralurl", "link", "reference_url")
 
 # Values that carry no identifier and pass through unmasked.
-SKIP_VALUES = frozenset({"", "N/A", "n/a", "unknown", "none", "-"})
+#: ``<>`` is the SMTP null return path, carried by every bounce and DSN. It is
+#: a protocol constant, not a principal, and typing ``mail_from`` (#80) turned
+#: the most common value on that surface into an irreversible placeholder that
+#: names nobody.
+SKIP_VALUES = frozenset({"", "N/A", "n/a", "unknown", "none", "-", "<>"})

--- a/src/fortianalyzer_mcp/masking/unmask.py
+++ b/src/fortianalyzer_mcp/masking/unmask.py
@@ -146,6 +146,23 @@ class ArgUnmasker:
             return marked
         if vtype in (IP, MAC, IP_OR_HOST):
             return self._unmask_by_type(vtype, candidate)
+        # A masked Host header comes back as ``<token>:<port>``, because the
+        # masker splits the pair rather than burning it whole. Without the
+        # mirror here that value passed straight through, so a model copying a
+        # ported host out of a response into a query argument got no
+        # restoration and matched zero rows: the split claimed to preserve the
+        # query-back pivot while only half building it.
+        #
+        # Decompose, resolve, reassemble, exactly as ``resolve_url`` already
+        # does for a URL's host and port. Strictly a no-op unless the head
+        # genuinely resolves, so an ordinary ``host:port`` a caller typed by
+        # hand reaches the appliance as written rather than being rewritten by
+        # a failed lookup.
+        head, sep, port = candidate.partition(":")
+        if sep and head and port.isascii() and port.isdigit() and len(port) <= 5:
+            resolved = self.resolve_scalar(head, vtype)
+            if resolved != head:
+                return f"{resolved}:{port}"
         return value
 
     # -- masked URLs (#40 url/referralurl) ---------------------------------- #

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -441,15 +441,22 @@ class OutputMasker:
             # as anything useful. ``_mask_url_host`` already splits a URL's
             # host from the rest for the same reason.
             #
-            # Exactly ONE colon, and a numeric tail. Splitting on the last
-            # colon alone was wrong and my first comment here claimed a
-            # safety it did not have: ``2001:db8::1`` ends in a digit, so it
-            # split into a burned ``2001:db8:`` host and a stray ``:1``. A
-            # bare ``host:port`` has one colon; an IPv6 literal has several
-            # and the bracketed form ``[::1]:8080`` has more still, so both
-            # fall through to be handled whole.
+            # A numeric ASCII tail after the FIRST colon. Splitting on the
+            # last colon was wrong and my first comment claimed a safety it
+            # did not have: ``2001:db8::1`` ends in a digit, so it split into
+            # a burned ``2001:db8:`` host and a stray ``:1``.
+            #
+            # Partitioning on the first colon rejects multi-colon values
+            # indirectly rather than by counting: an IPv6 literal leaves
+            # ``db8::1`` as the tail and the bracketed ``[::1]:8080`` leaves
+            # ``:1]:8080``, neither of which is all digits, so both fall
+            # through and are handled whole.
+            #
+            # ``isascii`` matters: ``str.isdigit`` alone accepts Unicode
+            # digits, so an Arabic-Indic port would split and echo a tail this
+            # code never validated.
             host, sep, port = value.partition(":")
-            if sep and host and port.isdigit() and len(port) <= 5:
+            if sep and host and port.isascii() and port.isdigit() and len(port) <= 5:
                 masked_host = self._mask_scalar(vtype, host, mapping, keep=keep)
                 return f"{masked_host}:{port}"
         if self._engine.is_own_v2_token(value):

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -434,6 +434,24 @@ class OutputMasker:
         """
         if value.strip() in SKIP_VALUES:
             return value
+        if vtype == DOMAIN:
+            # An HTTP Host header is ``host[:port]`` and a port is not an
+            # identifier, so masking the pair whole loses the host's
+            # reversibility AND the port's readability: neither half survives
+            # as anything useful. ``_mask_url_host`` already splits a URL's
+            # host from the rest for the same reason.
+            #
+            # Exactly ONE colon, and a numeric tail. Splitting on the last
+            # colon alone was wrong and my first comment here claimed a
+            # safety it did not have: ``2001:db8::1`` ends in a digit, so it
+            # split into a burned ``2001:db8:`` host and a stray ``:1``. A
+            # bare ``host:port`` has one colon; an IPv6 literal has several
+            # and the bracketed form ``[::1]:8080`` has more still, so both
+            # fall through to be handled whole.
+            host, sep, port = value.partition(":")
+            if sep and host and port.isdigit() and len(port) <= 5:
+                masked_host = self._mask_scalar(vtype, host, mapping, keep=keep)
+                return f"{masked_host}:{port}"
         if self._engine.is_own_v2_token(value):
             # Already this layer's own output. Masking it again destroys
             # it, loudly on a typed route that cannot parse a token (an IP

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -3148,3 +3148,75 @@ class TestGroupbyDimensionNamesCarryTheirType:
         }[dimension]
         out = masker.mask_result({"groupby1": f"{dimension}:{value}"})["groupby1"]
         assert value in out
+
+
+class TestTheNewNamesDoNotBurnRoutineShapes:
+    """#124 types four names that were previously untyped, and typing a name
+    changes what happens to values that do not fit the type.
+
+    An adversarial review measured the trade: on main these rode out in CLEAR
+    (a leak), and once typed they fail CLOSED to an irreversible placeholder.
+    Failing closed is right, but a placeholder is not a token: it cannot be
+    unmasked, so the analyst loses the query-back pivot. Two of the three
+    shapes it found are routine enough to be worth handling rather than
+    burning, and both are introduced by this PR rather than pre-existing.
+
+    Deliberately NOT handled here: ``enduser:CORP\\alice``. A domain-qualified
+    principal burns identically under the already-typed twin ``user`` on
+    main, so it is a question about the USERNAME mint in general and not
+    something this PR introduces.
+    """
+
+    def test_a_host_header_keeps_its_port_and_masks_the_host(self, masker: OutputMasker) -> None:
+        """``http_host`` is the HTTP Host header, which is ``host[:port]``.
+
+        The port is not an identifier and the host is, so burning the pair
+        loses both the reversibility of the host and the readability of the
+        port. ``_mask_url_host`` already splits a URL's host from the rest for
+        the same reason.
+        """
+        out = masker.mask_result({"groupby1": "http_host:corp.example.com:8080"})["groupby1"]
+
+        assert "corp.example.com" not in out
+        assert out.endswith(":8080"), f"port should survive, got {out!r}"
+        assert "unrepresentable" not in out, f"host should mint a token, got {out!r}"
+
+    def test_the_ported_host_mints_the_same_token_as_the_bare_host(
+        self, masker: OutputMasker
+    ) -> None:
+        """Otherwise one host has two identities depending on the port."""
+        ported = masker.mask_result({"groupby1": "http_host:corp.example.com:8080"})["groupby1"]
+        bare = masker.mask_result({"groupby1": "http_host:corp.example.com"})["groupby1"]
+
+        assert ported.split("http_host:")[1].rsplit(":", 1)[0] == bare.split("http_host:")[1]
+
+    def test_the_null_envelope_sender_is_not_an_identifier(self, masker: OutputMasker) -> None:
+        """``<>`` is the SMTP null return path, a protocol constant.
+
+        Every bounce and DSN carries it, so burning it turns the most common
+        value on the surface into an irreversible placeholder while naming
+        nobody.
+        """
+        out = masker.mask_result({"groupby1": "mail_from:<>"})["groupby1"]
+        assert out == "mail_from:<>"
+
+    @pytest.mark.parametrize(
+        "value",
+        ["2001:db8::1", "[2001:db8::1]:8080", "corp.example.com:abc"],
+        ids=["ipv6-bare", "ipv6-bracketed", "non-numeric-tail"],
+    )
+    def test_a_colon_that_is_not_a_port_is_not_split(
+        self, masker: OutputMasker, value: str
+    ) -> None:
+        """My first version of the port split cut in the wrong place.
+
+        It used the LAST colon, so ``2001:db8::1`` ends in a digit and split
+        into a burned ``2001:db8:`` plus a stray ``:1``. The comment above it
+        claimed IPv6 fell through unchanged, which it did not. Only a value
+        with exactly one colon and a numeric tail is a ``host:port``.
+        """
+        out = masker.mask_result({"groupby1": f"http_host:{value}"})["groupby1"]
+        body = out.split("http_host:", 1)[1]
+
+        assert value not in body, "the value itself must not survive in clear"
+        assert not body.endswith(":1"), f"split at the wrong colon: {body!r}"

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -3268,3 +3268,50 @@ class TestTheNewNamesDoNotBurnRoutineShapes:
         else:
             assert "unrepresentable" in out, f"expected a whole-value burn, got {out!r}"
         assert value not in out
+
+    def test_the_ported_token_round_trips_as_an_argument(self) -> None:
+        """The half of this change I claimed and had not built.
+
+        The justification for splitting the port is that burning the pair
+        destroys the query-back pivot. That is only true if the model can
+        hand the token back. An adversarial review found it could not: the
+        bare token resolved and ``<token>:8080`` passed through untouched, so
+        a model copying a ported host out of a response into a query argument
+        got no restoration and matched zero rows.
+
+        ``resolve_url`` already decomposes, resolves and reassembles a URL
+        including its port; this is the same move for a bare host.
+        """
+        engine = FPEEngine(KEY)
+        masker = OutputMasker(engine)
+        unmasker = ArgUnmasker(engine)
+
+        ported = masker.mask_result({"http_host": "corp.example.com:8080"})["http_host"]
+
+        assert unmasker.unmask_args({"http_host": ported}) == {"http_host": "corp.example.com:8080"}
+
+    def test_an_unresolvable_head_leaves_the_argument_alone(self) -> None:
+        """No behaviour change for anything that is not a token plus a port.
+
+        The split must be a no-op unless the head genuinely resolves, so an
+        ordinary ``host:port`` a caller typed by hand reaches the appliance
+        exactly as written rather than being rewritten by a failed lookup.
+        """
+        unmasker = ArgUnmasker(FPEEngine(KEY))
+
+        assert unmasker.unmask_args({"http_host": "corp.example.com:8080"}) == {
+            "http_host": "corp.example.com:8080"
+        }
+
+    def test_a_unicode_digit_tail_is_not_treated_as_a_port(self) -> None:
+        """``str.isdigit`` alone accepts Unicode digits.
+
+        Harmless in itself, since a port names nobody, but it meant a tail
+        this code never validated was echoed verbatim on the strength of a
+        check that looked like it had validated it. ASCII is what a port is.
+        """
+        value = "corp.example.com:٨٠٨٠"
+        out = OutputMasker(FPEEngine(KEY)).mask_result({"http_host": value})["http_host"]
+
+        assert "unrepresentable" in out, f"expected a whole-value burn, got {out!r}"
+        assert "corp.example.com" not in out

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -3220,3 +3220,51 @@ class TestTheNewNamesDoNotBurnRoutineShapes:
 
         assert value not in body, "the value itself must not survive in clear"
         assert not body.endswith(":1"), f"split at the wrong colon: {body!r}"
+
+    @pytest.mark.parametrize(
+        ("value", "splits"),
+        [
+            ("corp.example.com:8080", True),
+            ("corp.example.com:0", True),
+            ("corp.example.com:00080", True),
+            ("a:1:2", False),
+            (":8080", False),
+            ("host:", False),
+            ("corp.example.com:abc", False),
+        ],
+        ids=[
+            "ordinary",
+            "port-zero",
+            "leading-zeros",
+            "two-colons",
+            "empty-host",
+            "empty-port",
+            "non-numeric",
+        ],
+    )
+    def test_the_split_declines_anything_that_is_not_a_host_port(
+        self, masker: OutputMasker, value: str, splits: bool
+    ) -> None:
+        """The gate is ``vtype == DOMAIN``, which is wider than ``http_host``.
+
+        Eight fields are DOMAIN-typed (``botnetdomain``, ``domain``,
+        ``domainctrldomain``, ``dst_domain``, ``http_host``, ``qname``,
+        ``scertcname``, ``srcdomain``), so this runs on all of them. A domain
+        cannot legally contain a colon, so any colon-bearing value here is
+        already anomalous; what matters is that the split never LOSES
+        information. Where it declines, the value burns exactly as it did
+        before, and where it fires, the host masks reversibly and the tail is
+        carried through untouched.
+
+        The recursive call cannot loop: ``partition`` hands it the segment
+        before the first colon, and a minted token contains no colon.
+        """
+        out = masker.mask_result({"qname": value})["qname"]
+
+        if splits:
+            tail = value.split(":", 1)[1]
+            assert out.endswith(f":{tail}"), f"tail not carried through: {out!r}"
+            assert "unrepresentable" not in out
+        else:
+            assert "unrepresentable" in out, f"expected a whole-value burn, got {out!r}"
+        assert value not in out

--- a/tests/test_masking_leak.py
+++ b/tests/test_masking_leak.py
@@ -3048,3 +3048,103 @@ class TestDevidCarriesASerial:
         monkeypatch.setenv("FAZ_MASKING_KEY", KEY)
         off = OutputMasker(FPEEngine(KEY), mask_device_identity=False)
         assert off.mask_result({"devid": self.SERIAL_VALUE})["devid"] == self.SERIAL_VALUE
+
+
+# --------------------------------------------------------------------------- #
+# groupby dimension names from the shipped alert-handler catalogue (#80)
+# --------------------------------------------------------------------------- #
+
+#: Every dimension name below was read out of the live handler catalogue
+#: (``get_alert_handlers(handler_type="both")``), not invented here: 55
+#: distinct names appear across the shipped rules, and these are the ones
+#: carrying an identifier that the flat allowlist did not type.
+#:
+#: The mechanism is the whole finding. ``COMPOSITE_PREFIXED`` masks
+#: ``"<fieldname>:<value>"`` by looking the INNER name up in the same type
+#: table, so ``groupby3`` being covered buys nothing when the name inside
+#: it is not. Measured on ``329ba81``, one masker, one key:
+#:
+#:     srcip:203.0.113.5        -> srcip:ip4-<kid>-<ciphertext>-<tag>
+#:     attackerip:203.0.113.5   -> attackerip:203.0.113.5
+#:
+#: Same value, same composite key, same record: the covered spelling mints
+#: a token and the uncovered spelling publishes the plaintext beside it.
+GROUPBY_IDENTIFIER_DIMENSIONS = [
+    ("attackerip", "203.0.113.5", "srcip"),
+    ("victimip", "203.0.113.5", "dstip"),
+    ("host_ip", "203.0.113.5", "srcip"),
+    ("dst_domain", "corp.example.com", "qname"),
+    ("http_host", "corp.example.com", "qname"),
+    ("net_remote_server", "corp.example.com", "dstendpoint"),
+    ("remotename", "corp.example.com", "hostname"),
+    ("user_name", "alice", "user"),
+    ("user_id", "alice", "user"),
+    ("enduser", "alice", "user"),
+    ("mail_from", "alice@example.com", "from"),
+]
+
+
+class TestGroupbyDimensionNamesCarryTheirType:
+    """The #80 residual: 55 dimension names ship in the handler catalogue
+    and the identifier-bearing ones were not in the type table."""
+
+    @pytest.mark.parametrize(
+        ("dimension", "value", "twin"),
+        GROUPBY_IDENTIFIER_DIMENSIONS,
+        ids=[d for d, _, _ in GROUPBY_IDENTIFIER_DIMENSIONS],
+    )
+    def test_the_dimension_masks_like_its_covered_twin(
+        self, masker: OutputMasker, dimension: str, value: str, twin: str
+    ) -> None:
+        out = masker.mask_result({"groupby1": f"{dimension}:{value}"})["groupby1"]
+        assert value not in out, (
+            f"{dimension} published {value!r} verbatim while its twin "
+            f"{twin} masks the same value in the same position"
+        )
+
+    @pytest.mark.parametrize(
+        ("dimension", "value", "twin"),
+        GROUPBY_IDENTIFIER_DIMENSIONS,
+        ids=[d for d, _, _ in GROUPBY_IDENTIFIER_DIMENSIONS],
+    )
+    def test_the_dimension_agrees_with_its_twin(
+        self, masker: OutputMasker, dimension: str, value: str, twin: str
+    ) -> None:
+        """Determinism is the reason this matters: if the two spellings of one
+        value minted different tokens, a record carrying both would still
+        hand over the pairing."""
+        got = masker.mask_result({"groupby1": f"{dimension}:{value}"})["groupby1"]
+        want = masker.mask_result({"groupby1": f"{twin}:{value}"})["groupby1"]
+        assert got.split(":", 1)[1] == want.split(":", 1)[1]
+
+    def test_logdev_name_follows_the_device_identity_flag(
+        self, masker: OutputMasker, full_masker: OutputMasker
+    ) -> None:
+        """It is estate identity, the same class as devname, so it must be
+        clear with the flag off and masked with it on.
+
+        Running this flag-off only is what made `devname` itself read as a
+        leak during the sweep, so both directions are asserted.
+        """
+        payload = {"groupby1": "logdev_name:fw-hq-01"}
+        assert "fw-hq-01" in masker.mask_result(payload)["groupby1"]
+        assert "fw-hq-01" not in full_masker.mask_result(payload)["groupby1"]
+
+    @pytest.mark.parametrize("dimension", ["euid", "srccountry", "dstcity", "catdesc"])
+    def test_the_deliberately_clear_dimensions_stay_clear(
+        self, masker: OutputMasker, dimension: str
+    ) -> None:
+        """Guards the obvious wrong fix. These four were each measured and
+        rejected as findings during the #80 sweep: euid is an internal row id
+        and documented join key, the geo pair is computed enrichment and a
+        first-class aggregation dimension, and catdesc is a FortiGuard
+        taxonomy label. Typing them would burn readable values for nothing.
+        """
+        value = {
+            "euid": "4471",
+            "srccountry": "Canada",
+            "dstcity": "Ottawa",
+            "catdesc": "Search Engines",
+        }[dimension]
+        out = masker.mask_result({"groupby1": f"{dimension}:{value}"})["groupby1"]
+        assert value in out

--- a/tests/test_masking_wrapper.py
+++ b/tests/test_masking_wrapper.py
@@ -59,7 +59,11 @@ class TestFieldTable:
             "srchost",
             "dsthost",
             "srcuser",
-            "remotename",
+            # "remotename" was on this list and has been removed: it does
+            # exist. The live alert-handler catalogue uses it as a groupby
+            # dimension (2 of the 55 distinct names), so typing it is not a
+            # no-op feigning coverage, it is the fix for a measured leak.
+            # See the #80 groupby-dimension work.
         ):
             assert dead not in FIELD_TYPES
 


### PR DESCRIPTION
The last coverage residual on #80, and the one I closed the issue's own list without working: "the 13 identifier-bearing groupby dimension names. `groupby3` is fixed, but the inner names themselves are a separate list and I have not worked them."

## The mechanism, which is why `groupby3` being covered bought nothing

`COMPOSITE_PREFIXED` masks `"<fieldname>:<value>"` by resolving the **inner** name through the same type table. An untyped inner name returns the pair unchanged. Measured on `329ba81`, one masker, one key:

```
srcip:203.0.113.5        ->  srcip:ip4-<kid>-<ct>-<tag>
attackerip:203.0.113.5   ->  attackerip:203.0.113.5
```

Same value, same composite key, same record. The covered spelling mints a token and the uncovered spelling publishes the plaintext beside it, which is the #118 finding again one level down.

## Enumerated, not guessed

Read out of the live handler catalogue, `get_alert_handlers(handler_type="both")`: **55 distinct dimension names** across the shipped rules, which matches the audit's count exactly. 16 are already typed, 39 are not. Of those 39, these carry an identifier:

| Dimension | Type | Covered twin it sits beside |
|---|---|---|
| `attackerip`, `victimip`, `host_ip` | `IP` | `srcip` / `dstip` |
| `dst_domain`, `http_host` | `DOMAIN` | `qname` |
| `net_remote_server` | `IP_OR_HOST` | `dstendpoint` |
| `remotename` | `HOSTNAME` | `hostname` |
| `user_name`, `user_id`, `enduser` | `USERNAME` | `user` / `unauthuser` |
| `mail_from` | `EMAIL` | `from` |
| `logdev_name` | `HOSTNAME`, **device identity** | `devname` |

Each takes its twin's type rather than a plausible one, and a test asserts the two spellings mint the **same token**, since a record carrying both would otherwise still hand over the pairing.

## Three things worth your eye

**`logdev_name` is in `DEVICE_IDENTITY_TYPES`, not `FIELD_TYPES`.** I ran the sweep under both flag settings precisely because of the #119 correction, and that is what separates this from a false positive: `devname` reads as a leak flag-off and masks flag-on, which is the documented design, whereas `logdev_name` leaked in **both** states.

**I removed `remotename` from the `test_rfc_dead_names_absent` guard.** That list asserts a name exists in no FAZ schema, because typing one would be "a silent no-op that feigns coverage". The premise is falsified: `remotename` is 2 of the 55 live catalogue names. I did not delete the guard, I removed one entry and recorded the measurement that moved it. If you would rather keep the guard intact and drop `remotename` from the fix, say so.

**39 uncovered, where the audit said 40.** One has closed since the audit was written. I did not chase which.

## Deliberately not fixed here

`_mask_prefixed` returns early on a TEXT inner type:

```python
if vtype is None or vtype == TEXT:
    return value
```

So `msg` inside a groupby leaks an address that the very same key masks at the flat level:

```
msg (flat)          "AP saw <mac> from 203.0.113.5"  ->  both masked
groupby1 "msg:..."  same string                      ->  verbatim
```

`msg` is 24 of the 55 catalogue occurrences, so this is live. It is a mechanism change rather than a table entry, and the TEXT early return looks deliberate rather than accidental, so it wants your ruling. Filed separately rather than smuggled in here, the way #120 was split out of #119.

2329 tests pass (2302 before), ruff and mypy clean.
