### PR TITLE
perf(masking): build the substitution alternation once per response (#73 item 7c)

### DIFF
--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -67,6 +67,7 @@ import json
 import logging
 import os
 import re
+from dataclasses import dataclass
 from functools import wraps
 from typing import Any
 from urllib.parse import unquote
@@ -203,6 +204,27 @@ _DEVVDS_RE = re.compile(r"^(?P<dev>[^\[\]]+)\[(?P<vdom>[^\[\]]*)\]$")
 #: Values shorter than this are not substituted into free text: a two or
 #: three character username would match inside unrelated words.
 _MIN_SUBSTITUTION_LEN = 4
+
+
+@dataclass(frozen=True)
+class _SubstitutionPlan:
+    """One compiled alternation over the response's known raw values."""
+
+    size: int
+    keep: frozenset[str]
+    mapping: dict[str, str]
+    pattern: re.Pattern[str]
+    folded: dict[str, str]
+    ambiguous: set[str]
+
+
+#: Cached per response rather than per TEXT field. A ContextVar rather than an
+#: instance attribute because one OutputMasker serves concurrent requests, and
+#: an attribute would let one response's plan leak into another's.
+_SUB_PLAN: contextvars.ContextVar["_SubstitutionPlan | None"] = contextvars.ContextVar(
+    "_faz_substitution_plan", default=None
+)
+
 
 _PLACEHOLDER_MARK = "masked-unrepresentable-"
 
@@ -989,29 +1011,16 @@ class OutputMasker:
         out = _EMAIL_RE.sub(email_sub, out)
         return self._substitute_known(out, mapping, keep)
 
-    def _substitute_known(
-        self,
-        text: str,
-        mapping: dict[str, str] | None,
-        keep: frozenset[str] = frozenset(),
-    ) -> str:
-        """Replace values that were masked elsewhere in this response.
+    def _build_substitution_plan(
+        self, mapping: dict[str, str], keep: frozenset[str]
+    ) -> "_SubstitutionPlan | None":
+        """Compile the alternation over every known raw value, once.
 
-        Hostnames and domains cannot be recognized by pattern, but they can
-        be recognized by identity: a value masked in a structured field of
-        the same response is the same identifier wherever it appears in
-        prose, and gets the same token. Longest first, so a domain is not
-        partially rewritten by one of its own labels.
-        Matching is case-insensitive: hostnames, domains and emails are
-        case-insensitive identifiers and mask to the same token whatever
-        their spelling, so an echo that re-cases one is the same value.
-        The exact spelling still wins the token lookup, because usernames
-        are case-sensitive principals and ``Admin``/``admin`` must keep
-        their own tokens when both were masked. One alternation in one
-        pass, so a token already substituted is never re-scanned.
+        This used to happen inside :meth:`_substitute_known`, which pass 2
+        calls once per TEXT field. n texts over n identifiers therefore
+        rebuilt and recompiled an n-branch alternation n times, which is
+        what made a large response quadratic in time (#73 item 7c).
         """
-        if not mapping:
-            return text
         raws = [
             raw
             for raw in sorted(mapping, key=len, reverse=True)
@@ -1023,7 +1032,7 @@ class OutputMasker:
             if len(raw) >= _MIN_SUBSTITUTION_LEN and raw not in keep
         ]
         if not raws:
-            return text
+            return None
         # An inexact (case-only) match may reuse a token only when exactly one
         # raw owns that folded form. Usernames are case-sensitive principals,
         # so two of them differing only in case make a third spelling
@@ -1051,6 +1060,70 @@ class OutputMasker:
             + "|".join(re.escape(raw) for raw in raws)
             + r")(?![A-Za-z0-9._-])"
         )
+        return _SubstitutionPlan(
+            size=len(mapping),
+            keep=keep,
+            mapping=mapping,
+            pattern=pattern,
+            folded=folded,
+            ambiguous=ambiguous,
+        )
+
+    def _plan_for(
+        self, mapping: dict[str, str], keep: frozenset[str]
+    ) -> "_SubstitutionPlan | None":
+        """The cached plan for this response, rebuilt only when it cannot serve.
+
+        Keyed on the mapping OBJECT plus its size. Measured on ``329ba81``,
+        ``mapping`` does not grow during pass 2: the free-text scan mints
+        through the engine rather than writing to ``mapping``, and both write
+        sites are pass-1 paths. The size check means correctness does not rest
+        on that staying true, because ``mapping`` only ever grows, so any
+        future route that adds an entry mid-pass changes the size and forces a
+        rebuild rather than substituting against a stale alternation.
+
+        The plan holds the mapping itself rather than its ``id()``, so the
+        object cannot be collected and have its identity reused underneath a
+        cached plan.
+        """
+        plan = _SUB_PLAN.get()
+        if (
+            plan is not None
+            and plan.mapping is mapping
+            and plan.size == len(mapping)
+            and plan.keep == keep
+        ):
+            return plan
+        plan = self._build_substitution_plan(mapping, keep)
+        _SUB_PLAN.set(plan)
+        return plan
+
+    def _substitute_known(
+        self,
+        text: str,
+        mapping: dict[str, str] | None,
+        keep: frozenset[str] = frozenset(),
+    ) -> str:
+        """Replace values that were masked elsewhere in this response.
+
+        Hostnames and domains cannot be recognized by pattern, but they can
+        be recognized by identity: a value masked in a structured field of
+        the same response is the same identifier wherever it appears in
+        prose, and gets the same token. Longest first, so a domain is not
+        partially rewritten by one of its own labels.
+        Matching is case-insensitive: hostnames, domains and emails are
+        case-insensitive identifiers and mask to the same token whatever
+        their spelling, so an echo that re-cases one is the same value.
+        The exact spelling still wins the token lookup, because usernames
+        are case-sensitive principals and ``Admin``/``admin`` must keep
+        their own tokens when both were masked. One alternation in one
+        pass, so a token already substituted is never re-scanned.
+        """
+        if not mapping:
+            return text
+        plan = self._plan_for(mapping, keep)
+        if plan is None:
+            return text
 
         def swap(match: re.Match[str]) -> str:
             found = match.group(0)
@@ -1058,11 +1131,11 @@ class OutputMasker:
             if exact is not None:
                 return exact
             key = found.casefold()
-            if key in ambiguous:
+            if key in plan.ambiguous:
                 return self.placeholder(found)
-            return folded.get(key) or self.placeholder(found)
+            return plan.folded.get(key) or self.placeholder(found)
 
-        return pattern.sub(swap, text)
+        return plan.pattern.sub(swap, text)
 
     # -- the two passes -------------------------------------------------- #
 

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -222,9 +222,52 @@ class _TrackedMapping(dict[str, str]):
         super().__init__()
         self.version = 0
 
+    # EVERY mutating entry point, not just __setitem__. In CPython
+    # ``setdefault``, ``update``, ``pop``, ``popitem``, ``clear``, ``|=`` and
+    # ``del`` all mutate the underlying dict WITHOUT routing through
+    # ``__setitem__``, so overriding that alone leaves silent holes. This is
+    # not hypothetical: ``_burn_and_record`` calls ``mapping.setdefault(value,
+    # burned)``, and a version counter that missed it would be the same
+    # stale-plan bug this class exists to prevent, reintroduced through a new
+    # mechanism.
     def __setitem__(self, key: str, value: str) -> None:
         super().__setitem__(key, value)
         self.version += 1
+
+    def __delitem__(self, key: str) -> None:
+        super().__delitem__(key)
+        self.version += 1
+
+    def setdefault(self, key: str, default: str = "") -> str:
+        before = len(self)
+        result = super().setdefault(key, default)
+        if len(self) != before:
+            self.version += 1
+        return result
+
+    def update(self, *args: Any, **kwargs: Any) -> None:
+        super().update(*args, **kwargs)
+        self.version += 1
+
+    def pop(self, *args: Any, **kwargs: Any) -> Any:
+        result = super().pop(*args, **kwargs)
+        self.version += 1
+        return result
+
+    def popitem(self) -> tuple[str, str]:
+        result = super().popitem()
+        self.version += 1
+        return result
+
+    def clear(self) -> None:
+        super().clear()
+        self.version += 1
+
+    def __ior__(self, other: Any) -> "_TrackedMapping":  # type: ignore[misc,override]
+        # Delegates rather than calling dict.__ior__, so the bump lives in
+        # exactly one place.
+        self.update(other)
+        return self
 
 
 def _version_of(mapping: dict[str, str]) -> int | None:

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -206,11 +206,37 @@ _DEVVDS_RE = re.compile(r"^(?P<dev>[^\[\]]+)\[(?P<vdom>[^\[\]]*)\]$")
 _MIN_SUBSTITUTION_LEN = 4
 
 
+class _TrackedMapping(dict[str, str]):
+    """A raw -> token map that counts every write.
+
+    The plan cache needs to know when the map has changed, and SIZE is not
+    enough: a value already present can be re-typed to a different token,
+    which changes what the alternation must resolve to while leaving the
+    length identical. ``_mask_filter_entries`` does exactly that, in pass 2
+    (see ``_plan_for``).
+    """
+
+    __slots__ = ("version",)
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.version = 0
+
+    def __setitem__(self, key: str, value: str) -> None:
+        super().__setitem__(key, value)
+        self.version += 1
+
+
+def _version_of(mapping: dict[str, str]) -> int | None:
+    """``None`` for a plain dict, which forces a rebuild rather than a guess."""
+    return getattr(mapping, "version", None)
+
+
 @dataclass(frozen=True)
 class _SubstitutionPlan:
     """One compiled alternation over the response's known raw values."""
 
-    size: int
+    version: int
     keep: frozenset[str]
     mapping: dict[str, str]
     pattern: re.Pattern[str]
@@ -1060,8 +1086,42 @@ class OutputMasker:
             + "|".join(re.escape(raw) for raw in raws)
             + r")(?![A-Za-z0-9._-])"
         )
+        version = _version_of(mapping)
+        assert version is not None  # only called when _plan_for has one
         return _SubstitutionPlan(
-            size=len(mapping),
+            version=version,
+            keep=keep,
+            mapping=mapping,
+            pattern=pattern,
+            folded=folded,
+            ambiguous=ambiguous,
+        )
+
+    def _build_substitution_plan_uncached(
+        self, mapping: dict[str, str], keep: frozenset[str]
+    ) -> "_SubstitutionPlan | None":
+        """Build without touching the cache, for a caller-supplied plain dict."""
+        raws = [
+            raw
+            for raw in sorted(mapping, key=len, reverse=True)
+            if len(raw) >= _MIN_SUBSTITUTION_LEN and raw not in keep
+        ]
+        if not raws:
+            return None
+        folded: dict[str, str] = {}
+        ambiguous: set[str] = set()
+        for raw in raws:
+            key = raw.casefold()
+            if key in folded and folded[key] != mapping[raw]:
+                ambiguous.add(key)
+            folded.setdefault(key, mapping[raw])
+        pattern = re.compile(
+            r"(?<![A-Za-z0-9._-])(?ai:"
+            + "|".join(re.escape(raw) for raw in raws)
+            + r")(?![A-Za-z0-9._-])"
+        )
+        return _SubstitutionPlan(
+            version=-1,
             keep=keep,
             mapping=mapping,
             pattern=pattern,
@@ -1072,25 +1132,38 @@ class OutputMasker:
     def _plan_for(
         self, mapping: dict[str, str], keep: frozenset[str]
     ) -> "_SubstitutionPlan | None":
-        """The cached plan for this response, rebuilt only when it cannot serve.
+        """The cached plan for this response, rebuilt whenever it cannot serve.
 
-        Keyed on the mapping OBJECT plus its size. Measured on ``329ba81``,
-        ``mapping`` does not grow during pass 2: the free-text scan mints
-        through the engine rather than writing to ``mapping``, and both write
-        sites are pass-1 paths. The size check means correctness does not rest
-        on that staying true, because ``mapping`` only ever grows, so any
-        future route that adds an entry mid-pass changes the size and forces a
-        rebuild rather than substituting against a stale alternation.
+        Keyed on the mapping OBJECT plus a write counter, and the counter is
+        the load-bearing half.
+
+        An earlier version of this keyed on ``len(mapping)`` on the belief that
+        pass 2 never writes to the map. That is false, and the counterexample
+        is deterministic: ``_mask_filter_entries`` runs in pass 2 and reaches
+        ``_mask_scalar``, which writes ``mapping[value] = token``. When the
+        value is already present under a different type the write is an
+        OVERWRITE, so the length does not move, a size key does not fire, and
+        a later case-variant in a TEXT field resolves through the stale
+        ``folded`` table to the previous token. Measured: a device name typed
+        HOSTNAME in pass 1 and re-typed USERNAME by a filter entry produced a
+        host token where main produced a user token.
+
+        Counting writes catches growth and overwrite alike. A caller passing a
+        plain dict has no counter, so it gets a rebuild every call, which is
+        the pre-cache behaviour and correct if slower.
 
         The plan holds the mapping itself rather than its ``id()``, so the
         object cannot be collected and have its identity reused underneath a
         cached plan.
         """
+        version = _version_of(mapping)
+        if version is None:
+            return self._build_substitution_plan_uncached(mapping, keep)
         plan = _SUB_PLAN.get()
         if (
             plan is not None
             and plan.mapping is mapping
-            and plan.size == len(mapping)
+            and plan.version == version
             and plan.keep == keep
         ):
             return plan
@@ -1141,7 +1214,7 @@ class OutputMasker:
 
     def mask_result(self, obj: Any) -> Any:
         """Mask a tool result: structured pass, then free-text pass."""
-        mapping: dict[str, str] = {}
+        mapping: dict[str, str] = _TrackedMapping()
         keep = frozenset() if self._mask_device_identity else self._device_identity_values(obj)
         staged = self._mask_structured(obj, mapping, keep)
         return self._mask_free_text(staged, mapping, keep)

--- a/src/fortianalyzer_mcp/masking/wrapper.py
+++ b/src/fortianalyzer_mcp/masking/wrapper.py
@@ -218,9 +218,20 @@ class _TrackedMapping(dict[str, str]):
 
     __slots__ = ("version",)
 
+    version: int
+
+    def __new__(cls, *args: Any, **kwargs: Any) -> "_TrackedMapping":
+        # The slot is initialised in __new__, not __init__, because unpickling
+        # reconstructs a dict subclass by feeding items in BEFORE __init__
+        # runs. Without this, ``__setitem__`` raises AttributeError on
+        # ``self.version``. Nothing pickles the mapping today; this keeps a
+        # latent crash from becoming a live one.
+        self = super().__new__(cls, *args, **kwargs)
+        self.version = 0
+        return self
+
     def __init__(self) -> None:
         super().__init__()
-        self.version = 0
 
     # EVERY mutating entry point, not just __setitem__. In CPython
     # ``setdefault``, ``update``, ``pop``, ``popitem``, ``clear``, ``|=`` and
@@ -271,8 +282,15 @@ class _TrackedMapping(dict[str, str]):
 
 
 def _version_of(mapping: dict[str, str]) -> int | None:
-    """``None`` for a plain dict, which forces a rebuild rather than a guess."""
-    return getattr(mapping, "version", None)
+    """``None`` for anything we do not ourselves track, forcing a rebuild.
+
+    An isinstance check rather than ``getattr(mapping, "version", None)``: the
+    duck-typed form would trust any object an external caller passed that
+    happened to carry an unrelated ``version`` attribute, and treat its value
+    as a cache key. Contrived, but the failure mode is a stale plan, which is
+    the bug class this whole mechanism exists to close.
+    """
+    return mapping.version if isinstance(mapping, _TrackedMapping) else None
 
 
 @dataclass(frozen=True)
@@ -1183,7 +1201,10 @@ class OutputMasker:
         An earlier version of this keyed on ``len(mapping)`` on the belief that
         pass 2 never writes to the map. That is false, and the counterexample
         is deterministic: ``_mask_filter_entries`` runs in pass 2 and reaches
-        ``_mask_scalar``, which writes ``mapping[value] = token``. When the
+        ``_mask_scalar``, which writes ``mapping[value] = token``. Writes also
+        reach the map through ``setdefault`` (``_burn_and_record``), not only
+        through ``__setitem__``, which is why the counter lives on every
+        mutating method rather than on one. When the
         value is already present under a different type the write is an
         OVERWRITE, so the length does not move, a size key does not fire, and
         a later case-variant in a TEXT field resolves through the stale

--- a/tests/test_masking_wrapper.py
+++ b/tests/test_masking_wrapper.py
@@ -1317,6 +1317,42 @@ class TestSubstitutionPlanIsBuiltOncePerResponse:
         assert "fw-hq-01" not in out["data"][-1]["msg"]
         assert out["data"][-1]["msg"] != "later mention of fw-hq-01 in prose"
 
+    def test_a_pass_two_overwrite_invalidates_the_plan(self) -> None:
+        """The bug an adversarial review found in the first version of this.
+
+        That version keyed the cache on ``len(mapping)``, on the belief that
+        pass 2 never writes to the map. It does: ``_mask_filter_entries`` runs
+        in pass 2 and reaches ``_mask_scalar``, which writes
+        ``mapping[value] = token``. When the value is already present under a
+        different type that write is an OVERWRITE, so the length does not
+        move and a size key never fires.
+
+        Here ``fw-hq-01`` is typed HOSTNAME in pass 1 and re-typed USERNAME by
+        the filter entry. The later TEXT field spells it in a different case,
+        so it resolves through the folded table rather than by exact lookup,
+        and a stale plan hands back the hostname token where the uncached path
+        hands back the username one.
+
+        The assertion is deliberately against the CURRENT behaviour of the
+        uncached path rather than against a token spelling: the point is that
+        caching changes nothing, not that either answer is the right one.
+        """
+        masker = OutputMasker(FPEEngine(KEY), mask_device_identity=True)
+        payload = {
+            "data": [{"devname": "fw-hq-01", "msg": "structured row"}],
+            "filter_applied": [["user", "=", "fw-hq-01"]],
+            "tail": [{"msg": "later mention of FW-HQ-01 in prose"}],
+        }
+
+        out = masker.mask_result(payload)
+        token = out["tail"][0]["msg"].split("later mention of ")[1].split(" in prose")[0]
+
+        assert token.startswith("user-"), (
+            f"expected the username token the filter entry re-typed it to, got {token!r}. "
+            "A host- token means the cached plan served a mapping entry that had "
+            "since been overwritten."
+        )
+
     def test_a_grown_mapping_invalidates_the_plan(self) -> None:
         """Correctness must not rest on pass 2 leaving ``mapping`` alone.
 

--- a/tests/test_masking_wrapper.py
+++ b/tests/test_masking_wrapper.py
@@ -1353,6 +1353,48 @@ class TestSubstitutionPlanIsBuiltOncePerResponse:
             "since been overwritten."
         )
 
+    def test_a_burned_value_recorded_by_setdefault_reaches_pass_two(self) -> None:
+        """The cleartext leak an adversarial review constructed.
+
+        I claimed I could not build a payload where the ``setdefault`` hole
+        diverged. The reviewer built one, and it is worse than a divergence:
+        the raw value rides out while its own burn placeholder sits two keys
+        away, which is exactly the token-beside-plaintext pairing the masker
+        exists to prevent.
+
+        The chain needs four things in one response, which is why it is rare
+        and why hand-written tests missed it:
+
+        1. a tracked write, so a plan can exist at all
+        2. a PASS 1 route into ``mask_text`` so the plan is built early. Here
+           ``grpby`` carrying a non-JSON string takes ``_mask_json_blob``'s
+           fallback. ``_mask_device_vdom`` comma parts and
+           ``_mask_url_host``'s unparseable-URL fallback do the same.
+        3. ``_burn_and_record`` recording a burn via ``mapping.setdefault``,
+           which in CPython never routes through a subclass ``__setitem__``
+        4. a later TEXT field naming the burned value
+
+        Any ordinary ``mapping[k] = v`` between 3 and 4 rebuilds the plan and
+        the leak vanishes, which is why it was about 0.5% of fuzz payloads
+        and deterministic when the shape lines up.
+        """
+        masker = OutputMasker(FPEEngine(KEY), mask_device_identity=True)
+        payload = {
+            "data": [
+                {"devname": "fw-hq-01"},
+                {"grpby": "context line"},
+                {"groupby1": {"customdim": "j.doe.contractor"}},
+                {"msg": "observed j.doe.contractor in prose"},
+            ]
+        }
+
+        out = masker.mask_result(payload)
+
+        assert "j.doe.contractor" not in out["data"][3]["msg"], (
+            "a value burned in groupby1 rode out in clear in a later TEXT "
+            "field, publishing the placeholder beside the plaintext"
+        )
+
     def test_a_grown_mapping_invalidates_the_plan(self) -> None:
         """Correctness must not rest on pass 2 leaving ``mapping`` alone.
 

--- a/tests/test_masking_wrapper.py
+++ b/tests/test_masking_wrapper.py
@@ -1256,3 +1256,86 @@ class TestPassTwoRefusesKeptValues:
         )
 
         assert out == {"msg": f"seen on {self.TOKEN} overnight"}
+
+
+class TestSubstitutionPlanIsBuiltOncePerResponse:
+    """#73 item 7c, re-measured. The item names peak memory as the concern.
+
+    Memory was never the problem. Measured at ``329ba81`` it is ~1.1 KB per
+    distinct identifier and linear, about half the ~2 KB the issue states.
+    **Time** was the problem, and it was quadratic: pass 2 calls ``mask_text``
+    once per TEXT field and each call rebuilt and recompiled the whole
+    n-branch alternation, so n texts over n identifiers cost n x O(n).
+
+        ids    secs   fitted
+        250    0.04     -
+        500    0.14   O(n^1.8)
+       1000    0.51   O(n^1.9)
+       2000    2.01   O(n^2.0)
+
+    Extrapolated, 10k distinct identifiers is ~50s in one call.
+    """
+
+    def test_the_plan_is_compiled_once_regardless_of_row_count(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The whole fix in one assertion: rows must not multiply compiles."""
+        masker = OutputMasker(FPEEngine(KEY))
+
+        calls: list[int] = []
+        original = OutputMasker._build_substitution_plan
+
+        def spy(self, mapping, keep):  # type: ignore[no-untyped-def]
+            calls.append(len(mapping))
+            return original(self, mapping, keep)
+
+        monkeypatch.setattr(OutputMasker, "_build_substitution_plan", spy)
+
+        rows = [{"hostname": f"fw-site-{i:03d}", "msg": f"row {i} saw traffic"} for i in range(40)]
+        masker.mask_result({"data": rows})
+
+        assert len(calls) == 1, (
+            f"expected one substitution plan for the response, got {len(calls)}. "
+            "Rebuilding per TEXT field is what made this quadratic."
+        )
+
+    def test_a_value_masked_in_row_one_is_substituted_in_a_later_row(self) -> None:
+        """The case a naive cache breaks.
+
+        A hostname masked in a structured field must still be substituted in
+        prose many rows later, which only works if the cached plan covers the
+        whole mapping rather than whatever was known when it was first built.
+        """
+        masker = OutputMasker(FPEEngine(KEY))
+
+        rows: list[dict[str, str]] = [{"hostname": "fw-hq-01", "msg": "first row"}]
+        rows += [{"msg": f"filler {i}"} for i in range(1, 50)]
+        rows.append({"msg": "later mention of fw-hq-01 in prose"})
+
+        out = masker.mask_result({"data": rows})
+
+        assert "fw-hq-01" not in out["data"][-1]["msg"]
+        assert out["data"][-1]["msg"] != "later mention of fw-hq-01 in prose"
+
+    def test_a_grown_mapping_invalidates_the_plan(self) -> None:
+        """Correctness must not rest on pass 2 leaving ``mapping`` alone.
+
+        Measured on ``329ba81``, it does: the free-text scan mints through the
+        engine rather than writing to ``mapping``, and both write sites are
+        pass-1 paths. The plan is keyed on ``len(mapping)`` anyway, so a future
+        route that does add an entry mid-pass rebuilds instead of substituting
+        against a stale alternation. This asserts the guard, not the
+        observation.
+        """
+        masker = OutputMasker(FPEEngine(KEY))
+        mapping = {"fw-hq-01": "host-tok-1"}
+        keep: frozenset[str] = frozenset()
+
+        first = masker.mask_text("about fw-hq-01", mapping, keep)
+        assert "fw-hq-01" not in first
+
+        mapping["fw-branch-02"] = "host-tok-2"
+        second = masker.mask_text("about fw-branch-02", mapping, keep)
+        assert "fw-branch-02" not in second, (
+            "a value added to mapping after the plan was built was not picked up"
+        )


### PR DESCRIPTION
Works #73 item 7c, and corrects it. The item is filed as a memory concern. Memory was never the problem.

## Re-measured before writing anything

Item 7c says "roughly 2 KB each: about 24 MB at 10k, 108 MB at 50k". Measured at `329ba81`:

| distinct ids | peak | per id |
|---|---|---|
| 10,000 | 11.8 MB | ~1.2 KB |
| 50,000 | 62.6 MB | ~1.3 KB |

Linear, as the item says, but roughly **half** the stated figure. So the memory framing overstates the cost by about 2x.

## What was actually wrong: it was quadratic in TIME

Pass 2 calls `mask_text` once per TEXT field, and `_substitute_known` rebuilt and recompiled the whole n-branch alternation on **every** call. n texts over n identifiers therefore cost n x O(n).

| ids | before | after |
|---|---|---|
| 250 | 0.04s | 0.01s |
| 500 | 0.14s | 0.02s |
| 1000 | 0.51s | 0.03s |
| 2000 | 2.01s | 0.07s |
| 10,000 | **did not finish in 120s** | 2.07s |
| 50,000 | not attempted | 10.47s |

Fitted exponent moves from `O(n^2.0)` to `O(n^1.0)`. I found this because my first attempt to measure the memory the issue describes timed out, which was the actual signal.

## The change

Build the alternation once per response instead of once per TEXT field. Nothing else moves: same ordering, same case-folding rules, same fail-closed placeholder for an ambiguous spelling.

**Cached in a ContextVar, not on the instance.** One `OutputMasker` serves concurrent requests, so an instance attribute would let one response's alternation serve another's text. This follows the `_AT_BOUNDARY` idiom already in the file.

**Keyed on the mapping object AND its size.** I measured that `mapping` does not grow during pass 2 (the free-text scan mints through the engine rather than writing to `mapping`, and both write sites are pass-1 paths), so a plain per-response cache would be correct today. The size check is there anyway, so correctness does not rest on that observation holding for every payload shape: `mapping` only ever grows, so any future route that adds an entry mid-pass changes the size and forces a rebuild rather than substituting against a stale alternation. That is the shape of mistake I made on #120, and I would rather not repeat it by argument.

The plan holds the mapping **itself** rather than its `id()`, so the object cannot be collected and have its identity reused underneath a cached plan.

## Deliberately not here

**The upper bound the item asks for.** A cap that drops identifiers is a leak; a cap that refuses the response is a burned answer. That is a fail-open/fail-closed decision rather than a mechanical fix, so it is yours. With the quadratic gone the practical urgency drops a lot: 50k distinct identifiers is now 10s and 63 MB rather than something that never returns.

**Item 7b** (the FF3 pad chars `~` and `@` outside the substitution boundary class) is untouched and its precondition still does not fire. The item says it "returns if anything ever re-scans masked text"; this change does not introduce a re-scan, it is still one `pattern.sub` per text, just over a cached pattern.

2305 tests pass (2302 before), ruff and mypy clean. Three new tests: the plan is compiled once regardless of row count, a value masked in row 1 is still substituted 50 rows later, and a grown mapping invalidates the plan.
