### PR TITLE
ci: run mypy, and raise the floor to a version that can parse this code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,10 @@ jobs:
         run: |
           uv run ruff check src/ tests/
 
+      - name: Check types
+        run: |
+          uv run mypy src/
+
   security:
     runs-on: ubuntu-latest
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dev = [
     "pytest-asyncio>=0.23.0",
     "pytest-cov>=4.1.0",
     "ruff>=0.4.0",
-    "mypy>=1.10.0",
+    "mypy>=1.14",
 ]
 
 [build-system]


### PR DESCRIPTION
CI runs ruff only, so nothing type-checks a PR. Companion to rstierli/fortimanager-mcp#91, which found that repo's main actually red. Here main is clean, but the declared floor is wrong.

> **Corrected after an adversarial review pass.** The honest-limit paragraph at the bottom of the first version of this body was wrong in the same way as the FortiManager one, and the correction changes the recommendation. Marked below.

## `mypy>=1.10.0` cannot check this codebase at all

```
skills/handlers.py:108: error: PEP 695 generics are not yet supported  [valid-type]
skills/handlers.py:109: error: Name "T" is not defined  [name-defined]
skills/handlers.py:110: error: Name "T" is not defined  [name-defined]
skills/handlers.py:114: error: Name "T" is not defined  [name-defined]
skills/handlers.py:1118: error: Argument "handler_class" to "AlertRuleHandler" has incompatible type "str"; expected "Literal['basic', 'correlation']"  [arg-type]
```

Four of the five are the parser, not the code: `_gather_bounded` uses PEP 695 generic syntax, which mypy learned later. The fifth is narrowing a `for` variable over a tuple of string literals, which mypy learned in 1.14.

Measured boundary rather than guessed:

| mypy | result |
| --- | --- |
| 1.10.0 | 5 errors |
| 1.11.0 | 5 errors |
| 1.13.0 | 1 error |
| **1.14.0** | **clean** |
| 1.14.1 | clean |
| 1.20.2 (latest 1.x) | clean |
| 2.1.0 | clean |
| 2.3.1 | clean |

So the floor becomes `mypy>=1.14`. **No source change:** the code is correct at every version, older mypy simply cannot see it, and contorting it for a version nobody runs would be the wrong trade. Contrast the FortiManager PR, where the code genuinely did need a change because two mypy generations disagreed in opposite directions on the same line.

## The step

```yaml
      - name: Check types
        run: |
          uv run mypy src/
```

In the existing `lint` job next to the two ruff steps, `src/` only. Nothing is claimed about `tests/`.

## Honest limit, corrected

**First version said:** this would not have caught the two `no-any-return` errors that reached FortiManager main in #87, because those were version-dependent and a floor-versioned CI run agrees with the merge.

**Measured at `8e1faf4`, the #87 merge commit:** mypy 1.10.0 and 1.20.2 both report those two errors. 2.1.0 and 2.3.1 are clean. So a step running the floor **would** have caught them. What would not is the step **as proposed**: unpinned, no lockfile in either repo, `uv sync --all-extras` resolving the newest mypy.

That is an argument for pinning rather than a footnote about it. Here the exposure is smaller, since the floor is being raised to a version that is right about this code either way, but the principle is the same: unpinned, this step tracks whatever mypy ships next. I will pin it on both PRs if you want, `mypy>=1.14,<2` or an exact version, your call. Not done unilaterally because it is a dependency-convention change.

`2382 passed`, ruff clean, mypy clean from 1.14 through 2.3.1.