### PR TITLE
fix(tls): name a setting that exists, and add FORTIANALYZER_CA_BUNDLE

### DIFF
--- a/src/fortianalyzer_mcp/api/client.py
+++ b/src/fortianalyzer_mcp/api/client.py
@@ -7,6 +7,7 @@ import asyncio
 import json
 import logging
 from collections.abc import Awaitable, Callable
+from pathlib import Path
 from typing import Any, cast
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
@@ -55,6 +56,7 @@ class FortiAnalyzerClient:
         username: str | None = None,
         password: str | None = None,
         verify_ssl: bool = True,
+        ca_bundle: str | None = None,
         timeout: int = 30,
         max_retries: int = 3,
     ) -> None:
@@ -64,6 +66,15 @@ class FortiAnalyzerClient:
         self.username = username
         self.password = password
         self.verify_ssl = verify_ssl
+        # Refuse at construction. Passing a bad path through would fail at the
+        # first call, and a typo'd one must never fall back to the system trust
+        # store: that verifies against the wrong root and looks like success.
+        if ca_bundle and not Path(ca_bundle).is_file():
+            raise ValueError(
+                f"CA bundle not found: {ca_bundle!r}. FORTIANALYZER_CA_BUNDLE must "
+                "point at a readable PEM file."
+            )
+        self.ca_bundle = ca_bundle
         self.timeout = timeout
         self.max_retries = max_retries
 
@@ -99,9 +110,22 @@ class FortiAnalyzerClient:
             username=settings.FORTIANALYZER_USERNAME,
             password=settings.FORTIANALYZER_PASSWORD,
             verify_ssl=settings.FORTIANALYZER_VERIFY_SSL,
+            ca_bundle=settings.FORTIANALYZER_CA_BUNDLE or None,
             timeout=settings.FORTIANALYZER_TIMEOUT,
             max_retries=settings.FORTIANALYZER_MAX_RETRIES,
         )
+
+    def resolve_verify(self) -> bool | str:
+        """What to hand ``requests`` as ``verify=``.
+
+        ``requests`` takes a bool or a CA-bundle path and pyfmg forwards the
+        value unchanged, so a path needs no pyfmg change. Disabled
+        verification wins over a configured bundle, so an explicit
+        ``FORTIANALYZER_VERIFY_SSL=false`` is never silently upgraded.
+        """
+        if not self.verify_ssl:
+            return False
+        return self.ca_bundle or True
 
     async def connect(self) -> None:
         """Establish connection and authenticate."""
@@ -111,10 +135,24 @@ class FortiAnalyzerClient:
 
         logger.info("Connecting to FortiAnalyzer")
         if not self.verify_ssl:
+            # This used to end "prefer trusting the FAZ CA (set the CA bundle)".
+            # It named a setting that did not exist, and the remedy would not
+            # have been enough anyway: a factory FortiAnalyzer certificate is
+            # self-signed with the serial as CN and carries no subjectAltName,
+            # so even with it trusted as the CA bundle a request by IP fails
+            # CERTIFICATE_VERIFY_FAILED on an address mismatch (#126).
             logger.warning(
                 "TLS verification is DISABLED (FORTIANALYZER_VERIFY_SSL=false) -- the FortiAnalyzer "
                 "API token and all log/PCAP data are exposed to man-in-the-middle interception. "
-                "Prefer trusting the FAZ CA (set the CA bundle) over disabling verification."
+                "Trusting the appliance CA is NOT sufficient on its own: a factory certificate is "
+                "self-signed with the serial as CN and carries no subjectAltName, so verification "
+                "still fails on an address mismatch. To enable it, install a certificate on the "
+                "appliance naming the address you connect to, then set FORTIANALYZER_CA_BUNDLE to "
+                "its issuing CA and FORTIANALYZER_VERIFY_SSL=true."
+            )
+        elif self.ca_bundle:
+            logger.info(
+                "TLS verification enabled for %s against CA bundle %s", self.host, self.ca_bundle
             )
 
         # Hold the I/O lock across the connected-check and login so two
@@ -130,7 +168,7 @@ class FortiAnalyzerClient:
                         apikey=self.api_token,
                         debug=False,
                         use_ssl=True,
-                        verify_ssl=self.verify_ssl,
+                        verify_ssl=self.resolve_verify(),
                         timeout=self.timeout,
                         check_adom_workspace=False,
                     )
@@ -141,7 +179,7 @@ class FortiAnalyzerClient:
                         self.password,
                         debug=False,
                         use_ssl=True,
-                        verify_ssl=self.verify_ssl,
+                        verify_ssl=self.resolve_verify(),
                         timeout=self.timeout,
                     )
                 else:
@@ -480,7 +518,7 @@ class FortiAnalyzerClient:
                 fmg.sess.post,
                 fmg._url,
                 data=json.dumps(json_request),
-                verify=fmg.verify_ssl,
+                verify=self.resolve_verify(),
                 timeout=fmg.timeout,
                 headers=headers,
             )

--- a/src/fortianalyzer_mcp/utils/config.py
+++ b/src/fortianalyzer_mcp/utils/config.py
@@ -51,6 +51,18 @@ class Settings(BaseSettings):
         description="Verify SSL certificates",
     )
 
+    FORTIANALYZER_CA_BUNDLE: str = Field(
+        default="",
+        description="Path to a PEM CA bundle used to verify the FortiAnalyzer "
+        "certificate. Only consulted when FORTIANALYZER_VERIFY_SSL is true. A "
+        "factory appliance certificate is self-signed with the serial as CN and "
+        "carries no subjectAltName, so verification cannot succeed against one "
+        "however it is trusted; this is for estates that have installed a "
+        "certificate naming the address actually connected to. A path that does "
+        "not exist is refused at startup rather than falling back to the system "
+        "trust store.",
+    )
+
     FORTIANALYZER_TIMEOUT: int = Field(
         default=30,
         ge=1,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -595,3 +595,80 @@ class TestSystemTimezoneDetection:
         monkeypatch.setattr(client, "get_system_status", fake_status)
         tz = await client.get_system_timezone()
         assert tz is None
+
+
+class TestCaBundleAndVerifyGuidance:
+    """`FORTIANALYZER_CA_BUNDLE` and the warning that names it (#126).
+
+    The warning told the operator to "trust the FAZ CA (set the CA bundle)".
+    Two things were wrong with that. Trusting the CA is not sufficient: a
+    factory FortiAnalyzer certificate is self-signed with the serial as CN and
+    carries no subjectAltName, so with that certificate trusted as the CA
+    bundle a request by IP still fails CERTIFICATE_VERIFY_FAILED on an address
+    mismatch. And the setting it told the operator to set did not exist.
+    """
+
+    def test_ca_bundle_path_reaches_the_transport(self, tmp_path) -> None:
+        bundle = tmp_path / "corp-ca.pem"
+        bundle.write_text("-----BEGIN CERTIFICATE-----\n")
+
+        client = FortiAnalyzerClient(
+            host="faz.example.com", api_token="t", verify_ssl=True, ca_bundle=str(bundle)
+        )
+
+        assert client.resolve_verify() == str(bundle)
+
+    def test_verify_disabled_beats_a_ca_bundle(self, tmp_path) -> None:
+        """An explicit FORTIANALYZER_VERIFY_SSL=false is never silently upgraded."""
+        bundle = tmp_path / "corp-ca.pem"
+        bundle.write_text("-----BEGIN CERTIFICATE-----\n")
+
+        client = FortiAnalyzerClient(
+            host="faz.example.com", api_token="t", verify_ssl=False, ca_bundle=str(bundle)
+        )
+
+        assert client.resolve_verify() is False
+
+    def test_no_bundle_keeps_the_system_trust_store(self) -> None:
+        client = FortiAnalyzerClient(host="faz.example.com", api_token="t", verify_ssl=True)
+        assert client.resolve_verify() is True
+
+    def test_a_missing_bundle_fails_closed(self) -> None:
+        """A typo'd path must not fall back to the system trust store, which
+        would verify against the wrong root and look like success."""
+        with pytest.raises(ValueError, match="CA bundle"):
+            FortiAnalyzerClient(
+                host="faz.example.com",
+                api_token="t",
+                verify_ssl=True,
+                ca_bundle="/nonexistent/corp-ca.pem",
+            )
+
+    @pytest.mark.asyncio
+    async def test_the_warning_names_a_setting_that_exists(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """The old text pointed at a 'CA bundle' knob this server never had."""
+        stub = MagicMock()
+        stub.login.return_value = (0, {"status": {"code": 0, "message": "OK"}})
+        stub.get.return_value = (0, {"status": {"code": 0}})
+        monkeypatch.setattr("fortianalyzer_mcp.api.client.FortiManager", lambda *a, **kw: stub)
+
+        client = FortiAnalyzerClient(host="faz.example.com", api_token="t", verify_ssl=False)
+
+        caplog.clear()
+        with caplog.at_level("WARNING", logger="fortianalyzer_mcp.api.client"):
+            try:
+                await client.connect()
+            except Exception:
+                pass
+
+        blob = " ".join(r.getMessage() for r in caplog.records if r.levelname == "WARNING")
+
+        assert "FORTIANALYZER_VERIFY_SSL=false" in blob
+        # Names the setting that now exists, rather than a vague "the CA bundle".
+        assert "FORTIANALYZER_CA_BUNDLE" in blob
+        # States the real blocker.
+        assert "subjectAltName" in blob or "SAN" in blob


### PR DESCRIPTION
Closes #126. Mirror of rstierli/fortimanager-mcp#90, which carries the full measurement.

## The warning named a setting that did not exist

```
Prefer trusting the FAZ CA (set the CA bundle) over disabling verification.
```

`FORTIANALYZER_VERIFY_SSL` was a bool and there was no CA-bundle field in `utils/config.py`, so this pointed the operator at a knob they could not find. That is the part specific to this repo; the FortiManager wording at least did not invent a setting.

## And the remedy would not have been enough

Measured on a stock FortiAnalyzer: the certificate is self-signed with the serial as CN and carries **no** subjectAltName. With that certificate trusted explicitly as the CA bundle, a request by IP still fails `CERTIFICATE_VERIFY_FAILED: IP address mismatch`. Trust was never the failing check.

The warning now says so and names the step that has to come first: install a certificate on the appliance naming the address you connect to.

## One thing worth a look

`FORTIANALYZER_CA_BUNDLE` had to reach **three** call sites, not two. Besides the two `verify_ssl=` passthroughs there is a raw `requests.post` in the PCAP path reading `fmg.verify_ssl` directly:

```python
verify=fmg.verify_ssl,   ->   verify=self.resolve_verify(),
```

Missing that one would have left PCAP downloads on the old bool while everything else honoured the bundle, which is exactly the kind of split that only shows up in production.

Same two decisions as the FortiManager side: disabled verification beats a configured bundle, so an explicit `false` is never silently upgraded; and a missing bundle path is refused at construction rather than falling back to the system trust store and verifying against the wrong root.

2307 tests pass (2302 before), ruff and mypy clean.
