### PR TITLE
fix(skills): the two threat_intel handler edges from the #130 review

### DIFF
--- a/src/fortianalyzer_mcp/skills/handlers.py
+++ b/src/fortianalyzer_mcp/skills/handlers.py
@@ -1332,8 +1332,14 @@ async def run_threat_intel(params: ThreatIntelParams) -> ThreatIntelResult:
             value = row.get("value")
             canonical = _INDICATOR_TYPE_CANONICAL.get(str(row.get("type") or "").lower())
             if not value or canonical is None:
+                # Name the uuid when the row carries one, and the type
+                # always, but never the value: this branch runs precisely
+                # when the type is NOT IP/URL/Domain, so the value has no
+                # shape the free-text scan recognises and a hostname-class
+                # one would ride through the warning verbatim (#130).
+                uuid = row.get("indicator-uuid")
                 warnings.append(
-                    f"linked indicator {row.get('indicator-uuid') or value!r} skipped: "
+                    f"linked indicator{f' {uuid!r}' if uuid else ''} skipped: "
                     f"type {row.get('type')!r} is not IP/URL/Domain or value is missing"
                 )
                 continue
@@ -1373,7 +1379,14 @@ async def run_threat_intel(params: ThreatIntelParams) -> ThreatIntelResult:
             (r for r in rows if str(r.get("value")) == value), None
         )
         if matched is None and rows:
-            matched = rows[0]
+            # A row whose value never matched the request describes some
+            # other subject, and its enrichment fields would be reported
+            # under this indicator. Keep it only when its own type is a
+            # class the masker can type the record's value from, which is
+            # the normalised-form case the fallback exists for (#130).
+            first = rows[0]
+            if _INDICATOR_TYPE_CANONICAL.get(str(first.get("type") or "").lower()):
+                matched = first
         if matched is None:
             warnings.append(
                 f"no stored enrichment for {indicator_type} {value!r} "

--- a/tests/test_skills_threat_intel.py
+++ b/tests/test_skills_threat_intel.py
@@ -271,6 +271,86 @@ class TestThreatIntel:
         assert result.indicators[0].record is None
         assert any("no stored enrichment" in w for w in result.warnings)
 
+    async def test_unmatched_row_of_unrecognised_type_is_not_attached(self):
+        """A row the reader returned for a different subject buys nothing.
+
+        The value never matched, so its enrichment fields describe some
+        other indicator, and an unrecognised ``type`` means the ``value``
+        inside the attached record is not maskable by context either.
+        """
+        stray = {
+            "value": "srv-fileshare-01",
+            "type": "Host",
+            "enrichment-reputation": "Malicious",
+            "enrichment-status": "Completed",
+        }
+        with (
+            t(GET_ENRICH, return_value=ok(data=[stray])),
+            t(GET_FORTIVIEW_DATA, return_value=ok(data=THREATS)),
+        ):
+            result = await handlers.run_threat_intel(
+                ThreatIntelParams(indicators=[{"value": "203.0.113.9", "type": "IP"}])
+            )
+        assert result.indicators[0].record is None
+        assert result.indicators[0].reputation is None
+        assert any("no stored enrichment" in w for w in result.warnings)
+        assert "srv-fileshare-01" not in result.model_dump_json()
+
+    async def test_unmatched_row_of_recognised_type_is_still_attached(self):
+        """The fallback keeps working where the value only differs by form.
+
+        The reader is queried per indicator, so a single row that does not
+        string-match is usually the same subject normalised. Keep it when
+        its ``type`` is a class the masker can type the ``value`` from.
+        """
+        normalised = dict(ENRICHED_DOMAIN, value="GOOD.example.com.")
+        with (
+            t(GET_ENRICH, return_value=ok(data=[normalised])),
+            t(GET_FORTIVIEW_DATA, return_value=ok(data=THREATS)),
+        ):
+            result = await handlers.run_threat_intel(
+                ThreatIntelParams(indicators=[{"value": "good.example.com", "type": "Domain"}])
+            )
+        assert result.indicators[0].record == normalised
+        assert result.indicators[0].reputation == "Good"
+
+    async def test_skip_warning_names_the_type_not_the_value(self):
+        """A skipped row has no recognised type, so its value has no shape.
+
+        The free-text scan covers IPv4, MAC and email, and the row is
+        skipped precisely because it is none of those, so a hostname-class
+        value would ride through the warning verbatim. The type is the
+        diagnostic content; the value is not.
+        """
+        linked = [{"value": "srv-fileshare-01", "type": "Host"}]
+        with (
+            t(GET_LINKED, return_value=ok(data=linked)),
+            t(GET_ENRICH, side_effect=enrich_map({})),
+            t(GET_FORTIVIEW_DATA, return_value=ok(data=THREATS)),
+        ):
+            result = await handlers.run_threat_intel(
+                ThreatIntelParams(alert_id="AL0001", indicators=EXPLICIT_TWO)
+            )
+        skip = [w for w in result.warnings if "skipped" in w]
+        assert len(skip) == 1
+        assert "'Host'" in skip[0]
+        assert "srv-fileshare-01" not in result.model_dump_json()
+
+    async def test_skip_warning_still_names_the_uuid_when_present(self):
+        linked = [{"value": "srv-fileshare-01", "type": "Host", "indicator-uuid": "iu-0009"}]
+        with (
+            t(GET_LINKED, return_value=ok(data=linked)),
+            t(GET_ENRICH, side_effect=enrich_map({})),
+            t(GET_FORTIVIEW_DATA, return_value=ok(data=THREATS)),
+        ):
+            result = await handlers.run_threat_intel(
+                ThreatIntelParams(alert_id="AL0001", indicators=EXPLICIT_TWO)
+            )
+        skip = [w for w in result.warnings if "skipped" in w]
+        assert len(skip) == 1
+        assert "iu-0009" in skip[0]
+        assert "srv-fileshare-01" not in result.model_dump_json()
+
     async def test_threat_landscape_failure_degrades_to_gap(self):
         with (
             t(GET_ENRICH, return_value=ok(data=[ENRICHED_IP])),


### PR DESCRIPTION
Part of #130, the handler half only. **Not** a fix for the mechanism question in that issue (should an untyped `value` fail closed to a placeholder?), which is still yours to rule on, so this does not close it.

I offered these two in the #130 comment where I conceded that filing them as design calls was the wrong framing. Neither carries the tension the mechanism question does.

## 1. `matched = rows[0]` attached a row nobody asked for

The reader is queried per indicator, so a single row that does not string-match the request is usually the same subject normalised, and keeping it is right. An arbitrary row of some other class is not.

The new test shows the damage without needing the masking argument: a `Host` row about a different subject came back carrying `"enrichment-reputation": "Malicious"`, and on current main that verdict is reported under an IP the reader said nothing about.

```
requested: 203.0.113.9 (IP)
reader returned: {"value": "srv-fileshare-01", "type": "Host", "enrichment-reputation": "Malicious"}
before: IndicatorEnrichmentRecord(value='203.0.113.9', type='IP', reputation='Malicious', record={...})
after:  IndicatorEnrichmentRecord(value='203.0.113.9', type='IP', reputation=None, record=None)
        + warning "no stored enrichment for IP '203.0.113.9'"
```

On top of that, the `value` inside the attached record is typed by its sibling `type`, so an unrecognised class means it passes through clear.

The fallback now fires only when the row's own type is a recognised class, which is the normalised-form case it exists for. A test pins that case so the fix cannot quietly become "drop the fallback".

## 2. The skip warning named the raw value

`row.get('indicator-uuid') or value!r` puts the value in the text whenever the appliance omits the uuid. That branch runs precisely when the type is not IP/URL/Domain, so the value has no shape the pass-2 scan looks for (IPv4, MAC, email), and `skipped` means it appears nowhere else for substitution to catch.

```
before: linked indicator 'srv-fileshare-01' skipped: type 'Host' is not IP/URL/Domain or value is missing
after:  linked indicator skipped: type 'Host' is not IP/URL/Domain or value is missing
```

The uuid is still named when the row has one, which the existing test at `test_alert_resolution_feeds_enrichment` already pins.

## Tests

Four, two of them controls for the behaviour being kept. The two assertions that matter are absence assertions against the whole serialised response, not substring checks on the new wording, so rewording the warning cannot silently pass them. Both new tests verified failing at the parent for the intended reason.

`2386 passed` (was 2382), ruff and mypy clean.

## Deliberately not here

- Typing `value` by name. That is the #80 remediation hazard and it is the part of my original reasoning I still stand behind.
- The `value!r` in the `enrichment unavailable` and `no stored enrichment` warnings. Those subjects carry a known type, so they are a different class, and one entangled with the still-open envelope question in #40.